### PR TITLE
feat: AU.9 - TDD Dividends Account Selection Tests

### DIFF
--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.spec.ts
@@ -803,6 +803,9 @@ describe.skip('DividendDepositsComponent - Account Selection Integration', () =>
     setCurrentAccountId: ReturnType<typeof vi.fn>;
   };
 
+  let mockDialog: { open: ReturnType<typeof vi.fn> };
+  let mockConfirmDialogService: { confirm: ReturnType<typeof vi.fn> };
+
   beforeEach(async () => {
     mockCurrentAccountStore = {
       id: signal<string>(''),
@@ -817,6 +820,14 @@ describe.skip('DividendDepositsComponent - Account Selection Integration', () =>
       deleteDivDeposit: vi.fn(),
     };
 
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => of(null) }),
+    };
+
+    mockConfirmDialogService = {
+      confirm: vi.fn().mockReturnValue(of(true)),
+    };
+
     await TestBed.configureTestingModule({
       imports: [DividendDepositsComponent],
       providers: [
@@ -828,9 +839,9 @@ describe.skip('DividendDepositsComponent - Account Selection Integration', () =>
           provide: currentAccountSignalStore,
           useValue: mockCurrentAccountStore,
         },
-        { provide: MatDialog, useValue: { open: vi.fn() } },
+        { provide: MatDialog, useValue: mockDialog },
         { provide: NotificationService, useValue: { success: vi.fn() } },
-        { provide: ConfirmDialogService, useValue: { confirm: vi.fn() } },
+        { provide: ConfirmDialogService, useValue: mockConfirmDialogService },
         {
           provide: divDepositsEffectsServiceToken,
           useValue: { add: vi.fn(), update: vi.fn(), delete: vi.fn() },
@@ -1109,6 +1120,16 @@ describe.skip('DividendDepositsComponent - Account Selection Integration', () =>
 
       // Verify service has the correct account context for add operations
       expect(mockDividendDepositsService.selectedAccountId()).toBe('acc-add');
+
+      // Simulate add - dialog opens with account context available
+      const newDividend = createDivDeposit({ accountId: 'acc-add' });
+      mockDialog.open.mockReturnValue({
+        afterClosed: () => of(newDividend),
+      });
+      component.onAddDividend();
+      expect(mockDividendDepositsService.addDivDeposit).toHaveBeenCalledWith(
+        newDividend
+      );
     });
 
     it('should handle delete operation with correct account context', () => {
@@ -1120,11 +1141,18 @@ describe.skip('DividendDepositsComponent - Account Selection Integration', () =>
       fixture.detectChanges();
 
       mockCurrentAccountStore.selectCurrentAccountId.set('acc-del');
-      mockDividendDepositsService.dividends.set([dividend]);
       fixture.detectChanges();
+
+      // Verify service has the correct account context for delete
+      expect(mockDividendDepositsService.selectedAccountId()).toBe('acc-del');
+
+      mockDividendDepositsService.dividends.set([dividend]);
 
       // Verify the dividend belongs to the current account
       expect(component.dividends$()[0].accountId).toBe('acc-del');
+
+      // Simulate delete - service method should be callable
+      component.onDeleteDividend(dividend);
     });
 
     it('should preserve component state across account switches', () => {


### PR DESCRIPTION
## Story AU.9: TDD - Dividends Account Selection Tests

### Summary
Adds disabled unit tests (`describe.skip`) for dividend deposits component account selection integration, following the TDD approach used in AU.5 and AU.7.

### Changes
- Added `describe.skip('DividendDepositsComponent - Account Selection Integration')` block with 22 tests covering:
  - **Subscribing to account selection changes** (3 tests): React to account ID changes, handle empty account ID, initial account selection
  - **Data refresh on account change** (4 tests): Load dividends for selected account, refresh table when account changes, clear dividends when deselected, update amounts for new account
  - **Correct account ID passed to service calls** (3 tests): Verify correct ID used, rapid account switches, pass-through to service
  - **Table updates with new account data** (3 tests): Display account-specific dividends, column stability, empty state handling
  - **Edge cases for account switching** (4 tests): Same account switch, add/delete with correct context, preserve component state

### TDD Approach
- Tests are written in RED (failing) state
- All tests disabled with `describe.skip()` to keep CI green
- Implementation story AU.10 will enable tests and make them pass (GREEN)

### Validation
- ✅ `pnpm all` (lint + build + test) — passed
- ✅ `pnpm e2e:dms-material:chromium` — passed
- ✅ `pnpm e2e:dms-material:firefox` — passed
- ✅ `pnpm dupcheck` — 0 clones found
- ✅ `pnpm format` — applied

Closes #559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suites for account selection and data refresh in the dividend deposits area (new tests are skipped and do not run).

---

**Note:** No user-facing changes or API modifications; this release updates internal test coverage only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->