### PR TITLE
feat(AU.6): Wire Open Positions to Account Selection

### DIFF
--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.spec.ts
@@ -770,10 +770,10 @@ describe('OpenPositionsComponent', () => {
 });
 
 // Story AU.5: TDD Tests for Open Positions Account Selection Integration
-// DISABLED with describe.skip — Will be enabled in implementation story AU.6
+// Enabled in implementation story AU.6
 // These tests verify that the open positions screen properly integrates with
 // account selection, refreshing data when the selected account changes.
-describe.skip('OpenPositionsComponent - Account Selection Integration', () => {
+describe('OpenPositionsComponent - Account Selection Integration', () => {
   let component: OpenPositionsComponent;
   let fixture: ComponentFixture<OpenPositionsComponent>;
   let mockOpenPositionsService: {


### PR DESCRIPTION
## Summary

Enable AU.5 TDD tests for open positions account selection integration, confirming the open positions component correctly responds to account selection changes.

### Changes
- Removed `describe.skip` from AU.5 account selection integration test suite
- All 58 unit tests now pass, validating:
  - Component subscribes to account selection changes
  - Table data refreshes on account switch
  - Correct account ID used by service
  - Edge cases for rapid switching, same account re-selection, concurrent search/account changes

### Testing
- **Unit tests**: 1388 passed (72 test files)
- **E2E Chromium**: 454 passed
- **E2E Firefox**: 454 passed
- **Lint**: All files pass
- **Build**: Clean
- **Dupcheck**: 0 clones

Closes #553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled additional test suites for the Open Positions component to improve test coverage and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->