### PR TITLE
AU.2: Implement Account Selection Signal/Service

### DIFF
--- a/apps/dms-material/src/app/store/current-account/current-account.signal-store.spec.ts
+++ b/apps/dms-material/src/app/store/current-account/current-account.signal-store.spec.ts
@@ -16,8 +16,7 @@ vi.mock(
 type SignalStoreModule = typeof import('./current-account.signal-store');
 let currentAccountSignalStore: SignalStoreModule['currentAccountSignalStore'];
 
-// DISABLE TESTS FOR CI - Will be enabled in implementation story AU.2
-describe.skip('currentAccountSignalStore', () => {
+describe('currentAccountSignalStore', () => {
   let store: InstanceType<typeof currentAccountSignalStore>;
 
   beforeEach(async function setup() {

--- a/apps/dms-material/src/app/store/current-account/select-current-account.signal.spec.ts
+++ b/apps/dms-material/src/app/store/current-account/select-current-account.signal.spec.ts
@@ -8,7 +8,17 @@ vi.mock(
   function mockSelectAccountChildren() {
     return {
       selectAccountChildren: vi.fn(function selectAccountChildrenMock() {
-        return { entities: {} };
+        return {
+          entities: {
+            'account-1': {
+              id: 'account-1',
+              name: 'Test Account',
+              trades: [],
+              divDeposits: [],
+              months: [{ month: 1, year: 2024 }],
+            },
+          },
+        };
       }),
     };
   }
@@ -22,8 +32,7 @@ type CurrentAccountStore = InstanceType<
   typeof import('./current-account.signal-store').currentAccountSignalStore
 >;
 
-// DISABLE TESTS FOR CI - Will be enabled in implementation story AU.2
-describe.skip('selectCurrentAccountSignal', () => {
+describe('selectCurrentAccountSignal', () => {
   beforeEach(async function loadModule() {
     const mod = await import('./select-current-account.signal');
     selectCurrentAccountSignal = mod.selectCurrentAccountSignal;


### PR DESCRIPTION
## AU.2: Implement Account Selection Signal/Service

### Summary

Enabled and validated all unit tests from AU.1 for the account selection signal store and selector function. The implementation (currentAccountSignalStore and selectCurrentAccountSignal) was already in place from previous work; this story's TDD GREEN phase confirms correctness by enabling the skipped test suites.

### Changes

- **current-account.signal-store.spec.ts**: Removed `describe.skip` to enable all 12 tests for `currentAccountSignalStore`
  - Initial state verification (empty id, selectCurrentAccountId fallback)
  - `setCurrentAccountId` method testing (update, switch, reset)
  - Computed signal behavior with explicit vs fallback IDs
  - Edge cases (empty string, rapid changes, idempotent setting)

- **select-current-account.signal.spec.ts**: Removed `describe.skip` to enable all 12 tests for `selectCurrentAccountSignal`
  - Updated `selectAccountChildren` mock to provide proper entity data for account-exists test scenarios
  - Account exists scenarios (returns correct account with trades, divDeposits, months)
  - Account not found scenarios (returns empty account object)
  - Reactivity verification (Signal type, computed behavior)
  - Data integrity checks

### Testing

- All 24 account selection tests pass (12 signal store + 12 selector)
- Full `pnpm all` passes (72 test files, 1357 tests, lint, build)
- E2E Chromium: 430 passed, 0 failed
- E2E Firefox: 358 passed, 0 failed
- Dupcheck: 0 clones
- Format: clean

Closes #545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled test suite execution for current account signal store functionality.
  * Enhanced mock data fixtures for account selection tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->