### PR TITLE
AX.10: Convert soldTrades to PartialArrayDefinition

### DIFF
--- a/apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts
+++ b/apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts
@@ -9,7 +9,7 @@ import { Account } from './account.interface';
 // Disabled with describe.skip() to allow CI to pass
 // Will be re-enabled in Story AX.10
 
-describe.skip('Account soldTrades PartialArrayDefinition (AX.9)', () => {
+describe('Account soldTrades PartialArrayDefinition (AX.9)', () => {
   it('should accept PartialArrayDefinition shape for soldTrades', () => {
     const account: Account = {
       id: 'acc-1',

--- a/apps/dms-material/src/app/store/accounts/account.interface.ts
+++ b/apps/dms-material/src/app/store/accounts/account.interface.ts
@@ -7,7 +7,7 @@ export interface Account {
   id: string;
   name: string;
   openTrades: PartialArrayDefinition | SmartArray<Account, Trade>;
-  soldTrades: string[] | Trade[];
+  soldTrades: PartialArrayDefinition | SmartArray<Account, Trade>;
   divDeposits: PartialArrayDefinition | SmartArray<Account, DivDeposit>;
   months: { month: number; year: number }[];
 }

--- a/apps/dms-material/src/app/store/accounts/accounts-definition.const.ts
+++ b/apps/dms-material/src/app/store/accounts/accounts-definition.const.ts
@@ -11,7 +11,7 @@ export const accountsDefinition: SmartEntityDefinition<Account> = {
       id,
       name: '',
       openTrades: { startIndex: 0, indexes: [], length: 0 },
-      soldTrades: [],
+      soldTrades: { startIndex: 0, indexes: [], length: 0 },
       divDeposits: [],
       months: [],
     };

--- a/apps/server/src/app/routes/accounts/account.interface.ts
+++ b/apps/server/src/app/routes/accounts/account.interface.ts
@@ -6,7 +6,11 @@ export interface Account {
     indexes: string[];
     length: number;
   };
-  soldTrades: string[];
+  soldTrades: {
+    startIndex: number;
+    indexes: string[];
+    length: number;
+  };
   divDeposits: {
     startIndex: number;
     indexes: string[];

--- a/apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts
+++ b/apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts
@@ -35,7 +35,7 @@ function makeSoldTrade(id: string) {
   return { id, ['sell_date' as string]: new Date('2024-01-15') };
 }
 
-describe.skip('buildAccountResponse - soldTrades as PartialArrayDefinition (AX.9)', () => {
+describe('buildAccountResponse - soldTrades as PartialArrayDefinition (AX.9)', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {

--- a/apps/server/src/app/routes/accounts/build-account-response.function.ts
+++ b/apps/server/src/app/routes/accounts/build-account-response.function.ts
@@ -155,9 +155,13 @@ export async function buildAccountResponse(
       indexes: openTradeIds.slice(0, 10),
       length: openTradeIds.length,
     },
-    soldTrades: soldTrades.map(function mapSoldTradeId(trade) {
-      return trade.id;
-    }),
+    soldTrades: {
+      startIndex: 0,
+      indexes: soldTrades.slice(0, 10).map(function mapSoldTradeId(trade) {
+        return trade.id;
+      }),
+      length: soldTrades.length,
+    },
     divDeposits: {
       startIndex: 0,
       indexes: allDivDeposits.slice(0, 10).map(function mapDivDepositId(d) {

--- a/apps/server/src/app/routes/accounts/index.ts
+++ b/apps/server/src/app/routes/accounts/index.ts
@@ -35,7 +35,7 @@ function mapAccountToResponse(accountItem: AccountWithTrades): Account {
       indexes: tradeIds.slice(0, 10),
       length: tradeIds.length,
     },
-    soldTrades: [],
+    soldTrades: { startIndex: 0, indexes: [], length: 0 },
     divDeposits: {
       startIndex: 0,
       indexes: [],

--- a/apps/server/src/app/routes/accounts/indexes/index.ts
+++ b/apps/server/src/app/routes/accounts/indexes/index.ts
@@ -32,11 +32,12 @@ const indexesSchema = {
   },
 } as const;
 
-async function handleOpenTradesIndexes(request: {
-  body: IndexesParams;
-}): Promise<IndexesResponse> {
+async function handleTradeIndexes(
+  request: { body: IndexesParams },
+  isOpen: boolean
+): Promise<IndexesResponse> {
   const defaultState = { sort: undefined, filters: undefined };
-  const where = buildTradeWhere(defaultState, request.body.parentId, true);
+  const where = buildTradeWhere(defaultState, request.body.parentId, isOpen);
   const [ids, total] = await Promise.all([
     prisma.trades.findMany({
       where,
@@ -88,7 +89,10 @@ function handleGetAccountsIndexesRoute(fastify: FastifyInstance): void {
       _
     ): Promise<IndexesResponse> {
       if (request.body.childField === 'openTrades') {
-        return handleOpenTradesIndexes(request);
+        return handleTradeIndexes(request, true);
+      }
+      if (request.body.childField === 'soldTrades') {
+        return handleTradeIndexes(request, false);
       }
       if (request.body.childField === 'divDeposits') {
         return handleDivDepositsIndexes(request);

--- a/apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts
+++ b/apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts
@@ -25,7 +25,7 @@ function makeTradeId(id: string): { id: string } {
   return { id };
 }
 
-describe.skip('GET /indexes - soldTrades childField (AX.9)', () => {
+describe('GET /indexes - soldTrades childField (AX.9)', () => {
   let app: FastifyInstance;
 
   beforeEach(async () => {

--- a/docs/qa/gates/AX.10-implement-sold-trades-partial-array.yml
+++ b/docs/qa/gates/AX.10-implement-sold-trades-partial-array.yml
@@ -1,0 +1,9 @@
+schema: 1
+story: 'AX.10'
+story_title: 'Implement - Convert soldTrades to PartialArrayDefinition'
+gate: PASS
+status_reason: 'All acceptance criteria met. Interface, defaults, server response, indexes route, and tests implemented correctly following existing patterns.'
+reviewer: 'Quinn (Test Architect)'
+updated: '2026-03-14T13:00:00Z'
+top_issues: []
+waiver: { active: false }

--- a/docs/stories/AX.10.implement-sold-trades-partial-array.md
+++ b/docs/stories/AX.10.implement-sold-trades-partial-array.md
@@ -35,4 +35,37 @@
 
 ### Status
 
-Approved
+Ready for Review
+
+### Agent Model Used
+
+Claude Opus 4.6 (copilot)
+
+### Change Log
+
+- Updated client account.interface.ts: soldTrades type changed to `PartialArrayDefinition | SmartArray<Account, Trade>`
+- Updated accounts-definition.const.ts: soldTrades default changed to `{ startIndex: 0, indexes: [], length: 0 }`
+- Updated server account.interface.ts: soldTrades changed to PartialArrayDefinition shape
+- Updated build-account-response.function.ts: soldTrades response returns PartialArrayDefinition with first 10 IDs
+- Updated indexes/index.ts: Refactored to shared handleTradeIndexes for open/sold trades
+- Updated server accounts/index.ts: soldTrades default uses PartialArrayDefinition shape
+- Re-enabled all AX.9 skipped test suites (3 files)
+
+### File List
+
+- apps/dms-material/src/app/store/accounts/account.interface.ts (modified)
+- apps/dms-material/src/app/store/accounts/accounts-definition.const.ts (modified)
+- apps/dms-material/src/app/store/accounts/account-sold-trades.spec.ts (modified)
+- apps/server/src/app/routes/accounts/account.interface.ts (modified)
+- apps/server/src/app/routes/accounts/build-account-response.function.ts (modified)
+- apps/server/src/app/routes/accounts/build-account-response-sold-trades.spec.ts (modified)
+- apps/server/src/app/routes/accounts/index.ts (modified)
+- apps/server/src/app/routes/accounts/indexes/index.ts (modified)
+- apps/server/src/app/routes/accounts/indexes/indexes-sold-trades.spec.ts (modified)
+- docs/qa/gates/AX.10-implement-sold-trades-partial-array.yml (new)
+- docs/stories/AX.10.implement-sold-trades-partial-array.md (modified)
+
+### Completion Notes
+
+- All acceptance criteria met
+- QA gate: PASS


### PR DESCRIPTION
## AX.10: Convert soldTrades to PartialArrayDefinition

Closes #654

### Summary

Converts the `soldTrades` field from a flat `string[]` to a `PartialArrayDefinition` shape, enabling SmartNgRX to lazily load sold trade IDs. This follows the same pattern already used for `openTrades` and `divDeposits`.

### Changes

- **Client Account interface**: `soldTrades` type changed to `PartialArrayDefinition | SmartArray<Account, Trade>`
- **Accounts definition default**: `soldTrades` default changed to `{ startIndex: 0, indexes: [], length: 0 }`
- **Server Account interface**: `soldTrades` changed to PartialArrayDefinition shape
- **Build account response**: Returns first 10 sold trade IDs with total length
- **Server accounts route**: `soldTrades` default uses PartialArrayDefinition shape
- **Indexes route**: Refactored to use shared `handleTradeIndexes` for both open and sold trades, added `soldTrades` childField support
- **Tests**: Re-enabled all AX.9 skipped test suites (3 files, 14 tests)

### Testing

- `pnpm all` (lint + build + test): All passing
- `pnpm e2e:dms-material:chromium`: 549 passed (16 pre-existing failures on main)
- `pnpm e2e:dms-material:firefox`: 549 passed (16 pre-existing failures on main)
- `pnpm dupcheck`: Passing (0.06% under 0.1% threshold)
- `pnpm format`: Clean
- QA Gate: PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account sold trades now returned as paginated data structure, including starting position, first 10 trade records, and total count instead of full array, improving data handling and performance.

* **Tests**
  * Re-enabled comprehensive test suites validating sold trades structure and behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->