### PR TITLE
feat: wire dividends to account selection (#561)

### DIFF
--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits-component.service.ts
@@ -14,7 +14,7 @@ export class DividendDepositsComponentService {
   private currentAccount = selectCurrentAccountSignal(this.currentAccountStore);
   private errorMessage = signal<string>('');
 
-  readonly selectedAccountId = this.currentAccountStore.selectCurrentAccountId;
+  readonly selectedAccountId = signal<string>('');
 
   getErrorMessage(): Signal<string> {
     return this.errorMessage.asReadonly();

--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.spec.ts
@@ -788,7 +788,7 @@ describe('DividendDepositsComponent - Delete Dialog SmartNgRX Integration (AQ.7)
 // Enabled in AU.10: Wire Dividend Deposits to Account Selection
 // These tests verify that the dividend deposits screen properly integrates with
 // account selection, refreshing data when the selected account changes.
-describe.skip('DividendDepositsComponent - Account Selection Integration', () => {
+describe('DividendDepositsComponent - Account Selection Integration', () => {
   let component: DividendDepositsComponent;
   let fixture: ComponentFixture<DividendDepositsComponent>;
   let mockDividendDepositsService: {

--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.ts
@@ -1,5 +1,10 @@
 import { CurrencyPipe, DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+} from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
@@ -9,6 +14,7 @@ import { BaseTableComponent } from '../../shared/components/base-table/base-tabl
 import { ColumnDef } from '../../shared/components/base-table/column-def.interface';
 import { ConfirmDialogService } from '../../shared/services/confirm-dialog.service';
 import { NotificationService } from '../../shared/services/notification.service';
+import { currentAccountSignalStore } from '../../store/current-account/current-account.signal-store';
 import { DivDeposit } from '../../store/div-deposits/div-deposit.interface';
 import { divDepositsEffectsServiceToken } from '../../store/div-deposits/div-deposits-effect-service-token';
 import { DivDepModal } from '../div-dep-modal/div-dep-modal.component';
@@ -29,10 +35,20 @@ import { DividendDepositsComponentService } from './dividend-deposits-component.
 })
 export class DividendDepositsComponent {
   readonly dividendDepositsService = inject(DividendDepositsComponentService);
+  private currentAccountStore = inject(currentAccountSignalStore);
   private dialog = inject(MatDialog);
   private notification = inject(NotificationService);
   private confirmDialog = inject(ConfirmDialogService);
   private effectsService = inject(divDepositsEffectsServiceToken);
+
+  constructor() {
+    const store = this.currentAccountStore;
+    const service = this.dividendDepositsService;
+    effect(function syncAccountSelection() {
+      const accountId = store.selectCurrentAccountId();
+      service.selectedAccountId.set(accountId);
+    });
+  }
 
   readonly dividends$ = this.dividendDepositsService.dividends;
 


### PR DESCRIPTION
## Story AU.10: Wire Dividends to Account Selection

Closes #561

### Changes
- **Component** (`dividend-deposits.component.ts`): Inject `currentAccountSignalStore` and add `effect()` to sync account selection to the service
- **Service** (`dividend-deposits-component.service.ts`): Changed `selectedAccountId` to a writable signal so the component can bridge store → service
- **Tests** (`dividend-deposits.component.spec.ts`): Enabled all AU.9 account selection integration tests (removed `describe.skip`)

### Pattern
Follows the same account selection wiring pattern used by open-positions (AU.6) and sold-positions (AU.8) components.

### Validation
- All 60 dividend-deposits unit tests pass (including 11 re-enabled AU.9 tests)
- All 1422 unit tests pass across the project
- All 454 Chromium E2E tests pass
- All 454 Firefox E2E tests pass
- Lint: clean
- Dupcheck: 0 clones
- Format: applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved account selection synchronization in the dividend deposits module to ensure the interface properly reflects and updates when users switch between accounts.

* **Tests**
  * Re-enabled integration tests for account selection functionality that were previously disabled, enhancing validation of account switching and dividend deposits features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->