### PR TITLE
Story AX.1: TDD - Expose rendered range from BaseTableComponent

### DIFF
--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.spec.ts
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.spec.ts
@@ -1,4 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ListRange } from '@angular/cdk/collections';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { Subject } from 'rxjs';
 
 import { BaseTableComponent } from './base-table.component';
 import { ColumnDef } from './column-def.interface';
@@ -67,4 +75,121 @@ describe('BaseTableComponent', () => {
     );
     expect(headerCells.length).toBeGreaterThan(0);
   });
+});
+
+// TDD RED Phase: Tests for Story AX.1 - renderedRangeChange output
+// These tests define expected behavior for viewport range tracking.
+// They are disabled (.skip) because the implementation does not exist yet.
+// Story AX.2 will implement the functionality and re-enable these tests.
+describe.skip('BaseTableComponent - Rendered Range Tracking', () => {
+  let component: BaseTableComponent<{ id: string; name: string }>;
+  let fixture: ComponentFixture<
+    BaseTableComponent<{ id: string; name: string }>
+  >;
+  let rangeSubject: Subject<ListRange>;
+
+  const columns: ColumnDef[] = [
+    { field: 'name', header: 'Name', sortable: true },
+  ];
+
+  beforeEach(async () => {
+    rangeSubject = new Subject<ListRange>();
+
+    await TestBed.configureTestingModule({
+      imports: [BaseTableComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BaseTableComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('columns', columns);
+    fixture.componentRef.setInput('data', [
+      { id: '1', name: 'Row 1' },
+      { id: '2', name: 'Row 2' },
+    ]);
+  });
+
+  function mockViewport(): void {
+    const mockViewportRef = {
+      renderedRangeStream: rangeSubject.asObservable(),
+    } as unknown as CdkVirtualScrollViewport;
+
+    Object.defineProperty(component, 'viewport', {
+      value: function viewportSignal() {
+        return mockViewportRef;
+      },
+    });
+  }
+
+  it('should subscribe to viewport renderedRangeStream in ngAfterViewInit', () => {
+    mockViewport();
+    fixture.detectChanges();
+
+    const spy = vi.spyOn(component.renderedRangeChange, 'emit');
+    rangeSubject.next({ start: 0, end: 10 });
+
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('should emit renderedRangeChange when viewport range changes', fakeAsync(() => {
+    mockViewport();
+    fixture.detectChanges();
+
+    const emitted: ListRange[] = [];
+    component.renderedRangeChange.subscribe(function captureRange(
+      range: ListRange
+    ) {
+      emitted.push(range);
+    });
+
+    rangeSubject.next({ start: 0, end: 10 });
+    tick(100);
+
+    expect(emitted).toEqual([{ start: 0, end: 10 }]);
+  }));
+
+  it('should debounce range emissions by 100ms', fakeAsync(() => {
+    mockViewport();
+    fixture.detectChanges();
+
+    const emitted: ListRange[] = [];
+    component.renderedRangeChange.subscribe(function captureRange(
+      range: ListRange
+    ) {
+      emitted.push(range);
+    });
+
+    rangeSubject.next({ start: 0, end: 10 });
+    tick(50);
+    rangeSubject.next({ start: 5, end: 15 });
+    tick(50);
+    rangeSubject.next({ start: 10, end: 20 });
+    tick(100);
+
+    // Only the last emission within the debounce window should come through
+    expect(emitted).toEqual([{ start: 10, end: 20 }]);
+  }));
+
+  it('should cleanup subscription on destroy', fakeAsync(() => {
+    mockViewport();
+    fixture.detectChanges();
+
+    const spy = vi.spyOn(component.renderedRangeChange, 'emit');
+
+    fixture.destroy();
+
+    rangeSubject.next({ start: 0, end: 10 });
+    tick(100);
+
+    expect(spy).not.toHaveBeenCalled();
+  }));
+
+  it('should handle undefined viewport gracefully', fakeAsync(() => {
+    // Do not mock viewport — leave it as undefined
+    fixture.detectChanges();
+
+    const spy = vi.spyOn(component.renderedRangeChange, 'emit');
+    tick(100);
+
+    expect(spy).not.toHaveBeenCalled();
+  }));
 });

--- a/docs/qa/gates/AX.1-tdd-base-table-rendered-range.yml
+++ b/docs/qa/gates/AX.1-tdd-base-table-rendered-range.yml
@@ -1,0 +1,8 @@
+schema: 1
+story: 'AX.1'
+gate: PASS
+status_reason: 'All acceptance criteria met. TDD RED phase tests written and disabled with .skip() as required.'
+reviewer: 'Quinn'
+updated: '2026-03-13T21:15:00Z'
+top_issues: []
+waiver: { active: false }

--- a/docs/stories/AX.1.tdd-base-table-rendered-range.md
+++ b/docs/stories/AX.1.tdd-base-table-rendered-range.md
@@ -9,11 +9,13 @@
 ## Context
 
 **Current System:**
+
 - `BaseTableComponent` uses CDK virtual scrolling
 - No mechanism to notify consumers about which rows are currently visible
 - Components need visible range info to implement virtual data access patterns
 
 **Implementation Approach:**
+
 - Write tests for `renderedRangeChange` signal output
 - Test subscription to `viewport().renderedRangeStream`
 - Test debouncing and cleanup
@@ -103,4 +105,38 @@ Temporarily remove `.skip()` from one test to verify it fails, then re-add `.ski
 
 ### Status
 
-Approved
+Complete
+
+### Agent Model Used
+
+Claude Opus 4.6 (copilot)
+
+### Tasks
+
+- [x] Write BaseTableComponent rendered range tracking tests (describe.skip)
+  - [x] Test subscribes to viewport renderedRangeStream in ngAfterViewInit
+  - [x] Test renderedRangeChange output emits when range changes
+  - [x] Test debouncing (100ms)
+  - [x] Test cleanup subscription on destroy
+  - [x] Test handles undefined viewport gracefully
+- [x] Verify tests are skipped and CI passes
+
+### File List
+
+- Modified: `apps/dms-material/src/app/shared/components/base-table/base-table.component.spec.ts`
+
+### Change Log
+
+- Added `describe.skip('BaseTableComponent - Rendered Range Tracking')` test suite with 5 tests covering viewport range tracking behavior (TDD RED phase)
+- Tests cover: subscription in ngAfterViewInit, renderedRangeChange emission, 100ms debouncing, cleanup on destroy, undefined viewport handling
+- Tests are disabled with `.skip()` to allow CI to pass since implementation does not exist yet
+
+### Debug Log References
+
+None
+
+### Completion Notes
+
+- All 5 TDD tests written and skipped
+- Existing tests continue to pass (1615 passed, 8 skipped)
+- Tests follow existing Angular testing patterns using Vitest


### PR DESCRIPTION
## Story AX.1: TDD - Expose rendered range from BaseTableComponent

Adds TDD RED phase unit tests for the `renderedRangeChange` output on `BaseTableComponent`.

### Changes

- Added `describe.skip('BaseTableComponent - Rendered Range Tracking')` test suite with 5 tests covering viewport range tracking behavior
- Tests cover: subscription in `ngAfterViewInit`, `renderedRangeChange` emission, 100ms debouncing, cleanup on destroy, undefined viewport handling
- Tests are disabled with `.skip()` because the implementation does not exist yet (TDD RED phase)
- Added QA gate file: PASS

### Testing

All tests pass with the new tests skipped:
- `pnpm all` passes (lint, build, test)
- `pnpm dupcheck` passes (pre-existing 1 clone, unchanged)
- `pnpm format` applied
- E2E tests: pre-existing server-side-sorting failures only (unchanged)

Closes #636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for BaseTable virtual scroll rendering capabilities with mock fixtures and test helpers.

* **Documentation**
  * Updated development documentation to reflect test suite enhancements for table rendering behavior tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->