### PR TITLE
feat(sold-positions): wire sold positions to account selection (#557)

### DIFF
--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
@@ -517,10 +517,10 @@ describe('SoldPositionsComponent', () => {
 });
 
 // Story AU.7: TDD Tests for Sold Positions Account Selection Integration
-// Disabled with describe.skip — will be enabled in implementation story AU.8
+// Enabled in AU.8: Wire Sold Positions to Account Selection
 // These tests verify that the sold positions screen properly integrates with
 // account selection, refreshing data when the selected account changes.
-describe.skip('SoldPositionsComponent - Account Selection Integration', () => {
+describe('SoldPositionsComponent - Account Selection Integration', () => {
   let component: SoldPositionsComponent;
   let fixture: ComponentFixture<SoldPositionsComponent>;
   let mockSoldPositionsComponentService: {


### PR DESCRIPTION
## Story AU.8: Wire Sold Positions to Account Selection

### Summary

Enable the AU.7 TDD tests for sold positions account selection integration. The `SoldPositionsComponentService` already wires to `currentAccountSignalStore` via `selectCurrentAccountSignal`, providing reactive account-filtered data. This story verifies the integration by enabling the previously-skipped test suite.

### Changes

- Removed `describe.skip` from AU.7 account selection integration tests in `sold-positions.component.spec.ts`
- All 52 sold-positions tests pass, including the 16 newly-enabled account selection integration tests

### What the tests verify

- Component reacts to account selection changes
- Table data refreshes when account changes
- Capital gains recalculate for new account
- Correct account ID passed to service
- Date filters preserved across account switches
- Edge cases: rapid account switches, empty positions, concurrent filter changes

### Testing

- `pnpm all` — 1405 tests pass
- `pnpm e2e:dms-material:chromium` — 454 passed
- `pnpm e2e:dms-material:firefox` — 453 passed (1 flaky, passed on retry)
- `pnpm dupcheck` — clean
- `pnpm format` — clean

Closes #557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Activated account selection integration test suite to enhance validation coverage and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->