### PR TITLE
test(AW.9): TDD RED - write skipped tests verifying client-side sorting removal

### DIFF
--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.spec.ts
@@ -1275,3 +1275,131 @@ describe('OpenPositionsComponent - Account Selection Integration', () => {
     });
   });
 });
+
+// Story AW.9: TDD RED - Verify client-side sorting logic is removed
+// Tests will be enabled in Story AW.10 after sorting removal is implemented
+describe('OpenPositionsComponent - Client-Side Sorting Removal', () => {
+  let component: OpenPositionsComponent;
+  let fixture: ComponentFixture<OpenPositionsComponent>;
+  let mockOpenPositionsService: {
+    trades: WritableSignal<Trade[]>;
+    selectOpenPositions: WritableSignal<OpenPosition[]>;
+    deleteOpenPosition: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    mockOpenPositionsService = {
+      trades: signal<Trade[]>([]),
+      selectOpenPositions: signal<OpenPosition[]>([]),
+      deleteOpenPosition: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [OpenPositionsComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: OpenPositionsComponentService,
+          useValue: mockOpenPositionsService,
+        },
+        {
+          provide: tradeEffectsServiceToken,
+          useValue: {
+            update: vi.fn().mockReturnValue(of([])),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OpenPositionsComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe.skip('Verify no client-side sorting', () => {
+    it('should not have sortData method', () => {
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        typeof (component as Record<string, unknown>)['sortData']
+      ).not.toBe('function');
+    });
+
+    it('should preserve server response order', () => {
+      const serverOrder: OpenPosition[] = [
+        { id: '3', symbol: 'GOOGL', buy: 100 } as OpenPosition,
+        { id: '1', symbol: 'AAPL', buy: 150 } as OpenPosition,
+        { id: '2', symbol: 'MSFT', buy: 300 } as OpenPosition,
+      ];
+      mockOpenPositionsService.selectOpenPositions.set(serverOrder);
+
+      const displayed = component.selectOpenPositions$();
+      const displayedSymbols = displayed.map(function getSymbol(
+        p: OpenPosition
+      ) {
+        return p.symbol;
+      });
+
+      // Data should be in exact server response order
+      expect(displayedSymbols).toEqual(['GOOGL', 'AAPL', 'MSFT']);
+    });
+
+    it('should trigger HTTP call on sort change instead of local sorting', () => {
+      const sortStateService = TestBed.inject(SortStateService);
+      const saveSpy = vi.spyOn(sortStateService, 'saveSortState');
+
+      component.onSortChange({ active: 'buy', direction: 'asc' });
+
+      // Sort change should delegate to SortStateService (which triggers HTTP via interceptor)
+      expect(saveSpy).toHaveBeenCalledWith('trades-open', {
+        field: 'buy',
+        order: 'asc',
+      });
+
+      // Component should NOT have any local sort logic
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        (component as Record<string, unknown>)['compareFunction']
+      ).toBeUndefined();
+    });
+
+    it('should not manipulate data array order', () => {
+      const testData: OpenPosition[] = [
+        { id: '3', symbol: 'GOOGL', buy: 100, quantity: 75 } as OpenPosition,
+        { id: '1', symbol: 'AAPL', buy: 300, quantity: 100 } as OpenPosition,
+        { id: '2', symbol: 'MSFT', buy: 200, quantity: 50 } as OpenPosition,
+      ];
+      mockOpenPositionsService.selectOpenPositions.set(testData);
+
+      const displayed = component.selectOpenPositions$();
+
+      // Data order must match server response exactly
+      expect(displayed[0].id).toBe('3');
+      expect(displayed[1].id).toBe('1');
+      expect(displayed[2].id).toBe('2');
+    });
+
+    it('should not use Array.sort() on table data', () => {
+      const testData: OpenPosition[] = [
+        { id: '2', symbol: 'MSFT', buy: 300 } as OpenPosition,
+        { id: '1', symbol: 'AAPL', buy: 150 } as OpenPosition,
+      ];
+      mockOpenPositionsService.selectOpenPositions.set(testData);
+
+      const sortSpy = vi.spyOn(Array.prototype, 'sort');
+
+      component.selectOpenPositions$();
+
+      const dataSortCalls = sortSpy.mock.calls.filter(function isDataSort(
+        call
+      ) {
+        return call.length > 0;
+      });
+      expect(dataSortCalls.length).toBe(0);
+
+      sortSpy.mockRestore();
+    });
+  });
+});

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
@@ -1018,3 +1018,145 @@ describe('SoldPositionsComponent - Account Selection Integration', () => {
     });
   });
 });
+
+// Story AW.9: TDD RED - Verify client-side sorting logic is removed
+// Tests will be enabled in Story AW.10 after sorting removal is implemented
+describe('SoldPositionsComponent - Client-Side Sorting Removal', () => {
+  let component: SoldPositionsComponent;
+  let fixture: ComponentFixture<SoldPositionsComponent>;
+  let mockSoldPositionsService: {
+    selectSoldPositions: WritableSignal<ClosedPosition[]>;
+  };
+
+  beforeEach(async () => {
+    mockSoldPositionsService = {
+      selectSoldPositions: signal<ClosedPosition[]>([]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [SoldPositionsComponent],
+      providers: [
+        {
+          provide: SoldPositionsComponentService,
+          useValue: mockSoldPositionsService,
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SoldPositionsComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe.skip('Verify no client-side sorting', () => {
+    it('should not have sortData method', () => {
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        typeof (component as Record<string, unknown>)['sortData']
+      ).not.toBe('function');
+    });
+
+    it('should preserve server response order', () => {
+      const serverOrder: ClosedPosition[] = [
+        { id: '3', symbol: 'GOOGL', sell: 120 } as ClosedPosition,
+        { id: '1', symbol: 'AAPL', sell: 180 } as ClosedPosition,
+        { id: '2', symbol: 'MSFT', sell: 320 } as ClosedPosition,
+      ];
+      mockSoldPositionsService.selectSoldPositions.set(serverOrder);
+
+      const displayed = component.displayedPositions();
+      const displayedSymbols = displayed.map(function getSymbol(
+        p: ClosedPosition
+      ) {
+        return p.symbol;
+      });
+
+      // Data should be in exact server response order
+      expect(displayedSymbols).toEqual(['GOOGL', 'AAPL', 'MSFT']);
+    });
+
+    it('should trigger HTTP call on sort change instead of local sorting', () => {
+      const sortStateService = TestBed.inject(SortStateService);
+      const saveSpy = vi.spyOn(sortStateService, 'saveSortState');
+
+      component.onSortChange({ active: 'sell', direction: 'desc' });
+
+      // Sort change should delegate to SortStateService (which triggers HTTP via interceptor)
+      expect(saveSpy).toHaveBeenCalledWith('trades-closed', {
+        field: 'sell',
+        order: 'desc',
+      });
+
+      // Component should NOT have any local sort logic
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        (component as Record<string, unknown>)['compareFunction']
+      ).toBeUndefined();
+    });
+
+    it('should not manipulate data array order', () => {
+      const testData: ClosedPosition[] = [
+        {
+          id: '3',
+          symbol: 'GOOGL',
+          sell: 120,
+          sell_date: '2024-07-01',
+        } as ClosedPosition,
+        {
+          id: '1',
+          symbol: 'AAPL',
+          sell: 180,
+          sell_date: '2024-06-01',
+        } as ClosedPosition,
+        {
+          id: '2',
+          symbol: 'MSFT',
+          sell: 320,
+          sell_date: '2024-05-01',
+        } as ClosedPosition,
+      ];
+      mockSoldPositionsService.selectSoldPositions.set(testData);
+
+      const displayed = component.displayedPositions();
+
+      // Data order must match server response exactly
+      expect(displayed[0].id).toBe('3');
+      expect(displayed[1].id).toBe('1');
+      expect(displayed[2].id).toBe('2');
+    });
+
+    it('should not use Array.sort() on table data', () => {
+      const testData: ClosedPosition[] = [
+        {
+          id: '2',
+          symbol: 'MSFT',
+          sell: 320,
+          sell_date: '2024-05-01',
+        } as ClosedPosition,
+        {
+          id: '1',
+          symbol: 'AAPL',
+          sell: 180,
+          sell_date: '2024-06-01',
+        } as ClosedPosition,
+      ];
+      mockSoldPositionsService.selectSoldPositions.set(testData);
+
+      const sortSpy = vi.spyOn(Array.prototype, 'sort');
+
+      component.displayedPositions();
+
+      const dataSortCalls = sortSpy.mock.calls.filter(function isDataSort(
+        call
+      ) {
+        return call.length > 0;
+      });
+      expect(dataSortCalls.length).toBe(0);
+
+      sortSpy.mockRestore();
+    });
+  });
+});

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
@@ -2342,3 +2342,133 @@ describe('GlobalUniverseComponent - Ex-Date Editing Enhancements (TDD - Story AN
     });
   });
 });
+
+// Story AW.9: TDD RED - Verify client-side sorting logic is removed
+// Tests will be enabled in Story AW.10 after sorting removal is implemented
+describe('GlobalUniverseComponent - Client-Side Sorting Removal', () => {
+  let component: GlobalUniverseComponent;
+  let fixture: ComponentFixture<GlobalUniverseComponent>;
+  let mockUniverseService: {
+    universes: ReturnType<typeof signal<Universe[]>>;
+  };
+
+  beforeEach(async () => {
+    mockUniverseService = {
+      universes: signal<Universe[]>([]),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [GlobalUniverseComponent],
+      providers: [
+        provideSmartNgRX(),
+        {
+          provide: UniverseSyncService,
+          useValue: {
+            syncFromScreener: vi.fn().mockReturnValue(of({})),
+            isSyncing: vi.fn().mockReturnValue(false),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            success: vi.fn(),
+            error: vi.fn(),
+            showPersistent: vi.fn(),
+          },
+        },
+        { provide: UniverseService, useValue: mockUniverseService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GlobalUniverseComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe.skip('Verify no client-side sorting', () => {
+    it('should not have sortData method', () => {
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        typeof (component as Record<string, unknown>)['sortData']
+      ).not.toBe('function');
+    });
+
+    it('should not manipulate data array order', () => {
+      const testData: Universe[] = [
+        { id: '3', symbol: 'GOOGL' } as Universe,
+        { id: '1', symbol: 'AAPL' } as Universe,
+        { id: '2', symbol: 'MSFT' } as Universe,
+      ];
+      mockUniverseService.universes.set(testData);
+
+      const displayed = component.filteredData$();
+
+      // Data should preserve insertion order from server, not be alphabetically sorted
+      expect(displayed[0].symbol).toBe('GOOGL');
+      expect(displayed[1].symbol).toBe('AAPL');
+      expect(displayed[2].symbol).toBe('MSFT');
+    });
+
+    it('should preserve server response order', () => {
+      const serverOrder: Universe[] = [
+        { id: '2', symbol: 'MSFT' } as Universe,
+        { id: '3', symbol: 'GOOGL' } as Universe,
+        { id: '1', symbol: 'AAPL' } as Universe,
+      ];
+      mockUniverseService.universes.set(serverOrder);
+
+      const displayed = component.filteredData$();
+      const displayedSymbols = displayed.map(function getSymbol(u: Universe) {
+        return u.symbol;
+      });
+
+      expect(displayedSymbols).toEqual(['MSFT', 'GOOGL', 'AAPL']);
+    });
+
+    it('should trigger HTTP call on sort change instead of local sorting', () => {
+      const sortStateService = TestBed.inject(SortStateService);
+      const saveSpy = vi.spyOn(sortStateService, 'saveSortState');
+
+      component.onSortChange({ active: 'symbol', direction: 'asc' });
+
+      // Sort change should delegate to SortStateService (which triggers HTTP via interceptor)
+      expect(saveSpy).toHaveBeenCalledWith('universes', {
+        field: 'symbol',
+        order: 'asc',
+      });
+
+      // Component should NOT have any local sort logic that reorders filteredData$
+      expect(
+        (component as Record<string, unknown>)['sortData']
+      ).toBeUndefined();
+      expect(
+        (component as Record<string, unknown>)['compareFunction']
+      ).toBeUndefined();
+    });
+
+    it('should not use Array.sort() on table data', () => {
+      const testData: Universe[] = [
+        { id: '3', symbol: 'GOOGL', last_price: 100 } as Universe,
+        { id: '1', symbol: 'AAPL', last_price: 200 } as Universe,
+        { id: '2', symbol: 'MSFT', last_price: 150 } as Universe,
+      ];
+      mockUniverseService.universes.set(testData);
+
+      // Spy on Array.prototype.sort to ensure it is not called on the data array
+      const sortSpy = vi.spyOn(Array.prototype, 'sort');
+
+      component.filteredData$();
+
+      // The component should not sort the data array
+      const dataSortCalls = sortSpy.mock.calls.filter(function isDataSort(
+        call
+      ) {
+        return call.length > 0;
+      });
+      expect(dataSortCalls.length).toBe(0);
+
+      sortSpy.mockRestore();
+    });
+  });
+});

--- a/docs/stories/AW.9.tdd-verify-client-side-sorting-removed.md
+++ b/docs/stories/AW.9.tdd-verify-client-side-sorting-removed.md
@@ -124,14 +124,50 @@ pnpm test:dms-material
 
 ### Agent Model Used
 
+Claude Sonnet 4.6
+
 ### Status
 
-Approved
+Ready for Review
 
 ### Tasks / Subtasks
 
+- [x] Read three component source files to understand existing sorting patterns
+- [x] Write `.skip`-wrapped tests in `global-universe.component.spec.ts`
+  - [x] Test no `sortData()` method exists
+  - [x] Test data arrays not manipulated for sorting
+  - [x] Test server response order preserved
+  - [x] Test sort change triggers HTTP call via SortStateService
+  - [x] Test no `Array.sort()` on table data
+- [x] Write `.skip`-wrapped tests in `open-positions.component.spec.ts`
+  - [x] Test no `sortData()` method exists
+  - [x] Test server response order preserved
+  - [x] Test sort change triggers HTTP call via SortStateService
+  - [x] Test data array order not manipulated
+  - [x] Test no `Array.sort()` on table data
+- [x] Write `.skip`-wrapped tests in `sold-positions.component.spec.ts`
+  - [x] Test no `sortData()` method exists
+  - [x] Test server response order preserved
+  - [x] Test sort change triggers HTTP call via SortStateService
+  - [x] Test data array order not manipulated
+  - [x] Test no `Array.sort()` on table data
+- [x] Run `pnpm format` — pass
+- [x] Run `pnpm all` (lint + build + test) — pass
+- [x] Run `pnpm dupcheck` — pass (1 pre-existing clone)
+- [x] Run e2e chromium — pass
+- [x] Run e2e firefox — pass
+
 ### File List
 
+- `apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts` (modified)
+- `apps/dms-material/src/app/account-panel/open-positions/open-positions.component.spec.ts` (modified)
+- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts` (modified)
+- `docs/stories/AW.9.tdd-verify-client-side-sorting-removed.md` (modified)
+
 ### Change Log
+
+- Added `describe.skip('Verify no client-side sorting', ...)` block to `global-universe.component.spec.ts` with 5 tests
+- Added `describe.skip('Verify no client-side sorting', ...)` block to `open-positions.component.spec.ts` with 5 tests
+- Added `describe.skip('Verify no client-side sorting', ...)` block to `sold-positions.component.spec.ts` with 5 tests
 
 ### Debug Log References


### PR DESCRIPTION
## Story AW.9: TDD RED - Write Skipped Tests Verifying Client-Side Sorting Removal

### Summary
Adds `describe.skip(...)` test blocks to three component spec files verifying that client-side sorting logic has been removed. This is the TDD RED phase — tests document what needs to change in AW.10.

### Changes
- **global-universe.component.spec.ts**: Added 5 skipped tests verifying no `sortData()` method, data order preserved from server, sort changes delegate to `SortStateService`, and no `Array.sort()` on table data
- **open-positions.component.spec.ts**: Added 5 skipped tests with same verification pattern for open positions
- **sold-positions.component.spec.ts**: Added 5 skipped tests with same verification pattern for sold positions
- **AW.9 story file**: Updated Dev Agent Record with completion details

### Testing
- `pnpm all` (lint + build + test): ✅ Pass
- `pnpm dupcheck`: ✅ Pass (1 pre-existing clone)
- `pnpm format`: ✅ Pass
- e2e Chromium: ✅ Pass (all tests)
- e2e Firefox: ✅ Pass (all tests)

### Notes
- All new tests are wrapped in `describe.skip(...)` to ensure CI passes
- Tests will be enabled in Story AW.10 when client-side sorting is actually removed

Closes #620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suites for sorting behavior verification across multiple components.

* **Documentation**
  * Updated test plan documentation with detailed acceptance criteria and test case specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->