### PR TITLE
Epic E1: Risk group seed and validation - Add unit tests

### DIFF
--- a/apps/server/src/app/routes/settings/common/ensure-risk-groups-exist.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/ensure-risk-groups-exist.function.spec.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { ensureRiskGroupsExist } from './ensure-risk-groups-exist.function';
+
+// Hoisted mocks
+const { mockFindMany, mockCreate } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockCreate: vi.fn(),
+}));
+
+vi.mock('../../../prisma/prisma-client', () => ({
+  prisma: {
+    risk_group: {
+      findMany: mockFindMany,
+      create: mockCreate,
+    },
+  },
+}));
+
+describe('ensureRiskGroupsExist', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('creates all risk groups when none exist', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    mockCreate
+      .mockResolvedValueOnce({ id: 1, name: 'Equities' })
+      .mockResolvedValueOnce({ id: 2, name: 'Income' })
+      .mockResolvedValueOnce({ id: 3, name: 'Tax Free Income' });
+
+    const result = await ensureRiskGroupsExist();
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(3);
+    expect(mockCreate).toHaveBeenCalledWith({ data: { name: 'Equities' } });
+    expect(mockCreate).toHaveBeenCalledWith({ data: { name: 'Income' } });
+    expect(mockCreate).toHaveBeenCalledWith({ data: { name: 'Tax Free Income' } });
+    
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: 1, name: 'Equities' });
+    expect(result[1]).toEqual({ id: 2, name: 'Income' });
+    expect(result[2]).toEqual({ id: 3, name: 'Tax Free Income' });
+  });
+
+  test('returns existing risk groups when all exist', async () => {
+    const existingGroups = [
+      { id: 1, name: 'Equities' },
+      { id: 2, name: 'Income' },
+      { id: 3, name: 'Tax Free Income' },
+    ];
+    mockFindMany.mockResolvedValueOnce(existingGroups);
+
+    const result = await ensureRiskGroupsExist();
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).not.toHaveBeenCalled();
+    
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: 1, name: 'Equities' });
+    expect(result[1]).toEqual({ id: 2, name: 'Income' });
+    expect(result[2]).toEqual({ id: 3, name: 'Tax Free Income' });
+  });
+
+  test('returns existing risk groups in different order', async () => {
+    const existingGroups = [
+      { id: 3, name: 'Tax Free Income' },
+      { id: 1, name: 'Equities' },
+      { id: 2, name: 'Income' },
+    ];
+    mockFindMany.mockResolvedValueOnce(existingGroups);
+
+    const result = await ensureRiskGroupsExist();
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).not.toHaveBeenCalled();
+    
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: 1, name: 'Equities' });
+    expect(result[1]).toEqual({ id: 2, name: 'Income' });
+    expect(result[2]).toEqual({ id: 3, name: 'Tax Free Income' });
+  });
+
+  test('creates missing risk groups when some exist', async () => {
+    const existingGroups = [
+      { id: 1, name: 'Equities' },
+    ];
+    mockFindMany.mockResolvedValueOnce(existingGroups);
+    mockCreate
+      .mockResolvedValueOnce({ id: 2, name: 'Income' })
+      .mockResolvedValueOnce({ id: 3, name: 'Tax Free Income' });
+
+    const result = await ensureRiskGroupsExist();
+
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate).toHaveBeenCalledWith({ data: { name: 'Income' } });
+    expect(mockCreate).toHaveBeenCalledWith({ data: { name: 'Tax Free Income' } });
+    
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ id: 1, name: 'Equities' });
+    expect(result[1]).toEqual({ id: 2, name: 'Income' });
+    expect(result[2]).toEqual({ id: 3, name: 'Tax Free Income' });
+  });
+
+  test('handles database error on findMany', async () => {
+    const dbError = new Error('Database connection failed');
+    mockFindMany.mockRejectedValueOnce(dbError);
+
+    await expect(ensureRiskGroupsExist()).rejects.toThrow('Database connection failed');
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  test('handles database error on create', async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    const dbError = new Error('Create operation failed');
+    mockCreate.mockRejectedValueOnce(dbError);
+
+    await expect(ensureRiskGroupsExist()).rejects.toThrow('Create operation failed');
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  test('ensures correct order when existing groups have extra properties', async () => {
+    const existingGroups = [
+      { id: 1, name: 'Equities', created_at: '2024-01-01', updated_at: '2024-01-01' },
+      { id: 2, name: 'Income', created_at: '2024-01-01', updated_at: '2024-01-01' },
+      { id: 3, name: 'Tax Free Income', created_at: '2024-01-01', updated_at: '2024-01-01' },
+    ];
+    mockFindMany.mockResolvedValueOnce(existingGroups);
+
+    const result = await ensureRiskGroupsExist();
+
+    expect(result).toHaveLength(3);
+    expect(result[0].name).toBe('Equities');
+    expect(result[1].name).toBe('Income');
+    expect(result[2].name).toBe('Tax Free Income');
+  });
+});

--- a/apps/server/src/app/routes/settings/common/ensure-risk-groups-exist.function.ts
+++ b/apps/server/src/app/routes/settings/common/ensure-risk-groups-exist.function.ts
@@ -1,0 +1,26 @@
+import { prisma } from '../../../prisma/prisma-client';
+
+type PrismaRiskGroup = Awaited<ReturnType<typeof prisma.risk_group.findMany>>[number];
+
+export async function ensureRiskGroupsExist(): Promise<PrismaRiskGroup[]> {
+  const existingRiskGroups = await prisma.risk_group.findMany();
+
+  const requiredGroups = ['Equities', 'Income', 'Tax Free Income'];
+  const results: PrismaRiskGroup[] = [];
+
+  for (const groupName of requiredGroups) {
+    let group = existingRiskGroups.find(function findGroup(riskGroup) {
+      return riskGroup.name === groupName;
+    });
+
+    if (!group) {
+      group = await prisma.risk_group.create({
+        data: { name: groupName },
+      });
+    }
+
+    results.push(group);
+  }
+
+  return results;
+}

--- a/apps/server/src/app/routes/settings/index.ts
+++ b/apps/server/src/app/routes/settings/index.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import yahooFinance from 'yahoo-finance2';
 
 import { prisma } from '../../prisma/prisma-client';
+import { ensureRiskGroupsExist } from './common/ensure-risk-groups-exist.function';
 import { getDistributions } from './common/get-distributions.function';
 import { getLastPrice } from './common/get-last-price.function';
 import { Settings } from './settings.interface';
@@ -18,34 +19,6 @@ interface Distribution {
 
 yahooFinance.suppressNotices(['yahooSurvey']);
 
-async function ensureRiskGroupsExist(): Promise<PrismaRiskGroup[]> {
-  const riskGroups = await prisma.risk_group.findMany();
-
-  if (riskGroups.length === 0) {
-    const equities = await prisma.risk_group.create({
-      data: { name: 'Equities' },
-    });
-    const income = await prisma.risk_group.create({
-      data: { name: 'Income' },
-    });
-    const taxFreeIncome = await prisma.risk_group.create({
-      data: { name: 'Tax Free Income' },
-    });
-    return [equities, income, taxFreeIncome];
-  }
-
-  const equities = riskGroups.find(function findEquities(riskGroup) {
-    return riskGroup.name === 'Equities';
-  })!;
-  const income = riskGroups.find(function findIncome(riskGroup) {
-    return riskGroup.name === 'Income';
-  })!;
-  const taxFreeIncome = riskGroups.find(function findTaxFreeIncome(riskGroup) {
-    return riskGroup.name === 'Tax Free Income';
-  })!;
-
-  return [equities, income, taxFreeIncome];
-}
 
 function parseSymbols(value: string): string[] {
   return value


### PR DESCRIPTION
## Summary
Completes Epic E1: Risk group seed and validation by adding comprehensive unit tests for the `ensureRiskGroupsExist` function.

- Extracted existing function to separate module for better testability
- Added 7 comprehensive unit test scenarios
- Improved implementation to properly handle partial risk group existence
- All tests pass with proper database isolation using mocks

## Changes Made
- **New File**: `ensure-risk-groups-exist.function.ts` - Extracted function for testability
- **New File**: `ensure-risk-groups-exist.function.spec.ts` - Comprehensive unit tests (7 scenarios)
- **Modified**: `settings/index.ts` - Import extracted function, removed duplicate code

## Test Coverage
✅ Creates risk groups when none exist  
✅ Returns existing risk groups when all exist  
✅ Handles partial risk group existence (creates missing ones)  
✅ Handles different ordering of existing groups  
✅ Database error scenarios (both findMany and create)  
✅ Groups with additional properties  
✅ Proper mocking ensures no real database access  

## Acceptance Criteria Met
- ✅ Ensure risk groups exist before sync (existing runtime function)
- ✅ Unit test for ensure behavior (7 comprehensive test cases)

Closes #55