### PR TITLE
AX.9: TDD - Convert soldTrades to PartialArrayDefinition

### DIFF
--- a/apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts
+++ b/apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { accountsDefinition } from './accounts-definition.const';
+import { Account } from './account.interface';
+
+// Story AX.9: TDD Tests for Account interface and default row with PartialArrayDefinition for soldTrades
+// RED phase — these tests expect soldTrades to use PartialArrayDefinition
+// which hasn't been implemented yet
+// Disabled with describe.skip() to allow CI to pass
+// Will be re-enabled in Story AX.10
+
+describe.skip('Account soldTrades PartialArrayDefinition (AX.9)', () => {
+  it('should accept PartialArrayDefinition shape for soldTrades', () => {
+    const account: Account = {
+      id: 'acc-1',
+      name: 'Test Account',
+      openTrades: {
+        startIndex: 0,
+        indexes: [],
+        length: 0,
+      } as unknown as Account['openTrades'],
+      soldTrades: {
+        startIndex: 0,
+        indexes: ['trade-1', 'trade-2'],
+        length: 10,
+      } as unknown as Account['soldTrades'],
+      divDeposits: {
+        startIndex: 0,
+        indexes: [],
+        length: 0,
+      },
+      months: [],
+    };
+
+    const soldTrades = account.soldTrades as unknown as {
+      startIndex: number;
+      indexes: string[];
+      length: number;
+    };
+    expect(soldTrades.startIndex).toBe(0);
+    expect(soldTrades.indexes).toEqual(['trade-1', 'trade-2']);
+    expect(soldTrades.length).toBe(10);
+  });
+
+  it('should have default row with PartialArrayDefinition shape for soldTrades', () => {
+    const defaultRow = accountsDefinition.defaultRow('test-id');
+
+    const soldTrades = defaultRow.soldTrades as unknown as {
+      startIndex: number;
+      indexes: string[];
+      length: number;
+    };
+    expect(soldTrades).toEqual({
+      startIndex: 0,
+      indexes: [],
+      length: 0,
+    });
+  });
+
+  it('should have default row with correct id', () => {
+    const defaultRow = accountsDefinition.defaultRow('my-id');
+    expect(defaultRow.id).toBe('my-id');
+  });
+});

--- a/apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts
+++ b/apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fastify, { FastifyInstance } from 'fastify';
+
+import registerAccountRoutes from './index';
+
+// Story AX.9: TDD Tests for soldTrades PartialArrayDefinition conversion
+// RED phase — these tests call the actual route and assert soldTrades is
+// a PartialArrayDefinition shape. Currently the server returns string[],
+// so these tests will FAIL when un-skipped (correct RED behavior).
+// Disabled with describe.skip() to allow CI to pass.
+// Will be re-enabled in Story AX.10.
+
+// Hoisted mocks
+const { mockPrismaTrades, mockPrismaDivDeposits, mockPrismaAccounts } =
+  vi.hoisted(() => ({
+    mockPrismaTrades: { findMany: vi.fn(), count: vi.fn() },
+    mockPrismaDivDeposits: { findMany: vi.fn(), count: vi.fn() },
+    mockPrismaAccounts: { findMany: vi.fn() },
+  }));
+
+vi.mock('../../prisma/prisma-client', () => ({
+  prisma: {
+    trades: mockPrismaTrades,
+    divDeposits: mockPrismaDivDeposits,
+    accounts: mockPrismaAccounts,
+  },
+}));
+
+// Stub sub-route registrations
+vi.mock('./indexes', () => ({
+  default: vi.fn(),
+}));
+
+function makeSoldTrade(id: string) {
+  return { id, ['sell_date' as string]: new Date('2024-01-15') };
+}
+
+describe.skip('buildAccountResponse - soldTrades as PartialArrayDefinition (AX.9)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = fastify({ logger: false });
+    await app.register(registerAccountRoutes, { prefix: '/api/accounts' });
+    await app.ready();
+    mockPrismaTrades.findMany.mockReset();
+    mockPrismaDivDeposits.findMany.mockReset();
+    mockPrismaAccounts.findMany.mockReset();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should return soldTrades as PartialArrayDefinition with startIndex 0', async () => {
+    const soldTradeData = Array.from(
+      { length: 15 },
+      function createSoldTrade(_, i) {
+        return makeSoldTrade(`sold-${i}`);
+      }
+    );
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    // First findMany call returns open trades, second returns sold trades
+    mockPrismaTrades.findMany
+      .mockResolvedValueOnce([]) // open trades
+      .mockResolvedValueOnce(soldTradeData); // sold trades
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body[0].soldTrades).toEqual({
+      startIndex: 0,
+      indexes: [
+        'sold-0',
+        'sold-1',
+        'sold-2',
+        'sold-3',
+        'sold-4',
+        'sold-5',
+        'sold-6',
+        'sold-7',
+        'sold-8',
+        'sold-9',
+      ],
+      length: 15,
+    });
+  });
+
+  it('should return first 10 sold trade IDs in indexes when more than 10 exist', async () => {
+    const soldTradeData = Array.from(
+      { length: 25 },
+      function createSoldTrade(_, i) {
+        return makeSoldTrade(`sold-${i}`);
+      }
+    );
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    mockPrismaTrades.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(soldTradeData);
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body[0].soldTrades.indexes).toHaveLength(10);
+    expect(body[0].soldTrades.indexes[0]).toBe('sold-0');
+    expect(body[0].soldTrades.indexes[9]).toBe('sold-9');
+  });
+
+  it('should return total length equal to all sold trades count', async () => {
+    const soldTradeData = Array.from(
+      { length: 42 },
+      function createSoldTrade(_, i) {
+        return makeSoldTrade(`sold-${i}`);
+      }
+    );
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    mockPrismaTrades.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(soldTradeData);
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body[0].soldTrades.length).toBe(42);
+  });
+
+  it('should filter sold trades by sell_date IS NOT NULL', async () => {
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    mockPrismaTrades.findMany.mockResolvedValue([]);
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    // Verify the sold trades query includes sell_date: { not: null } filter
+    // The second findMany call is for sold trades
+    const soldTradesCall = mockPrismaTrades.findMany.mock.calls[1];
+    expect(soldTradesCall[0]).toEqual(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          accountId: 'acc-1',
+          sell_date: { not: null },
+        }),
+      })
+    );
+  });
+
+  it('should return all IDs when fewer than 10 sold trades exist', async () => {
+    const soldTradeData = Array.from(
+      { length: 5 },
+      function createSoldTrade(_, i) {
+        return makeSoldTrade(`sold-${i}`);
+      }
+    );
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    mockPrismaTrades.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(soldTradeData);
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body[0].soldTrades.indexes).toHaveLength(5);
+    expect(body[0].soldTrades.length).toBe(5);
+  });
+
+  it('should return empty PartialArrayDefinition when no sold trades exist', async () => {
+    mockPrismaAccounts.findMany.mockResolvedValue([
+      { id: 'acc-1', name: 'Test' },
+    ]);
+    mockPrismaTrades.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts',
+      payload: ['acc-1'],
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body[0].soldTrades).toEqual({
+      startIndex: 0,
+      indexes: [],
+      length: 0,
+    });
+  });
+});

--- a/apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts
+++ b/apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fastify, { FastifyInstance } from 'fastify';
+
+import registerAccountIndexesRoutes from './index';
+
+// Story AX.9: TDD Tests for /indexes endpoint handling soldTrades
+// RED phase — these tests expect soldTrades handling that doesn't exist yet
+// Disabled with describe.skip() to allow CI to pass
+// Will be re-enabled in Story AX.10
+
+// Hoisted mocks
+const { mockPrismaTrades, mockPrismaDivDeposits } = vi.hoisted(() => ({
+  mockPrismaTrades: { findMany: vi.fn(), count: vi.fn() },
+  mockPrismaDivDeposits: { findMany: vi.fn(), count: vi.fn() },
+}));
+
+vi.mock('../../../prisma/prisma-client', () => ({
+  prisma: {
+    trades: mockPrismaTrades,
+    divDeposits: mockPrismaDivDeposits,
+  },
+}));
+
+function makeTradeId(id: string): { id: string } {
+  return { id };
+}
+
+describe.skip('GET /indexes - soldTrades childField (AX.9)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = fastify({ logger: false });
+    await app.register(registerAccountIndexesRoutes, {
+      prefix: '/api/accounts/indexes',
+    });
+    await app.ready();
+    mockPrismaTrades.findMany.mockReset();
+    mockPrismaTrades.count.mockReset();
+    mockPrismaDivDeposits.findMany.mockReset();
+    mockPrismaDivDeposits.count.mockReset();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('should handle childField === "soldTrades" and return matching trade IDs', async () => {
+    const tradeIds = Array.from({ length: 5 }, function createId(_, i) {
+      return makeTradeId(`sold-${i}`);
+    });
+    mockPrismaTrades.findMany.mockResolvedValue(tradeIds);
+    mockPrismaTrades.count.mockResolvedValue(20);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 0,
+        length: 5,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(response.statusCode).toBe(200);
+    expect(body.startIndex).toBe(0);
+    expect(body.indexes).toEqual([
+      'sold-0',
+      'sold-1',
+      'sold-2',
+      'sold-3',
+      'sold-4',
+    ]);
+    expect(body.length).toBe(20);
+  });
+
+  it('should filter sold trades by sell_date IS NOT NULL', async () => {
+    mockPrismaTrades.findMany.mockResolvedValue([makeTradeId('sold-1')]);
+    mockPrismaTrades.count.mockResolvedValue(1);
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 0,
+        length: 10,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    // Verify that findMany was called with sell_date: { not: null } filter
+    expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          accountId: 'acc-1',
+          sell_date: { not: null },
+        }),
+      })
+    );
+  });
+
+  it('should apply buildTradeOrderBy for sold trade ordering', async () => {
+    mockPrismaTrades.findMany.mockResolvedValue([]);
+    mockPrismaTrades.count.mockResolvedValue(0);
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 0,
+        length: 10,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    // Verify ordering is applied
+    expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: expect.any(Object),
+      })
+    );
+  });
+
+  it('should return correct slice using skip and take', async () => {
+    const tradeIds = Array.from({ length: 3 }, function createId(_, i) {
+      return makeTradeId(`sold-${i + 5}`);
+    });
+    mockPrismaTrades.findMany.mockResolvedValue(tradeIds);
+    mockPrismaTrades.count.mockResolvedValue(15);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 5,
+        length: 3,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.startIndex).toBe(5);
+    expect(body.indexes).toEqual(['sold-5', 'sold-6', 'sold-7']);
+    expect(body.length).toBe(15);
+  });
+
+  it('should return correct total count from prisma count', async () => {
+    mockPrismaTrades.findMany.mockResolvedValue([makeTradeId('s-1')]);
+    mockPrismaTrades.count.mockResolvedValue(100);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 0,
+        length: 1,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.length).toBe(100);
+  });
+
+  it('should return empty indexes and length 0 when no sold trades match', async () => {
+    mockPrismaTrades.findMany.mockResolvedValue([]);
+    mockPrismaTrades.count.mockResolvedValue(0);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/accounts/indexes',
+      payload: {
+        startIndex: 0,
+        length: 10,
+        parentId: 'acc-1',
+        childField: 'soldTrades',
+      },
+    });
+
+    const body = JSON.parse(response.body);
+    expect(body.indexes).toEqual([]);
+    expect(body.length).toBe(0);
+  });
+});

--- a/docs/qa/gates/AX.9-tdd-sold-trades-partial-array.yml
+++ b/docs/qa/gates/AX.9-tdd-sold-trades-partial-array.yml
@@ -1,0 +1,14 @@
+schema: 1
+story: 'AX.9'
+story_title: 'TDD - Convert soldTrades to PartialArrayDefinition'
+gate: PASS
+status_reason: 'All TDD RED phase tests written, disabled with .skip(), covering all acceptance criteria.'
+reviewer: 'Quinn (Test Architect)'
+updated: '2026-03-14T11:00:00Z'
+waiver: { active: false }
+top_issues: []
+risk_summary:
+  totals: { critical: 0, high: 0, medium: 0, low: 0 }
+  recommendations:
+    must_fix: []
+    monitor: []

--- a/docs/stories/AX.9.tdd-sold-trades-partial-array.md
+++ b/docs/stories/AX.9.tdd-sold-trades-partial-array.md
@@ -35,4 +35,39 @@
 
 ### Status
 
-Approved
+Complete
+
+### Agent Model Used
+
+Claude Opus 4.6 (copilot)
+
+### Tasks
+
+- [x] Create frontend Account interface soldTrades TDD tests
+- [x] Create server build-account-response soldTrades TDD tests
+- [x] Create server /indexes endpoint soldTrades TDD tests
+- [x] Verify sell_date IS NOT NULL filter in tests
+- [x] All tests disabled with `.skip()`
+
+### File List
+
+- apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts (new)
+- apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts (new)
+- apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts (new)
+- docs/qa/gates/AX.9-tdd-sold-trades-partial-array.yml (new)
+
+### Change Log
+
+- Created `account-sold-trades.spec.ts` - Frontend TDD tests for Account interface and default row soldTrades as PartialArrayDefinition
+- Created `build-account-response-sold-trades.spec.ts` - Server TDD tests for buildAccountResponse returning soldTrades as PartialArrayDefinition shape
+- Created `indexes-sold-trades.spec.ts` - Server TDD tests for /indexes endpoint handling childField === 'soldTrades' with sell_date IS NOT NULL filter
+- All tests use `describe.skip()` for RED phase (TDD)
+- Created QA gate file (PASS)
+
+### Debug Log References
+
+(none)
+
+### Completion Notes
+
+All TDD RED phase tests written and disabled, covering all acceptance criteria. Tests mirror the existing AX.5 openTrades patterns for consistency.


### PR DESCRIPTION
## Story AX.9: TDD - Convert soldTrades to PartialArrayDefinition

TDD RED phase tests for converting soldTrades from `string[]` to `PartialArrayDefinition`, mirroring the AX.5 pattern for openTrades.

### Changes

- **Frontend Account interface tests** (`account-sold-trades.spec.ts`): Tests that Account interface and default row accept PartialArrayDefinition shape for soldTrades
- **Server response tests** (`build-account-response-sold-trades.spec.ts`): Tests that buildAccountResponse returns soldTrades as `{ startIndex, indexes, length }` shape with first 10 IDs and total count
- **Server /indexes endpoint tests** (`indexes-sold-trades.spec.ts`): Tests for /indexes endpoint handling `childField === 'soldTrades'` with `sell_date IS NOT NULL` filter, pagination, and ordering
- **QA gate**: PASS

All tests are disabled with `describe.skip()` — they define the expected behavior for story AX.10 implementation.

### Testing

- All tests use `describe.skip()` so CI passes
- `pnpm all` passes (lint + build + test)
- `pnpm dupcheck` passes (no new duplicates)
- `pnpm format` clean

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for account sold transactions functionality across frontend and server layers, establishing testing framework for upcoming feature improvements.

* **Documentation**
  * Updated story documentation and quality assurance gates to reflect test-driven development progress on account transaction handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->