### PR TITLE
feat(sold-positions): implement virtual data access for sold positions [AX.12]

### DIFF
--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts
@@ -66,6 +66,10 @@ vi.mock('../../store/div-deposits/div-deposits.selectors', () => ({
   selectDivDepositEntity: vi.fn().mockReturnValue([]),
 }));
 
+vi.mock('../../store/trades/difference-in-trading-days.function', () => ({
+  differenceInTradingDays: vi.fn().mockReturnValue(100),
+}));
+
 // Helper to create a valid sold trade
 function createSoldTrade(overrides: Partial<Trade> = {}): Trade {
   return {
@@ -102,7 +106,7 @@ function createMockSoldTradesArray(count: number): Trade[] {
 
 // Story AX.11: TDD Tests for Sold Positions Virtual Data Access (Service)
 // Disabled in AX.11 (RED phase): Re-enable in AX.12
-describe.skip('SoldPositionsComponentService - Virtual Data Access (AX.11)', () => {
+describe('SoldPositionsComponentService - Virtual Data Access (AX.11)', () => {
   let service: SoldPositionsComponentService;
   let mockCurrentAccount: ReturnType<typeof signal>;
   let mockSoldTradesArray: Trade[];

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
@@ -1,4 +1,4 @@
-import { computed, inject, Injectable } from '@angular/core';
+import { computed, inject, Injectable, signal } from '@angular/core';
 
 import { buildUniverseMap } from '../../shared/build-universe-map.function';
 import { currentAccountSignalStore } from '../../store/current-account/current-account.signal-store';
@@ -12,6 +12,11 @@ import { classifyCapitalGain } from './classify-capital-gain.function';
 export class SoldPositionsComponentService {
   private currentAccountSignalStore = inject(currentAccountSignalStore);
 
+  visibleRange = signal<{ start: number; end: number }>({
+    start: 0,
+    end: 50,
+  });
+
   // eslint-disable-next-line @smarttools/no-anonymous-functions -- would hide this
   trades = computed(() => {
     const currentAccount = selectCurrentAccountSignal(
@@ -24,18 +29,34 @@ export class SoldPositionsComponentService {
   selectSoldPositions = computed(() => {
     const trades = this.trades();
     const universeMap = buildUniverseMap();
-    const soldPositions: ClosedPosition[] = [];
+    const range = this.visibleRange();
 
+    if (trades.length === 0) {
+      return [] as ClosedPosition[];
+    }
+
+    // First pass: collect indices of valid sold trades (cheap validation check)
+    const soldIndices: number[] = [];
     for (let i = 0; i < trades.length; i++) {
       const trade = trades[i];
       if (!this.isValidSoldTrade(trade)) {
         continue;
       }
-
       const universe = universeMap.get(trade.universeId);
       if (!universe) {
         continue;
       }
+      soldIndices.push(i);
+    }
+
+    // Visible-window: sparse array sized to sold count, only transform visible items
+    const totalSold = soldIndices.length;
+    const soldPositions = new Array<ClosedPosition>(totalSold);
+    const rangeEnd = Math.min(range.end, totalSold);
+    for (let j = range.start; j < rangeEnd; j++) {
+      const tradeIdx = soldIndices[j];
+      const trade = trades[tradeIdx];
+      const universe = universeMap.get(trade.universeId)!;
 
       const daysHeld = differenceInTradingDays(
         trade.buy_date,
@@ -45,7 +66,7 @@ export class SoldPositionsComponentService {
       const capitalGainPercentage =
         trade.buy !== 0 ? ((trade.sell - trade.buy) / trade.buy) * 100 : 0;
 
-      soldPositions.push({
+      soldPositions[j] = {
         id: trade.id,
         symbol: universe.symbol,
         buy: trade.buy,
@@ -57,7 +78,7 @@ export class SoldPositionsComponentService {
         capitalGain,
         capitalGainPercentage,
         gainLossType: classifyCapitalGain(capitalGain),
-      });
+      };
     }
 
     return soldPositions;

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html
@@ -3,6 +3,7 @@
   [data]="displayedPositions()"
   [columns]="columns"
   (sortChange)="onSortChange($event)"
+  (renderedRangeChange)="onRangeChange($event)"
 >
   <ng-template #filterRowTemplate let-column>
     @if (column.field === 'symbol') {

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
@@ -69,6 +69,10 @@ describe('SoldPositionsComponent', () => {
   const soldPositionsSignal = signal<ClosedPosition[]>([]);
   const mockServiceForInjection = {
     selectSoldPositions: soldPositionsSignal,
+    visibleRange: signal<{ start: number; end: number }>({
+      start: 0,
+      end: 50,
+    }),
   };
 
   beforeEach(async () => {
@@ -389,6 +393,7 @@ describe('SoldPositionsComponent - Account Selection Integration', () => {
   let fixture: ComponentFixture<SoldPositionsComponent>;
   let mockSoldPositionsComponentService: {
     selectSoldPositions: WritableSignal<ClosedPosition[]>;
+    visibleRange: WritableSignal<{ start: number; end: number }>;
   };
   let mockCurrentAccountStore: {
     id: WritableSignal<string>;
@@ -405,6 +410,10 @@ describe('SoldPositionsComponent - Account Selection Integration', () => {
 
     mockSoldPositionsComponentService = {
       selectSoldPositions: signal<ClosedPosition[]>([]),
+      visibleRange: signal<{ start: number; end: number }>({
+        start: 0,
+        end: 50,
+      }),
     };
 
     await TestBed.configureTestingModule({
@@ -809,11 +818,16 @@ describe('SoldPositionsComponent - Client-Side Sorting Removal', () => {
   let fixture: ComponentFixture<SoldPositionsComponent>;
   let mockSoldPositionsService: {
     selectSoldPositions: WritableSignal<ClosedPosition[]>;
+    visibleRange: WritableSignal<{ start: number; end: number }>;
   };
 
   beforeEach(async () => {
     mockSoldPositionsService = {
       selectSoldPositions: signal<ClosedPosition[]>([]),
+      visibleRange: signal<{ start: number; end: number }>({
+        start: 0,
+        end: 50,
+      }),
     };
 
     await TestBed.configureTestingModule({
@@ -946,7 +960,7 @@ describe('SoldPositionsComponent - Client-Side Sorting Removal', () => {
 
 // Story AX.11: TDD Tests for Sold Positions Virtual Data Access
 // Disabled in AX.11 (RED phase): Re-enable in AX.12
-describe.skip('SoldPositionsComponent - Virtual Data Access (AX.11)', () => {
+describe('SoldPositionsComponent - Virtual Data Access (AX.11)', () => {
   let component: SoldPositionsComponent;
   let fixture: ComponentFixture<SoldPositionsComponent>;
   let mockSoldPositionsService: {

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts
@@ -31,6 +31,12 @@ export class SoldPositionsComponent implements OnDestroy {
   private readonly sortFilterStateService = inject(SortFilterStateService);
 
   searchText = signal<string>('');
+
+  visibleRange = signal<{ start: number; end: number }>({
+    start: 0,
+    end: 50,
+  });
+
   private symbolFilterTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnDestroy(): void {
@@ -44,6 +50,11 @@ export class SoldPositionsComponent implements OnDestroy {
   readonly displayedPositions = computed(() => {
     return this.soldPositionsService.selectSoldPositions();
   });
+
+  onRangeChange(range: { start: number; end: number }): void {
+    this.visibleRange.set(range);
+    this.soldPositionsService.visibleRange.set(range);
+  }
 
   onSymbolFilterChange(value: string): void {
     this.searchText.set(value);

--- a/docs/stories/AX.12.implement-sold-positions-virtual-data.md
+++ b/docs/stories/AX.12.implement-sold-positions-virtual-data.md
@@ -35,4 +35,39 @@
 
 ### Status
 
-Approved
+Ready for Review
+
+### Tasks
+
+- [x] Add `visibleRange` signal to SoldPositionsComponent
+- [x] Add `onRangeChange` handler to SoldPositionsComponent
+- [x] Add `visibleRange` signal to SoldPositionsComponentService
+- [x] Modify `selectSoldPositions` to use visible-window loop
+- [x] Bind `(renderedRangeChange)` in template
+- [x] Enable AX.11 TDD tests (remove `.skip`)
+
+### Agent Model Used
+
+Claude Opus 4.6
+
+### File List
+
+- apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts
+- apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html
+- apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
+- apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts
+- apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts
+- docs/stories/AX.12.implement-sold-positions-virtual-data.md
+
+### Change Log
+
+- Added `visibleRange` signal with default `{ start: 0, end: 50 }` to SoldPositionsComponent
+- Added `onRangeChange` method to SoldPositionsComponent that propagates to service
+- Added `(renderedRangeChange)="onRangeChange($event)"` binding to template
+- Added `visibleRange` signal to SoldPositionsComponentService
+- Refactored `selectSoldPositions` to use visible-window loop pattern (sparse array: only transform items in visible range)
+- Enabled AX.11 TDD tests in both component and service spec files
+
+### Completion Notes
+
+### Debug Log References


### PR DESCRIPTION
## Story AX.12: Implement - Virtual data access for Sold Positions

**As a** user with many sold positions  
**I want** the table to load only visible rows  
**So that** scrolling through history is efficient

### Changes

- Added `visibleRange` signal with default `{ start: 0, end: 50 }` to SoldPositionsComponent
- Added `onRangeChange` method to SoldPositionsComponent that propagates to service
- Added `(renderedRangeChange)="onRangeChange($event)"` binding to template
- Added `visibleRange` signal to SoldPositionsComponentService
- Refactored `selectSoldPositions` to use visible-window loop pattern (sparse array: only transform items in visible range)
- Enabled AX.11 TDD tests in both component and service spec files

### Files Changed

- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts`
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html`
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts`
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.spec.ts`
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts`
- `docs/stories/AX.12.implement-sold-positions-virtual-data.md`

### Testing

- 48 component tests passing
- 10 service tests passing
- Lint, format, dupcheck all passing

Closes #658

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented virtual scrolling for the sold positions list to enhance performance when handling large datasets. The component now dynamically renders only items visible in the current viewport window, reducing memory consumption and improving scrolling responsiveness. Users viewing extensive transaction histories will experience smoother navigation and faster overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->