### PR TITLE
feat: Set Up Application Configuration with Material Providers

### DIFF
--- a/apps/rms-material/src/app/app.config.ts
+++ b/apps/rms-material/src/app/app.config.ts
@@ -1,18 +1,123 @@
 import {
+  provideHttpClient,
+  withFetch,
+  withInterceptors,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
   ApplicationConfig,
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
+import {
+  provideSmartNgRX,
+  smartErrorHandlerToken,
+} from '@smarttools/smart-signals';
 
+import { environment } from '../environments/environment';
+import { configureAmplify } from './amplify.config';
 import { appRoutes } from './app.routes';
+import { AuthService } from './auth/auth.service';
+import { authInterceptor } from './auth/interceptors/auth.interceptor';
+import { MockAuthService } from './auth/mock-auth.service';
+import { MockProfileService } from './auth/services/mock-profile.service';
+import { ProfileService } from './auth/services/profile.service';
+import { ErrorHandlerService } from './error-handler/error-handler.service';
+import { UniverseSyncService } from './shared/services/universe-sync.service';
+import { AccountEffectsService } from './store/accounts/account-effect.service';
+import { accountEffectsServiceToken } from './store/accounts/account-effect-service-token';
+import { DivDepositTypesEffectsService } from './store/div-deposit-types/div-deposit-types-effect.service';
+import { divDepositTypesEffectsServiceToken } from './store/div-deposit-types/div-deposit-types-effect-service-token';
+import { DivDepositsEffectsService } from './store/div-deposits/div-deposits-effect.service';
+import { divDepositsEffectsServiceToken } from './store/div-deposits/div-deposits-effect-service-token';
+import { RiskGroupEffectsService } from './store/risk-group/risk-group-effect.service';
+import { riskGroupEffectsServiceToken } from './store/risk-group/risk-group-effect-service-token';
+import { ScreenEffectsService } from './store/screen/screen-effect.service';
+import { screenEffectsServiceToken } from './store/screen/screen-effect-service-token';
+import { TopEffectsService } from './store/top/top-effect.service';
+import { topEffectsServiceToken } from './store/top/top-effect-service-token';
+import { TradeEffectsService } from './store/trades/trade-effect.service';
+import { tradeEffectsServiceToken } from './store/trades/trade-effect-service-token';
+import { UniverseEffectsService } from './store/universe/universe-effect.service';
+import { universeEffectsServiceToken } from './store/universe/universe-effect-service-token';
+
+// Configure Amplify before app initialization only if not using mock auth
+const shouldUseMockAuth = environment.auth?.useMockAuth;
+if (!shouldUseMockAuth) {
+  configureAmplify();
+}
 
 export const appConfig: ApplicationConfig = {
   providers: [
+    // Conditional auth service provider
+    {
+      provide: AuthService,
+      useClass: shouldUseMockAuth ? MockAuthService : AuthService,
+    },
+    // Conditional profile service provider
+    {
+      provide: ProfileService,
+      useClass: shouldUseMockAuth ? MockProfileService : ProfileService,
+    },
+    {
+      provide: topEffectsServiceToken,
+      useClass: TopEffectsService,
+    },
+    {
+      provide: accountEffectsServiceToken,
+      useClass: AccountEffectsService,
+    },
+    {
+      provide: riskGroupEffectsServiceToken,
+      useClass: RiskGroupEffectsService,
+    },
+    {
+      provide: universeEffectsServiceToken,
+      useClass: UniverseEffectsService,
+    },
+    {
+      provide: tradeEffectsServiceToken,
+      useClass: TradeEffectsService,
+    },
+    {
+      provide: divDepositsEffectsServiceToken,
+      useClass: DivDepositsEffectsService,
+    },
+    {
+      provide: divDepositTypesEffectsServiceToken,
+      useClass: DivDepositTypesEffectsService,
+    },
+    {
+      provide: smartErrorHandlerToken,
+      useClass: ErrorHandlerService,
+    },
+    {
+      provide: screenEffectsServiceToken,
+      useClass: ScreenEffectsService,
+    },
+    {
+      provide: UniverseSyncService,
+      useClass: UniverseSyncService,
+    },
+
+    // Angular core providers
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
     provideAnimationsAsync(),
+
+    // HTTP client with auth interceptor
+    provideHttpClient(
+      withInterceptors([authInterceptor]),
+      withInterceptorsFromDi(),
+      withFetch()
+    ),
+
+    // Router
     provideRouter(appRoutes),
+
+    // SmartNgRX
+    provideSmartNgRX(),
   ],
 };

--- a/apps/rms-material/src/app/app.routes.ts
+++ b/apps/rms-material/src/app/app.routes.ts
@@ -1,3 +1,5 @@
 import { Route } from '@angular/router';
 
+// Initial minimal routes - will be expanded in later stories
+// The App component serves as the shell with router-outlet
 export const appRoutes: Route[] = [];


### PR DESCRIPTION
## Summary

- Configure app.config.ts with all required providers for rms-material
- Add conditional auth service providers (AuthService/MockAuthService based on environment)
- Add conditional profile service providers (ProfileService/MockProfileService)
- Register all 8 SmartNgRX effect service tokens (top, accounts, riskGroup, universe, trades, divDeposits, divDepositTypes, screen)
- Configure HTTP client with auth interceptor
- Add SmartNgRX provider and error handler token
- Set up Amplify configuration for non-mock auth environments
- Initialize empty routes (App component serves as shell with router-outlet)

## Test plan

- [x] rms-material:lint passes
- [x] rms-material:build:production succeeds
- [x] rms-material:test passes (330 tests)
- [x] All existing RMS tests pass (625 tests)
- [x] All server tests pass (259 tests)
- [x] Application bootstraps without duplicate rendering

Closes #205