### PR TITLE
Story G3: Clean Up Feature Flag Service

### DIFF
--- a/apps/rms/src/app/shared/services/feature-flags.service.ts
+++ b/apps/rms/src/app/shared/services/feature-flags.service.ts
@@ -1,26 +1,8 @@
-import { httpResource } from '@angular/common/http';
-import { computed, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 
 @Injectable({
   providedIn: 'root'
 })
 export class FeatureFlagsService {
-    // Use httpResource for reactive HTTP requests
-  private featureFlagsResource = httpResource<{ useScreenerForUniverse: boolean }>(function getResource() {
-    return {
-      url: '/api/feature-flags'
-    }
-  });
-
-  // Computed signal for the feature flag
-  // eslint-disable-next-line @smarttools/no-anonymous-functions -- would hide this
-  readonly isUseScreenerForUniverseEnabled = computed(() => {
-    const result = this.featureFlagsResource.value();
-    return result?.useScreenerForUniverse ?? false;
-  });
-
-  // Method to manually refresh feature flags
-  refreshFeatureFlags(): void {
-    this.featureFlagsResource.set(undefined); // Trigger refresh
-  }
+  // Service maintained as shell for future feature flag implementations
 }


### PR DESCRIPTION
## Summary
Clean up the FeatureFlagsService to remove unused sync feature flag logic while maintaining service structure for potential future use.

## Changes Made
- Removed `isUseScreenerForUniverseEnabled` computed signal
- Removed httpResource for feature flags API
- Removed `refreshFeatureFlags` method  
- Maintained service shell structure for future feature flags
- Removed unused imports (httpResource, computed)

## Test Plan
- [x] Build passes successfully
- [x] Linting passes without issues
- [x] No references to removed methods found in codebase

Closes #69