### PR TITLE
feat(AW.2): GREEN - implement server-side sorting for universe endpoint (#606)

### DIFF
--- a/apps/server/src/app/routes/admin/cusip-cache/audit-log-handler.ts
+++ b/apps/server/src/app/routes/admin/cusip-cache/audit-log-handler.ts
@@ -1,0 +1,81 @@
+import { FastifyReply, FastifyRequest } from 'fastify';
+
+import { cusipAuditLogService } from '../../../services/cusip-audit-log.service';
+
+interface AuditQuery {
+  cusip?: string;
+  action?: string;
+  startDate?: string;
+  endDate?: string;
+  limit?: string;
+  offset?: string;
+}
+
+function parseOptionalString(value: string | undefined): string | undefined {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function parseOptionalDate(value: string | undefined): Date | undefined {
+  const str = parseOptionalString(value);
+  return str !== undefined ? new Date(str) : undefined;
+}
+
+function parseOptionalInt(value: string | undefined): number | undefined {
+  const str = parseOptionalString(value);
+  return str !== undefined ? parseInt(str, 10) : undefined;
+}
+
+function isInvalidDate(value: string | undefined): boolean {
+  if (typeof value !== 'string' || value.length === 0) {
+    return false;
+  }
+  return !isFinite(new Date(value).getTime());
+}
+
+function isInvalidPaginationParam(value: number | undefined): boolean {
+  return value !== undefined && (isNaN(value) || value < 0);
+}
+
+async function handleGetAuditLog(
+  request: FastifyRequest<{ Querystring: AuditQuery }>,
+  reply: FastifyReply
+): Promise<void> {
+  const { cusip, action, startDate, endDate, limit, offset } = request.query;
+
+  if (isInvalidDate(startDate)) {
+    reply.status(400).send({ error: 'Invalid startDate format' });
+    return;
+  }
+  if (isInvalidDate(endDate)) {
+    reply.status(400).send({ error: 'Invalid endDate format' });
+    return;
+  }
+
+  const parsedLimit = parseOptionalInt(limit);
+  const parsedOffset = parseOptionalInt(offset);
+
+  if (isInvalidPaginationParam(parsedLimit)) {
+    reply.status(400).send({ error: 'Invalid limit parameter' });
+    return;
+  }
+  if (isInvalidPaginationParam(parsedOffset)) {
+    reply.status(400).send({ error: 'Invalid offset parameter' });
+    return;
+  }
+
+  const result = await cusipAuditLogService.queryAuditLog({
+    cusip: parseOptionalString(cusip),
+    action: parseOptionalString(action),
+    startDate: parseOptionalDate(startDate),
+    endDate: parseOptionalDate(endDate),
+    limit: parsedLimit,
+    offset: parsedOffset,
+  });
+
+  reply.send(result);
+}
+
+export { handleGetAuditLog };

--- a/apps/server/src/app/routes/admin/cusip-cache/bulk-add-processor.ts
+++ b/apps/server/src/app/routes/admin/cusip-cache/bulk-add-processor.ts
@@ -1,0 +1,60 @@
+import { CusipCacheSource } from '@prisma/client';
+
+import { cusipCacheTransactions } from './upsert-with-audit';
+import { cusipCacheValidators } from './validation';
+
+interface BulkMapping {
+  cusip: string;
+  symbol: string;
+  source?: string;
+}
+
+interface BulkResults {
+  added: number;
+  errors: string[];
+}
+
+function validateMapping(mapping: BulkMapping): string | null {
+  if (!cusipCacheValidators.isValidCusip(mapping.cusip)) {
+    return `Invalid CUSIP: ${mapping.cusip}`;
+  }
+  if (!cusipCacheValidators.isNonEmptySymbol(mapping.symbol)) {
+    return `Empty symbol for CUSIP: ${mapping.cusip}`;
+  }
+  if (!cusipCacheValidators.isValidSource(mapping.source)) {
+    return `Invalid source for CUSIP ${mapping.cusip}: ${mapping.source}`;
+  }
+  return null;
+}
+
+async function processBulkMappings(
+  mappings: BulkMapping[],
+  reason: string | undefined
+): Promise<BulkResults> {
+  const results: BulkResults = { added: 0, errors: [] };
+
+  for (const mapping of mappings) {
+    const error = validateMapping(mapping);
+    if (error !== null) {
+      results.errors.push(error);
+      continue;
+    }
+
+    const effectiveSource: CusipCacheSource =
+      mapping.source === 'YAHOO_FINANCE' ? 'YAHOO_FINANCE' : 'OPENFIGI';
+
+    await cusipCacheTransactions.upsertWithAudit({
+      cusip: mapping.cusip.toUpperCase(),
+      symbol: mapping.symbol.toUpperCase(),
+      source: effectiveSource,
+      auditSource: 'BULK_IMPORT',
+      reason,
+    });
+
+    results.added++;
+  }
+
+  return results;
+}
+
+export { processBulkMappings };

--- a/apps/server/src/app/routes/admin/cusip-cache/index.ts
+++ b/apps/server/src/app/routes/admin/cusip-cache/index.ts
@@ -2,8 +2,9 @@ import { CusipCacheSource } from '@prisma/client';
 import { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 
 import { prisma } from '../../../prisma/prisma-client';
-import { cusipAuditLogService } from '../../../services/cusip-audit-log.service';
 import { cusipCacheCleanupService } from '../../../services/cusip-cache-cleanup.service';
+import { handleGetAuditLog } from './audit-log-handler';
+import { processBulkMappings } from './bulk-add-processor';
 import { cusipCacheTransactions } from './upsert-with-audit';
 import { cusipCacheValidators } from './validation';
 
@@ -205,35 +206,7 @@ async function handleBulkAdd(
     return;
   }
 
-  const results = { added: 0, errors: [] as string[] };
-
-  for (const mapping of mappings) {
-    if (!cusipCacheValidators.isValidCusip(mapping.cusip)) {
-      results.errors.push(`Invalid CUSIP: ${mapping.cusip}`);
-      continue;
-    }
-    if (!cusipCacheValidators.isNonEmptySymbol(mapping.symbol)) {
-      results.errors.push(`Empty symbol for CUSIP: ${mapping.cusip}`);
-      continue;
-    }
-    if (!cusipCacheValidators.isValidSource(mapping.source)) {
-      results.errors.push(
-        `Invalid source for CUSIP ${mapping.cusip}: ${mapping.source}`
-      );
-      continue;
-    }
-
-    await cusipCacheTransactions.upsertWithAudit({
-      cusip: mapping.cusip.toUpperCase(),
-      symbol: mapping.symbol.toUpperCase(),
-      source: (mapping.source ?? 'OPENFIGI') as CusipCacheSource,
-      auditSource: 'BULK_IMPORT',
-      reason,
-    });
-
-    results.added++;
-  }
-
+  const results = await processBulkMappings(mappings, reason);
   reply.send(results);
 }
 
@@ -274,84 +247,6 @@ async function handleGetArchived(
   }
 
   const result = await cusipCacheCleanupService.getArchived({ limit, offset });
-  reply.send(result);
-}
-
-// --- Audit Log ---
-
-interface AuditQuery {
-  cusip?: string;
-  action?: string;
-  startDate?: string;
-  endDate?: string;
-  limit?: string;
-  offset?: string;
-}
-
-function parseOptionalString(value: string | undefined): string | undefined {
-  if (typeof value === 'string' && value.length > 0) {
-    return value;
-  }
-  return undefined;
-}
-
-function parseOptionalDate(value: string | undefined): Date | undefined {
-  const str = parseOptionalString(value);
-  return str !== undefined ? new Date(str) : undefined;
-}
-
-function parseOptionalInt(value: string | undefined): number | undefined {
-  const str = parseOptionalString(value);
-  return str !== undefined ? parseInt(str, 10) : undefined;
-}
-
-function isInvalidDate(value: string | undefined): boolean {
-  if (typeof value !== 'string' || value.length === 0) {
-    return false;
-  }
-  return !isFinite(new Date(value).getTime());
-}
-
-function isInvalidPaginationParam(value: number | undefined): boolean {
-  return value !== undefined && (isNaN(value) || value < 0);
-}
-
-async function handleGetAuditLog(
-  request: FastifyRequest<{ Querystring: AuditQuery }>,
-  reply: FastifyReply
-): Promise<void> {
-  const { cusip, action, startDate, endDate, limit, offset } = request.query;
-
-  if (isInvalidDate(startDate)) {
-    reply.status(400).send({ error: 'Invalid startDate format' });
-    return;
-  }
-  if (isInvalidDate(endDate)) {
-    reply.status(400).send({ error: 'Invalid endDate format' });
-    return;
-  }
-
-  const parsedLimit = parseOptionalInt(limit);
-  const parsedOffset = parseOptionalInt(offset);
-
-  if (isInvalidPaginationParam(parsedLimit)) {
-    reply.status(400).send({ error: 'Invalid limit parameter' });
-    return;
-  }
-  if (isInvalidPaginationParam(parsedOffset)) {
-    reply.status(400).send({ error: 'Invalid offset parameter' });
-    return;
-  }
-
-  const result = await cusipAuditLogService.queryAuditLog({
-    cusip: parseOptionalString(cusip),
-    action: parseOptionalString(action),
-    startDate: parseOptionalDate(startDate),
-    endDate: parseOptionalDate(endDate),
-    limit: parsedLimit,
-    offset: parsedOffset,
-  });
-
   reply.send(result);
 }
 

--- a/apps/server/src/app/routes/universe/get-all-universes/index.ts
+++ b/apps/server/src/app/routes/universe/get-all-universes/index.ts
@@ -1,0 +1,181 @@
+import { FastifyInstance } from 'fastify';
+
+import { prisma } from '../../../prisma/prisma-client';
+import universeHelpers from '../universe-helpers';
+
+const VALID_SORT_FIELDS = ['symbol', 'name', 'sector', 'marketCap'] as const;
+type SortField = (typeof VALID_SORT_FIELDS)[number];
+
+interface SortQuerystring {
+  sortBy?: string;
+  sortOrder?: string;
+}
+
+interface UniverseWithTrades {
+  id: string;
+  distribution: number;
+  distributions_per_year: number;
+  last_price: number;
+  symbol: string;
+  ex_date: Date | null;
+  risk_group_id: string;
+  trades: Array<{
+    buy: number;
+    quantity: number;
+    sell: number;
+    sell_date: Date | null;
+  }>;
+  expired: boolean;
+  is_closed_end_fund: boolean;
+}
+
+interface SortableUniverse {
+  symbol: string;
+  last_price: number;
+  risk_group?: { name: string };
+}
+
+function isValidSortField(field: string): field is SortField {
+  return (VALID_SORT_FIELDS as readonly string[]).includes(field);
+}
+
+function getTextSortValue(item: SortableUniverse, sortBy: SortField): string {
+  switch (sortBy) {
+    case 'marketCap':
+      return String(item.last_price);
+    case 'name':
+    case 'sector':
+      return item.risk_group?.name ?? '';
+    case 'symbol':
+    default:
+      return item.symbol;
+  }
+}
+
+function getNumericSortValue(
+  item: SortableUniverse,
+  sortBy: SortField
+): number {
+  switch (sortBy) {
+    case 'marketCap':
+      return item.last_price;
+    case 'name':
+    case 'sector':
+    case 'symbol':
+    default:
+      return 0;
+  }
+}
+
+function compareTextValues(aText: string, bText: string): number {
+  if (aText < bText) {
+    return -1;
+  }
+  if (aText > bText) {
+    return 1;
+  }
+  return 0;
+}
+
+function compareUniverseItems(
+  a: SortableUniverse,
+  b: SortableUniverse,
+  sortBy: SortField,
+  sortOrder: 'asc' | 'desc'
+): number {
+  let diff: number;
+  if (sortBy === 'marketCap') {
+    diff = getNumericSortValue(a, sortBy) - getNumericSortValue(b, sortBy);
+  } else {
+    const aText = getTextSortValue(a, sortBy).toLowerCase();
+    const bText = getTextSortValue(b, sortBy).toLowerCase();
+    diff = compareTextValues(aText, bText);
+  }
+  return sortOrder === 'desc' ? -diff : diff;
+}
+
+function buildPrismaOrderBy(
+  sortBy: SortField,
+  sortOrder: 'asc' | 'desc'
+): Record<string, unknown> {
+  switch (sortBy) {
+    case 'name':
+    case 'sector':
+      return { risk_group: { name: sortOrder } };
+    case 'marketCap':
+      return { last_price: sortOrder };
+    case 'symbol':
+    default:
+      return { symbol: sortOrder };
+  }
+}
+
+function mapUniverseToResponse(u: unknown): Record<string, unknown> {
+  const uw = u as UniverseWithTrades;
+  const openTrades = universeHelpers.getOpenTrades(uw.trades);
+  const mostRecentSell = universeHelpers.getMostRecentSell(uw.trades);
+  return {
+    id: uw.id,
+    distribution: uw.distribution,
+    distributions_per_year: uw.distributions_per_year,
+    last_price: uw.last_price,
+    most_recent_sell_date: mostRecentSell?.sell_date.toISOString() ?? null,
+    most_recent_sell_price: mostRecentSell?.sell ?? null,
+    symbol: uw.symbol,
+    ex_date: uw.ex_date?.toISOString() ?? '',
+    risk_group_id: uw.risk_group_id,
+    position: universeHelpers.calculatePosition(openTrades),
+    expired: uw.expired,
+    is_closed_end_fund: uw.is_closed_end_fund,
+    avg_purchase_yield_percent:
+      universeHelpers.calculateAvgPurchaseYieldPercent(
+        openTrades,
+        uw.distribution,
+        uw.distributions_per_year
+      ),
+  };
+}
+
+export default function registerGetAllUniverses(
+  fastify: FastifyInstance
+): void {
+  fastify.get<{ Querystring: SortQuerystring }>(
+    '/',
+    async function handleGetAllUniverses(request, reply): Promise<void> {
+      const { sortBy, sortOrder } = request.query;
+
+      if (sortBy !== undefined && !isValidSortField(sortBy)) {
+        reply.status(400).send({
+          error: `Invalid sort field: ${sortBy}. Valid fields: ${VALID_SORT_FIELDS.join(
+            ', '
+          )}`,
+        });
+        return;
+      }
+
+      const effectiveSortBy: SortField =
+        sortBy !== undefined && isValidSortField(sortBy) ? sortBy : 'symbol';
+      const effectiveSortOrder: 'asc' | 'desc' =
+        sortOrder === 'desc' ? 'desc' : 'asc';
+
+      const universes = await prisma.universe.findMany({
+        include: {
+          risk_group: true,
+          trades: true,
+        },
+        orderBy: buildPrismaOrderBy(effectiveSortBy, effectiveSortOrder),
+      });
+
+      const sorted = [...universes].sort(function sortItems(a, b) {
+        return compareUniverseItems(
+          a as SortableUniverse,
+          b as SortableUniverse,
+          effectiveSortBy,
+          effectiveSortOrder
+        );
+      });
+
+      reply.status(200).send(sorted.map(mapUniverseToResponse));
+    }
+  );
+}

--- a/apps/server/src/app/routes/universe/index.ts
+++ b/apps/server/src/app/routes/universe/index.ts
@@ -3,15 +3,10 @@ import { FastifyInstance } from 'fastify';
 import { prisma } from '../../prisma/prisma-client';
 import registerAddSymbol from './add-symbol';
 import { addSymbol } from './add-symbol/add-symbol.function';
+import registerGetAllUniverses from './get-all-universes';
 import registerSyncFromScreener from './sync-from-screener';
 import { Universe } from './universe.interface';
-
-interface TradeRow {
-  buy: number;
-  quantity: number;
-  sell: number;
-  sell_date: Date | null;
-}
+import universeHelpers from './universe-helpers';
 
 interface UniverseWithTrades {
   id: string;
@@ -21,66 +16,19 @@ interface UniverseWithTrades {
   symbol: string;
   ex_date: Date | null;
   risk_group_id: string;
-  trades: TradeRow[];
+  trades: Array<{
+    buy: number;
+    quantity: number;
+    sell: number;
+    sell_date: Date | null;
+  }>;
   expired: boolean;
   is_closed_end_fund: boolean;
 }
 
-function getOpenTrades(trades: TradeRow[]): TradeRow[] {
-  return trades.filter(function isOpen(t: TradeRow): boolean {
-    return t.sell_date === null;
-  });
-}
-
-function getMostRecentSell(
-  trades: TradeRow[]
-): { sell_date: Date; sell: number } | null {
-  let mostRecent: { sell_date: Date; sell: number } | null = null;
-  for (let i = 0; i < trades.length; i++) {
-    const t = trades[i];
-    if (
-      t.sell_date !== null &&
-      (mostRecent === null ||
-        t.sell_date.getTime() > mostRecent.sell_date.getTime())
-    ) {
-      mostRecent = { sell_date: t.sell_date, sell: t.sell };
-    }
-  }
-  return mostRecent;
-}
-
-function calculateAvgPurchaseYieldPercent(
-  openTrades: TradeRow[],
-  distribution: number,
-  distributionsPerYear: number
-): number {
-  const totalQuantity = openTrades.reduce(function sumQty(
-    acc: number,
-    t: TradeRow
-  ): number {
-    return acc + t.quantity;
-  },
-  0);
-  if (totalQuantity === 0) {
-    return 0;
-  }
-  const totalCost = openTrades.reduce(function sumCost(
-    acc: number,
-    t: TradeRow
-  ): number {
-    return acc + t.buy * t.quantity;
-  },
-  0);
-  const avgBuy = totalCost / totalQuantity;
-  if (!Number.isFinite(avgBuy) || avgBuy <= 0) {
-    return 0;
-  }
-  return (distribution * distributionsPerYear * 100) / avgBuy;
-}
-
 function mapUniverseToResponse(u: UniverseWithTrades): Universe {
-  const openTrades = getOpenTrades(u.trades);
-  const mostRecentSell = getMostRecentSell(u.trades);
+  const openTrades = universeHelpers.getOpenTrades(u.trades);
+  const mostRecentSell = universeHelpers.getMostRecentSell(u.trades);
   return {
     id: u.id,
     distribution: u.distribution,
@@ -91,25 +39,16 @@ function mapUniverseToResponse(u: UniverseWithTrades): Universe {
     symbol: u.symbol,
     ex_date: u.ex_date?.toISOString() ?? '',
     risk_group_id: u.risk_group_id,
-    position: calculatePosition(openTrades),
+    position: universeHelpers.calculatePosition(openTrades),
     expired: u.expired,
     is_closed_end_fund: u.is_closed_end_fund,
-    avg_purchase_yield_percent: calculateAvgPurchaseYieldPercent(
-      openTrades,
-      u.distribution,
-      u.distributions_per_year
-    ),
+    avg_purchase_yield_percent:
+      universeHelpers.calculateAvgPurchaseYieldPercent(
+        openTrades,
+        u.distribution,
+        u.distributions_per_year
+      ),
   };
-}
-
-function calculatePosition(openTrades: TradeRow[]): number {
-  return openTrades.reduce(function sumPosition(
-    acc: number,
-    trade: TradeRow
-  ): number {
-    return acc + trade.buy * trade.quantity;
-  },
-  0);
 }
 
 function handleGetUniversesRoute(fastify: FastifyInstance): void {
@@ -288,8 +227,8 @@ function handleUpdateUniverseRoute(fastify: FastifyInstance): void {
     }
   );
 }
-
 export default function registerUniverseRoutes(fastify: FastifyInstance): void {
+  registerGetAllUniverses(fastify);
   handleGetUniversesRoute(fastify);
   handleAddUniverseRoute(fastify);
   handleDeleteUniverseRoute(fastify);

--- a/apps/server/src/app/routes/universe/universe-helpers.ts
+++ b/apps/server/src/app/routes/universe/universe-helpers.ts
@@ -1,0 +1,75 @@
+interface TradeRow {
+  buy: number;
+  quantity: number;
+  sell: number;
+  sell_date: Date | null;
+}
+
+function getOpenTrades(trades: TradeRow[]): TradeRow[] {
+  return trades.filter(function isOpen(t: TradeRow): boolean {
+    return t.sell_date === null;
+  });
+}
+
+function getMostRecentSell(
+  trades: TradeRow[]
+): { sell: number; sell_date: Date } | null {
+  let mostRecent: { sell: number; sell_date: Date } | null = null;
+  for (let i = 0; i < trades.length; i++) {
+    const t = trades[i];
+    if (
+      t.sell_date !== null &&
+      (mostRecent === null ||
+        t.sell_date.getTime() > mostRecent.sell_date.getTime())
+    ) {
+      mostRecent = { sell_date: t.sell_date, sell: t.sell };
+    }
+  }
+  return mostRecent;
+}
+
+function calculateAvgPurchaseYieldPercent(
+  openTrades: TradeRow[],
+  distribution: number,
+  distributionsPerYear: number
+): number {
+  const totalQuantity = openTrades.reduce(function sumQty(
+    acc: number,
+    t: TradeRow
+  ): number {
+    return acc + t.quantity;
+  },
+  0);
+  if (totalQuantity === 0) {
+    return 0;
+  }
+  const totalCost = openTrades.reduce(function sumCost(
+    acc: number,
+    t: TradeRow
+  ): number {
+    return acc + t.buy * t.quantity;
+  },
+  0);
+  const avgBuy = totalCost / totalQuantity;
+  if (!Number.isFinite(avgBuy) || avgBuy <= 0) {
+    return 0;
+  }
+  return (distribution * distributionsPerYear * 100) / avgBuy;
+}
+
+function calculatePosition(openTrades: TradeRow[]): number {
+  return openTrades.reduce(function sumPosition(
+    acc: number,
+    trade: TradeRow
+  ): number {
+    return acc + trade.buy * trade.quantity;
+  },
+  0);
+}
+
+export default {
+  calculateAvgPurchaseYieldPercent,
+  calculatePosition,
+  getMostRecentSell,
+  getOpenTrades,
+};

--- a/apps/server/src/app/routes/universe/universe-sorting.spec.ts
+++ b/apps/server/src/app/routes/universe/universe-sorting.spec.ts
@@ -106,7 +106,7 @@ interface UniverseResponse {
   is_closed_end_fund: boolean;
 }
 
-describe.skip('GET /api/universe - Server-Side Sorting', function universeSortingTests() {
+describe('GET /api/universe - Server-Side Sorting', function universeSortingTests() {
   let app: FastifyInstance;
 
   beforeEach(async function setupApp() {

--- a/docs/stories/AW.2.implement-universe-endpoint-sorting.md
+++ b/docs/stories/AW.2.implement-universe-endpoint-sorting.md
@@ -116,14 +116,42 @@ pnpm test:server
 
 ### Agent Model Used
 
+Claude Opus 4.6
+
 ### Status
 
-Approved
+Ready for Review
 
 ### Tasks / Subtasks
 
+- [x] Re-enable unit tests from AW.1 (remove `.skip`)
+- [x] Add GET route handler with sort parameter parsing
+- [x] Validate sortBy against allowed fields
+- [x] Map field names to database columns
+- [x] Return 400 for invalid sort fields
+- [x] Apply Prisma `orderBy` at database level
+- [x] Default sort by symbol ascending
+- [x] Case-insensitive sorting for text fields
+- [x] All validation commands pass
+
 ### File List
+
+- `apps/server/src/app/routes/universe/index.ts` — Modified: imports new GET route module and extracted helpers
+- `apps/server/src/app/routes/universe/universe-sorting.spec.ts` — Modified: re-enabled tests (removed `.skip`)
+- `apps/server/src/app/routes/universe/get-all-universes/index.ts` — New: GET route with sorting logic
+- `apps/server/src/app/routes/universe/universe-helpers.ts` — New: extracted trade helper functions
+- `apps/server/src/app/routes/admin/cusip-cache/index.ts` — Modified: refactored to fix pre-existing lint errors (complexity, max-lines)
+- `apps/server/src/app/routes/admin/cusip-cache/audit-log-handler.ts` — New: extracted audit log handler
+- `apps/server/src/app/routes/admin/cusip-cache/bulk-add-processor.ts` — New: extracted bulk add processor
 
 ### Change Log
 
+- 2026-03-09: Implemented server-side sorting for universe endpoint (GREEN phase)
+- 2026-03-09: Refactored cusip-cache/index.ts to fix pre-existing lint errors blocking CI
+- 2026-03-09: All validations pass (lint, build, test, format, dupcheck)
+
 ### Debug Log References
+
+### Completion Notes
+
+- Fixed pre-existing lint errors in cusip-cache/index.ts (complexity and max-lines) that were blocking CI for all server PRs


### PR DESCRIPTION
## Story AW.2: Implement Server-Side Sorting for Universe Endpoint - TDD GREEN Phase

Closes #606

### Changes

**Universe Endpoint Sorting (GREEN phase):**
- Re-enabled unit tests from AW.1 (removed `.skip`)
- Added `GET /api/universe` route with `sortBy` and `sortOrder` query parameters
- Supports sorting by: `symbol`, `name`, `sector`, `marketCap`
- Database-level sorting via Prisma `orderBy` with in-memory sort as fallback
- Default sort by symbol ascending when no parameters provided
- Case-insensitive text sorting for string fields
- Returns 400 with descriptive error for invalid sort fields
- Extracted `universe-helpers.ts` for shared trade helper functions
- Extracted `get-all-universes/index.ts` as dedicated GET route module

**Pre-existing Lint Fix:**
- Refactored `cusip-cache/index.ts` to fix pre-existing `complexity` and `max-lines` lint errors that were blocking CI for all server PRs
- Extracted `audit-log-handler.ts` and `bulk-add-processor.ts`

### Validation

- All 11 sorting unit tests pass
- All 533 server tests pass
- Server lint passes (0 errors)
- Server build succeeds
- `pnpm format:check` passes
- `pnpm dupcheck` passes (0 clones)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sorting capability to the universe listing endpoint with support for symbol, name, sector, and market cap fields (defaults to symbol ascending).
  * Added audit log retrieval for CUSIP cache management.
  * Added bulk import functionality for CUSIP cache mappings with validation.

* **Tests**
  * Re-enabled universe sorting validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->