### PR TITLE
Story AJ.2: Implement Checkbox Editing with Backend Updates

### DIFF
--- a/apps/dms-material/src/app/global/global-screener/global-screener.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-screener/global-screener.component.spec.ts
@@ -31,6 +31,7 @@ describe('GlobalScreenerComponent', () => {
     refresh: ReturnType<typeof vi.fn>;
     loading: ReturnType<typeof vi.fn>;
     error: ReturnType<typeof vi.fn>;
+    updateScreener: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -49,6 +50,7 @@ describe('GlobalScreenerComponent', () => {
       refresh: vi.fn().mockReturnValue(of(null)),
       loading: vi.fn().mockReturnValue(false),
       error: vi.fn().mockReturnValue(null),
+      updateScreener: vi.fn(),
     };
 
     await TestBed.configureTestingModule({
@@ -201,6 +203,20 @@ describe('GlobalScreenerComponent', () => {
       });
     });
 
+    it('should call updateScreener for has_volitility', () => {
+      const row = {
+        id: '1',
+        symbol: 'TST',
+        has_volitility: false,
+      } as Screen;
+      component.onCellEdit(row, 'has_volitility', true);
+      expect(mockScreenerService.updateScreener).toHaveBeenCalledWith(
+        '1',
+        'has_volitility',
+        true
+      );
+    });
+
     it('should emit cell edit event for objectives_understood', () => {
       const row = {
         id: '1',
@@ -216,6 +232,20 @@ describe('GlobalScreenerComponent', () => {
       });
     });
 
+    it('should call updateScreener for objectives_understood', () => {
+      const row = {
+        id: '1',
+        symbol: 'TST',
+        objectives_understood: false,
+      } as Screen;
+      component.onCellEdit(row, 'objectives_understood', true);
+      expect(mockScreenerService.updateScreener).toHaveBeenCalledWith(
+        '1',
+        'objectives_understood',
+        true
+      );
+    });
+
     it('should emit cell edit event for graph_higher_before_2008', () => {
       const row = {
         id: '1',
@@ -229,6 +259,29 @@ describe('GlobalScreenerComponent', () => {
         field: 'graph_higher_before_2008',
         value: true,
       });
+    });
+
+    it('should call updateScreener for graph_higher_before_2008', () => {
+      const row = {
+        id: '1',
+        symbol: 'TST',
+        graph_higher_before_2008: false,
+      } as Screen;
+      component.onCellEdit(row, 'graph_higher_before_2008', true);
+      expect(mockScreenerService.updateScreener).toHaveBeenCalledWith(
+        '1',
+        'graph_higher_before_2008',
+        true
+      );
+    });
+
+    it('should not call updateScreener for non-boolean fields', () => {
+      const row = {
+        id: '1',
+        symbol: 'TST',
+      } as Screen;
+      component.onCellEdit(row, 'symbol', 'NEW');
+      expect(mockScreenerService.updateScreener).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/dms-material/src/app/global/global-screener/global-screener.component.ts
+++ b/apps/dms-material/src/app/global/global-screener/global-screener.component.ts
@@ -139,6 +139,18 @@ export class GlobalScreenerComponent {
   }
 
   onCellEdit(row: Screen, field: string, value: unknown): void {
+    if (
+      field === 'has_volitility' ||
+      field === 'objectives_understood' ||
+      field === 'graph_higher_before_2008'
+    ) {
+      this.screenerService.updateScreener(
+        row.id,
+        field as keyof Screen,
+        value as boolean
+      );
+    }
+
     this.cellEdit.emit({ row, field, value });
   }
 

--- a/docs/qa/gates/aj.2-implement-checkbox-editing-with-backend-updates.yml
+++ b/docs/qa/gates/aj.2-implement-checkbox-editing-with-backend-updates.yml
@@ -1,0 +1,20 @@
+schema: 1
+story: 'aj.2'
+gate: CONCERNS
+status_reason: 'Core checkbox editing functionality implemented and tested, but missing visual feedback and error handling for backend updates.'
+reviewer: 'Quinn'
+updated: '2026-01-19T16:20:00Z'
+top_issues:
+  - id: 'UX-001'
+    severity: medium
+    finding: 'No visual feedback for update success/failure'
+    suggested_action: 'Add loading indicators and success/error notifications for checkbox updates'
+  - id: 'REL-001'
+    severity: medium
+    finding: 'No error handling for failed backend updates'
+    suggested_action: 'Implement error handling in ScreenEffectsService.update() and show user feedback'
+  - id: 'ARCH-001'
+    severity: low
+    finding: 'Optimistic updates may not be properly handled'
+    suggested_action: 'Verify SmartNgRX optimistic update behavior and add rollback on failure'
+waiver: { active: false }

--- a/docs/stories/AJ.2.implement-checkbox-editing.md
+++ b/docs/stories/AJ.2.implement-checkbox-editing.md
@@ -121,20 +121,39 @@ SmartNgRX automatically calls this when the store is updated.
 - Redux DevTools: Verify store updates
 - Error testing: Simulate backend failure, verify error handling
 
+## QA Results
+
+### Review Date: 2026-01-19
+
+### Reviewed By: Quinn (Test Architect)
+
+### Gate Status
+
+Gate: CONCERNS → docs/qa/gates/aj.2-implement-checkbox-editing-with-backend-updates.yml
+
 ## Dev Agent Record
 
 ### Status
 
-Not Started
+Ready for Review
 
 ### File List
 
-(To be filled during implementation)
+- apps/dms-material/src/app/global/global-screener/global-screener.component.ts
+- apps/dms-material/src/app/global/global-screener/global-screener.component.spec.ts
+- apps/dms-material/src/app/global/global-screener/services/screener.service.ts
 
 ### Completion Notes
 
-(To be filled during implementation)
+- Updated `onCellEdit` method in GlobalScreenerComponent to call `updateScreener` for boolean fields
+- `updateScreener` method was already implemented in ScreenerService (matches DMS app pattern)
+- Added comprehensive tests for the new functionality
+- All validation commands passed successfully:
+  - ✅ `pnpm all` - All linting, building, and testing passed
+  - ✅ `pnpm format` - Code formatting completed
+  - ✅ `pnpm dupcheck` - No code duplication detected
 
 ### Change Log
 
-(To be filled during implementation)
+- **global-screener.component.ts**: Enhanced `onCellEdit` to update SmartNgRX store via `updateScreener` for boolean checkbox fields (has_volitility, objectives_understood, graph_higher_before_2008)
+- **global-screener.component.spec.ts**: Added tests for `updateScreener` calls for each boolean field and verification that non-boolean fields don't trigger updates


### PR DESCRIPTION
## Summary

This PR implements checkbox editing functionality with backend updates for the screener table, completing Story AJ.2.

### Changes

- **global-screener.component.ts**: Enhanced `onCellEdit` to update SmartNgRX store via `updateScreener` for boolean checkbox fields (has_volitility, objectives_understood, graph_higher_before_2008)
- **global-screener.component.spec.ts**: Added tests for `updateScreener` calls for each boolean field and verification that non-boolean fields don't trigger updates

The `updateScreener` method was already implemented in ScreenerService, matching the DMS app pattern. This change enables checkbox fields in the screener table to be editable and persist changes to the backend automatically through SmartNgRX.

## Testing

All validation commands passed successfully:
- ✅ `pnpm all` - All linting, building, and testing passed
- ✅ `pnpm format` - Code formatting completed
- ✅ `pnpm dupcheck` - No code duplication detected

Manual testing steps:
1. Click checkboxes in the screener table
2. Verify persistence to backend
3. Check Network tab for PUT requests to /api/screener/rows
4. Use Redux DevTools to verify store updates
5. Simulate backend failure to verify error handling

## Notes

A QA gate review identified some concerns (UX-001, REL-001, ARCH-001) related to visual feedback and error handling. These will be addressed in a future refactoring story.

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean/checkbox field edits in the Screener tool now automatically synchronize and persist changes to the backend database.

* **Bug Fixes**
  * Implemented safeguards to prevent accidental backend updates when editing non-boolean fields.

* **Tests**
  * Added comprehensive unit tests to verify checkbox field updates work correctly and prevent unintended modifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->