### PR TITLE
feat(AV.4): implement global tab selection persistence - GREEN phase

### DIFF
--- a/apps/dms-material/src/app/accounts/account.spec.ts
+++ b/apps/dms-material/src/app/accounts/account.spec.ts
@@ -276,7 +276,7 @@ describe('Account', () => {
   });
 
   describe('Global Tab Selection Persistence', () => {
-    it.skip('should save selected global tab to state service when navigating', () => {
+    it('should save selected global tab to state service when navigating', () => {
       component.navigateToGlobal('universe');
 
       expect(mockStatePersistenceService.saveState).toHaveBeenCalledWith(
@@ -285,18 +285,18 @@ describe('Account', () => {
       );
     });
 
-    it.skip('should load saved global tab selection on component init', () => {
+    it('should load saved global tab selection on component init', () => {
       mockStatePersistenceService.loadState.mockReturnValue('screener');
 
       component.ngOnInit();
 
       expect(mockStatePersistenceService.loadState).toHaveBeenCalledWith(
         'global-tab-selection',
-        expect.anything()
+        null
       );
     });
 
-    it.skip('should default to no tab selection when no saved state exists', () => {
+    it('should default to no tab selection when no saved state exists', () => {
       mockStatePersistenceService.loadState.mockReturnValue(null);
 
       component.ngOnInit();
@@ -307,7 +307,7 @@ describe('Account', () => {
       );
     });
 
-    it.skip('should navigate to saved global tab on init', () => {
+    it('should navigate to saved global tab on init', () => {
       mockStatePersistenceService.loadState.mockReturnValue('universe');
 
       component.ngOnInit();
@@ -316,7 +316,7 @@ describe('Account', () => {
       expect(mockRouter.navigate).toHaveBeenCalledWith(['/global', 'universe']);
     });
 
-    it.skip('should handle invalid saved tab gracefully', () => {
+    it('should handle invalid saved tab gracefully', () => {
       mockStatePersistenceService.loadState.mockReturnValue('nonexistent-tab');
 
       expect(() => {

--- a/apps/dms-material/src/app/accounts/account.ts
+++ b/apps/dms-material/src/app/accounts/account.ts
@@ -16,6 +16,7 @@ import { Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { SmartArray } from '@smarttools/smart-signals';
 
 import { NodeEditorComponent } from '../shared/components/edit/node-editor.component';
+import { StatePersistenceService } from '../shared/services/state-persistence.service';
 import { Account as AccountInterface } from '../store/accounts/account.interface';
 import { selectAccounts } from '../store/accounts/selectors/select-accounts.function';
 import { selectTopEntities } from '../store/top/selectors/select-top-entities.function';
@@ -43,6 +44,8 @@ import { AccountComponentService } from './account-component.service';
 export class Account implements OnInit {
   private accountService = inject(AccountComponentService);
   private router = inject(Router);
+  private statePersistence = inject(StatePersistenceService);
+  private readonly stateKey = 'global-tab-selection';
 
   accounts$ = selectAccounts as Signal<
     AccountInterface[] & SmartArray<Top, AccountInterface>
@@ -52,6 +55,13 @@ export class Account implements OnInit {
 
   ngOnInit(): void {
     this.accountService.init(this);
+    const savedTab = this.statePersistence.loadState<string | null>(
+      this.stateKey,
+      null
+    );
+    if (savedTab !== null) {
+      this.navigateToGlobal(savedTab);
+    }
   }
 
   // Convert SmartArray to regular array for Angular Material compatibility
@@ -75,6 +85,7 @@ export class Account implements OnInit {
   }
 
   navigateToGlobal(path: string): void {
+    this.statePersistence.saveState(this.stateKey, path);
     const context = this;
     void context.router
       .navigate(['/global', path])

--- a/docs/stories/AV.4.implement-global-tab-selection-persistence.md
+++ b/docs/stories/AV.4.implement-global-tab-selection-persistence.md
@@ -95,4 +95,31 @@ pnpm test:dms-material
 
 ### Status
 
-Approved
+Ready for Review
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### Completion Notes
+
+- Re-enabled all 5 Global Tab Selection Persistence tests from AV.3
+- Injected StatePersistenceService into Account component
+- navigateToGlobal now saves selected tab path via saveState
+- ngOnInit loads saved tab and navigates to it if non-null
+- Updated one test assertion: expect.anything() → null (vitest doesn't match null with anything())
+- All 1533 unit tests pass, 3 pre-existing skips only
+
+### File List
+
+- apps/dms-material/src/app/accounts/account.ts (modified)
+- apps/dms-material/src/app/accounts/account.spec.ts (modified)
+
+### Change Log
+
+- Import StatePersistenceService in Account component
+- Add statePersistence injection and stateKey constant
+- Save tab selection in navigateToGlobal via saveState
+- Load and restore tab selection in ngOnInit
+- Re-enable all 5 skipped persistence tests
+- Fix test assertion for loadState default parameter


### PR DESCRIPTION
## Story AV.4: Persist Global Tab Selection - TDD GREEN Phase

### Changes
- Inject `StatePersistenceService` into `Account` component
- Save selected global tab path via `saveState` when `navigateToGlobal` is called
- Restore saved tab selection on `ngOnInit` — if a saved tab exists, navigate to it
- Re-enable all 5 skipped persistence tests from AV.3
- Fix test assertion: `expect.anything()` → `null` (vitest doesn't match `null` with `anything()`)

### Implementation
- New private fields: `statePersistence = inject(StatePersistenceService)`, `stateKey = 'global-tab-selection'`
- `navigateToGlobal(path)` now calls `saveState(stateKey, path)` before navigating
- `ngOnInit()` calls `loadState<string | null>(stateKey, null)` and navigates if non-null

### Validation
- ✅ `pnpm all` passes (lint + build + test)
- ✅ 1533 unit tests pass (5 previously skipped now enabled)
- ✅ `pnpm e2e:dms-material:chromium` passes (512 passed, 19.0m)
- ✅ `pnpm e2e:dms-material:firefox` passes (513 passed, 22.6m)
- ✅ `pnpm dupcheck` passes (0 clones)
- ✅ `pnpm format` clean

### Related
- Previous: PR #588 (AV.3 - TDD RED phase tests)
- Next: AV.5 (TDD for view preferences)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tab selection persistence: The app now automatically saves and restores your last selected global tab, providing a seamless experience when navigating between sections or refreshing the page.

* **Tests**
  * Re-enabled tab persistence test suite to comprehensively verify functionality across navigation, initialization, and edge cases.

* **Documentation**
  * Updated documentation describing the implementation of the global tab selection persistence feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->