### PR TITLE
Story G2: Update Backend Feature Flag Endpoint

### DIFF
--- a/apps/server/src/app/routes/feature-flags/index.ts
+++ b/apps/server/src/app/routes/feature-flags/index.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from 'fastify';
 export default function registerFeatureFlagsRoutes(fastify: FastifyInstance): void {
   fastify.get('/', function handleGetFeatureFlags() {
     return {
-      useScreenerForUniverse: process.env.USE_SCREENER_FOR_UNIVERSE === 'true'
+      useScreenerForUniverse: true
     };
   });
 }


### PR DESCRIPTION
## Summary
Updates the backend feature flag endpoint to return static values instead of reading from environment variables, maintaining API contract while removing dynamic flag logic.

## Changes
- Modified `/api/feature-flags` endpoint to always return `useScreenerForUniverse: true`
- Removed dependency on `USE_SCREENER_FOR_UNIVERSE` environment variable
- Maintains backward compatibility with existing API contract

## Testing
- All existing server tests pass
- Linting passes

Closes #67