### PR TITLE
test(AV.12): TDD RED - write skipped E2E tests for state persistence

### DIFF
--- a/apps/dms-material-e2e/src/state-persistence.spec.ts
+++ b/apps/dms-material-e2e/src/state-persistence.spec.ts
@@ -1,0 +1,290 @@
+import { expect, Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+
+// Created by beforeAll — fresh accounts so we never depend on pre-existing data.
+let testAccountId = '';
+let testAccountName = '';
+let secondAccountId = '';
+let secondAccountName = '';
+
+/**
+ * Wait for the accounts panel sidebar and its content to load.
+ */
+async function waitForAccountsPanel(page: Page): Promise<void> {
+  await expect(page.locator('[data-testid="accounts-panel"]')).toBeVisible({
+    timeout: 15000,
+  });
+  await page.waitForLoadState('networkidle', { timeout: 30000 });
+  await Promise.race([
+    page
+      .locator('[data-testid="account-item"]')
+      .first()
+      .waitFor({ state: 'visible', timeout: 10000 })
+      .catch(ignoreError),
+    page
+      .locator('[data-testid="add-account-button"]')
+      .waitFor({ state: 'visible', timeout: 10000 }),
+  ]);
+}
+
+/**
+ * Click an account in the sidebar by name and wait for navigation.
+ */
+async function selectAccountByName(
+  page: Page,
+  accountName: string
+): Promise<void> {
+  const accountLink = page
+    .locator('[data-testid="account-item"]')
+    .filter({ hasText: accountName });
+  await expect(accountLink).toBeVisible({ timeout: 10000 });
+  await accountLink.click();
+  await page.waitForURL(/\/account\//, { timeout: 10000 });
+  await page.waitForLoadState('networkidle');
+}
+
+/** No-op catch handler (intentional swallow). */
+function ignoreError(): void {
+  /* swallowed on purpose */
+}
+
+// ─── State Persistence E2E Tests ──────────────────────────────────────────────
+
+test.describe.skip('State Persistence', () => {
+  test.beforeAll(async ({ request }) => {
+    // Create two fresh test accounts via API
+    const res1 = await request.post('/api/accounts/add', {
+      data: { name: `StatePersist Primary ${Date.now()}` },
+    });
+    if (!res1.ok()) {
+      throw new Error(
+        `Failed to create primary test account: ${res1.status()}`
+      );
+    }
+    const accounts1 = (await res1.json()) as Array<{
+      id: string;
+      name: string;
+    }>;
+    if (!accounts1[0]?.id) {
+      throw new Error('Primary account has no id');
+    }
+    testAccountId = accounts1[0].id;
+    testAccountName = accounts1[0].name;
+
+    const res2 = await request.post('/api/accounts/add', {
+      data: { name: `StatePersist Secondary ${Date.now()}` },
+    });
+    if (!res2.ok()) {
+      throw new Error(
+        `Failed to create secondary test account: ${res2.status()}`
+      );
+    }
+    const accounts2 = (await res2.json()) as Array<{
+      id: string;
+      name: string;
+    }>;
+    if (!accounts2[0]?.id) {
+      throw new Error('Secondary account has no id');
+    }
+    secondAccountId = accounts2[0].id;
+    secondAccountName = accounts2[0].name;
+  });
+
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage before each test for clean state
+    await page.goto('/auth/login', { waitUntil: 'domcontentloaded' });
+    await page.evaluate(() => localStorage.removeItem('dms-ui-state'));
+    await login(page);
+    await waitForAccountsPanel(page);
+  });
+
+  // ─── Global Tab Persistence ─────────────────────────────────────────────
+
+  test.describe('Global Tab Persistence', () => {
+    test('should persist global tab selection through page refresh', async ({
+      page,
+    }) => {
+      // Click on Screener global tab
+      await page.click('[data-testid="global-nav-screener"]');
+      await page.waitForURL('**/global/screener', { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify Screener tab is still selected
+      await expect(page).toHaveURL(/\/global\/screener/);
+      await expect(
+        page.locator('[data-testid="global-nav-screener"]')
+      ).toHaveClass(/active-link/);
+    });
+
+    test('should persist Summary global tab through refresh', async ({
+      page,
+    }) => {
+      // Click on Summary global tab
+      await page.click('[data-testid="global-nav-summary"]');
+      await page.waitForURL('**/global/summary', { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify Summary tab is still selected
+      await expect(page).toHaveURL(/\/global\/summary/);
+    });
+  });
+
+  // ─── Account Selection Persistence ──────────────────────────────────────
+
+  test.describe('Account Selection Persistence', () => {
+    test('should persist account selection through page refresh', async ({
+      page,
+    }) => {
+      // Select first account
+      await selectAccountByName(page, testAccountName);
+      await expect(page).toHaveURL(new RegExp(`/account/${testAccountId}`));
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify account is still selected
+      await expect(page).toHaveURL(new RegExp(`/account/${testAccountId}`));
+    });
+
+    test('should persist switching to a different account', async ({
+      page,
+    }) => {
+      // Select first account
+      await selectAccountByName(page, testAccountName);
+
+      // Switch to second account
+      await selectAccountByName(page, secondAccountName);
+      await expect(page).toHaveURL(new RegExp(`/account/${secondAccountId}`));
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify second account is still selected
+      await expect(page).toHaveURL(new RegExp(`/account/${secondAccountId}`));
+    });
+  });
+
+  // ─── Account Tab Persistence ────────────────────────────────────────────
+
+  test.describe('Account Tab Persistence', () => {
+    test('should persist account tab selection through page refresh', async ({
+      page,
+    }) => {
+      // Select account
+      await selectAccountByName(page, testAccountName);
+
+      // Click on Open Positions tab
+      await page.click('[data-testid="account-tab-open"]');
+      await page.waitForURL(/\/open$/, { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify Open Positions tab is still selected
+      await expect(page).toHaveURL(
+        new RegExp(`/account/${testAccountId}/open`)
+      );
+    });
+
+    test('should maintain independent tab state per account', async ({
+      page,
+    }) => {
+      // Select first account and set to Open Positions
+      await selectAccountByName(page, testAccountName);
+      await page.click('[data-testid="account-tab-open"]');
+      await page.waitForURL(/\/open$/, { timeout: 10000 });
+
+      // Select second account and set to Sold Positions
+      await selectAccountByName(page, secondAccountName);
+      await page.click('[data-testid="account-tab-sold"]');
+      await page.waitForURL(/\/sold$/, { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify second account with Sold tab is restored
+      await expect(page).toHaveURL(
+        new RegExp(`/account/${secondAccountId}/sold`)
+      );
+
+      // Switch to first account
+      await selectAccountByName(page, testAccountName);
+
+      // Verify first account with Open tab is restored
+      await expect(page).toHaveURL(
+        new RegExp(`/account/${testAccountId}/open`)
+      );
+    });
+
+    test('should persist Dividend Deposits tab selection', async ({ page }) => {
+      // Select account
+      await selectAccountByName(page, testAccountName);
+
+      // Click on Dividend Deposits tab
+      await page.click('[data-testid="account-tab-div-dep"]');
+      await page.waitForURL(/\/div-dep$/, { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify Dividend Deposits tab is still selected
+      await expect(page).toHaveURL(
+        new RegExp(`/account/${testAccountId}/div-dep`)
+      );
+    });
+  });
+
+  // ─── Complete State Restoration ─────────────────────────────────────────
+
+  test.describe('Complete State Restoration', () => {
+    test('should restore full state chain after page refresh', async ({
+      page,
+    }) => {
+      // Set up complete state: navigate globally first, then to account with tab
+      await page.click('[data-testid="global-nav-screener"]');
+      await page.waitForURL('**/global/screener', { timeout: 10000 });
+
+      // Select account and set tab
+      await selectAccountByName(page, testAccountName);
+      await page.click('[data-testid="account-tab-sold"]');
+      await page.waitForURL(/\/sold$/, { timeout: 10000 });
+
+      // Refresh page
+      await page.reload();
+      await waitForAccountsPanel(page);
+
+      // Verify account with correct tab is restored
+      await expect(page).toHaveURL(
+        new RegExp(`/account/${testAccountId}/sold`)
+      );
+    });
+  });
+
+  // ─── Fresh Start ────────────────────────────────────────────────────────
+
+  test.describe('Fresh Start', () => {
+    test('should use defaults when no saved state exists', async ({ page }) => {
+      // Clear any saved state
+      await page.evaluate(() => localStorage.removeItem('dms-ui-state'));
+
+      // Navigate to app root
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      // Verify defaults: should be on dashboard or initial route
+      await expect(page).toHaveURL(/\/(dashboard|global\/universe|$)/);
+    });
+  });
+});

--- a/apps/dms-material/src/app/account-panel/account-panel.component.html
+++ b/apps/dms-material/src/app/account-panel/account-panel.component.html
@@ -8,6 +8,7 @@
       [routerLinkActiveOptions]="{ exact: true }"
       [active]="rla1.isActive"
       (click)="onTabChange('')"
+      data-testid="account-tab-summary"
     >
       Summary
     </a>
@@ -18,6 +19,7 @@
       #rla2="routerLinkActive"
       [active]="rla2.isActive"
       (click)="onTabChange('open')"
+      data-testid="account-tab-open"
     >
       Open Positions
     </a>
@@ -28,6 +30,7 @@
       #rla3="routerLinkActive"
       [active]="rla3.isActive"
       (click)="onTabChange('sold')"
+      data-testid="account-tab-sold"
     >
       Sold Positions
     </a>
@@ -38,6 +41,7 @@
       #rla4="routerLinkActive"
       [active]="rla4.isActive"
       (click)="onTabChange('div-dep')"
+      data-testid="account-tab-div-dep"
     >
       Dividend Deposits
     </a>

--- a/apps/dms-material/src/app/accounts/account.html
+++ b/apps/dms-material/src/app/accounts/account.html
@@ -8,6 +8,7 @@
       mat-list-item
       routerLink="/global/universe"
       routerLinkActive="active-link"
+      data-testid="global-nav-universe"
     >
       <mat-icon matListItemIcon>public</mat-icon>
       <span matListItemTitle>Universe</span>
@@ -16,6 +17,7 @@
       mat-list-item
       routerLink="/global/screener"
       routerLinkActive="active-link"
+      data-testid="global-nav-screener"
     >
       <mat-icon matListItemIcon>filter_list</mat-icon>
       <span matListItemTitle>Screener</span>
@@ -24,6 +26,7 @@
       mat-list-item
       routerLink="/global/summary"
       routerLinkActive="active-link"
+      data-testid="global-nav-summary"
     >
       <mat-icon matListItemIcon>dashboard</mat-icon>
       <span matListItemTitle>Summary</span>
@@ -32,6 +35,7 @@
       mat-list-item
       routerLink="/global/error-logs"
       routerLinkActive="active-link"
+      data-testid="global-nav-error-logs"
     >
       <mat-icon matListItemIcon>error</mat-icon>
       <span matListItemTitle>Error Logs</span>

--- a/docs/stories/AV.12.tdd-e2e-state-persistence.md
+++ b/docs/stories/AV.12.tdd-e2e-state-persistence.md
@@ -193,4 +193,33 @@ Verify all new tests are skipped.
 
 ### Status
 
-Approved
+Ready for Review
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### File List
+
+- `apps/dms-material-e2e/src/state-persistence.spec.ts` (new - 9 skipped E2E tests)
+- `apps/dms-material/src/app/accounts/account.html` (modified - added data-testid to global nav links)
+- `apps/dms-material/src/app/account-panel/account-panel.component.html` (modified - added data-testid to tab links)
+- `docs/stories/AV.12.tdd-e2e-state-persistence.md` (modified - Dev Agent Record)
+
+### Change Log
+
+- Created `state-persistence.spec.ts` with `test.describe.skip` containing 9 E2E tests
+- Added data-testid attributes: global-nav-universe, global-nav-screener, global-nav-summary, global-nav-error-logs
+- Added data-testid attributes: account-tab-summary, account-tab-open, account-tab-sold, account-tab-div-dep
+- Tests cover: global tab persistence, account selection persistence, account tab persistence (including per-account independence), complete state restoration, fresh start
+
+### Debug Log References
+
+None needed
+
+### Completion Notes
+
+- All 9 E2E tests are skipped (RED phase)
+- 1553 unit tests passing, 0 E2E failures (skipped tests don't count)
+- E2E: 513 passed chromium + 513 passed firefox, 136 skipped each (including our 9)
+- 0 clones, lint clean, format clean


### PR DESCRIPTION
## Story AV.12: Write E2E Tests for State Persistence - TDD RED Phase

### Changes

**New E2E Test File**: `state-persistence.spec.ts` with 9 skipped tests covering:
- Global tab persistence through refresh (2 tests)
- Account selection persistence through refresh (2 tests)
- Account tab persistence through refresh (3 tests: basic, per-account independence, div-dep)
- Complete state restoration after refresh (1 test)
- Fresh start with no saved state (1 test)

**Data-testid Attributes Added**:
- Global nav: `global-nav-universe`, `global-nav-screener`, `global-nav-summary`, `global-nav-error-logs`
- Account tabs: `account-tab-summary`, `account-tab-open`, `account-tab-sold`, `account-tab-div-dep`

### Validation

- 1553 unit tests passing
- E2E: 513 chromium + 513 firefox passed (our 9 skipped)
- Lint clean, build clean
- 0 code clones, format clean

### Notes

- All tests use `test.describe.skip` (TDD RED phase)
- Story AV.13 will unskip and fix these tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite to validate UI state restoration across page reloads and navigation scenarios, including global tab persistence, account selection persistence, and per-account tab state recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->