### PR TITLE
fix(indexes): pass sort/filter state through to index queries [AX.13]

### DIFF
--- a/apps/server/src/app/routes/accounts/build-account-response.function.ts
+++ b/apps/server/src/app/routes/accounts/build-account-response.function.ts
@@ -5,6 +5,7 @@ import { buildDivDepositOrderBy } from './build-div-deposit-order-by.function';
 import { buildDivDepositWhere } from './build-div-deposit-where.function';
 import { buildTradeOrderBy } from './build-trade-order-by.function';
 import { buildTradeWhere } from './build-trade-where.function';
+import { getTradeComputedValue } from './get-trade-computed-value.function';
 import { isComputedTradeSort } from './is-computed-trade-sort.function';
 
 interface MonthData {
@@ -58,34 +59,6 @@ function combineAndSortMonths(
     const [year, month] = m.split('-');
     return { year: parseInt(year, 10), month: parseInt(month, 10) };
   });
-}
-
-interface TradeWithComputed {
-  id: string;
-  buy: number;
-  quantity: number;
-  universe: { last_price: number };
-}
-
-function computeUnrealizedGain(trade: TradeWithComputed): number {
-  return (trade.universe.last_price - trade.buy) * trade.quantity;
-}
-
-function computeUnrealizedGainPercent(trade: TradeWithComputed): number {
-  if (trade.buy <= 0) {
-    return 0;
-  }
-  return ((trade.universe.last_price - trade.buy) / trade.buy) * 100;
-}
-
-function getTradeComputedValue(
-  field: string,
-  trade: TradeWithComputed
-): number {
-  if (field === 'unrealizedGain') {
-    return computeUnrealizedGain(trade);
-  }
-  return computeUnrealizedGainPercent(trade);
 }
 
 async function getOpenTradeIds(

--- a/apps/server/src/app/routes/accounts/get-trade-computed-value.function.ts
+++ b/apps/server/src/app/routes/accounts/get-trade-computed-value.function.ts
@@ -1,0 +1,27 @@
+interface TradeWithComputed {
+  id: string;
+  buy: number;
+  quantity: number;
+  universe: { last_price: number };
+}
+
+function computeUnrealizedGain(trade: TradeWithComputed): number {
+  return (trade.universe.last_price - trade.buy) * trade.quantity;
+}
+
+function computeUnrealizedGainPercent(trade: TradeWithComputed): number {
+  if (trade.buy <= 0) {
+    return 0;
+  }
+  return ((trade.universe.last_price - trade.buy) / trade.buy) * 100;
+}
+
+export function getTradeComputedValue(
+  field: string,
+  trade: TradeWithComputed
+): number {
+  if (field === 'unrealizedGain') {
+    return computeUnrealizedGain(trade);
+  }
+  return computeUnrealizedGainPercent(trade);
+}

--- a/apps/server/src/app/routes/accounts/indexes/index.ts
+++ b/apps/server/src/app/routes/accounts/indexes/index.ts
@@ -1,8 +1,15 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance, FastifyRequest } from 'fastify';
 
 import { prisma } from '../../../prisma/prisma-client';
+import { getTableState } from '../../common/get-table-state.function';
+import { parseSortFilterHeader } from '../../common/parse-sort-filter-header.function';
+import { TableState } from '../../common/table-state.interface';
+import { buildDivDepositOrderBy } from '../build-div-deposit-order-by.function';
+import { buildDivDepositWhere } from '../build-div-deposit-where.function';
 import { buildTradeOrderBy } from '../build-trade-order-by.function';
 import { buildTradeWhere } from '../build-trade-where.function';
+import { getTradeComputedValue } from '../get-trade-computed-value.function';
+import { isComputedTradeSort } from '../is-computed-trade-sort.function';
 
 interface IndexesParams {
   startIndex: number;
@@ -32,24 +39,62 @@ const indexesSchema = {
   },
 } as const;
 
-async function handleTradeIndexes(
-  request: { body: IndexesParams },
+async function handleComputedTradeIndexes(
+  body: IndexesParams,
+  state: TableState,
   isOpen: boolean
 ): Promise<IndexesResponse> {
-  const defaultState = { sort: undefined, filters: undefined };
-  const where = buildTradeWhere(defaultState, request.body.parentId, isOpen);
+  const where = buildTradeWhere(state, body.parentId, isOpen);
+  const [trades, total] = await Promise.all([
+    prisma.trades.findMany({
+      where,
+      select: {
+        id: true,
+        buy: true,
+        quantity: true,
+        universe: { select: { last_price: true } },
+      },
+    }),
+    prisma.trades.count({ where }),
+  ]);
+  const field = state.sort!.field;
+  const order = state.sort!.order;
+  trades.sort(function sortByComputed(a, b) {
+    const diff =
+      getTradeComputedValue(field, a) - getTradeComputedValue(field, b);
+    return order === 'desc' ? -diff : diff;
+  });
+  const sliced = trades.slice(body.startIndex, body.startIndex + body.length);
+  return {
+    startIndex: body.startIndex,
+    indexes: sliced.map(function mapId(t) {
+      return t.id;
+    }),
+    length: total,
+  };
+}
+
+async function handleTradeIndexes(
+  body: IndexesParams,
+  state: TableState,
+  isOpen: boolean
+): Promise<IndexesResponse> {
+  if (isComputedTradeSort(state)) {
+    return handleComputedTradeIndexes(body, state, isOpen);
+  }
+  const where = buildTradeWhere(state, body.parentId, isOpen);
   const [ids, total] = await Promise.all([
     prisma.trades.findMany({
       where,
-      orderBy: buildTradeOrderBy(defaultState),
-      skip: request.body.startIndex,
-      take: request.body.length,
+      orderBy: buildTradeOrderBy(state),
+      skip: body.startIndex,
+      take: body.length,
       select: { id: true },
     }),
     prisma.trades.count({ where }),
   ]);
   return {
-    startIndex: request.body.startIndex,
+    startIndex: body.startIndex,
     indexes: ids.map(function itemToString(item: { id: string }) {
       return item.id;
     }),
@@ -57,22 +102,23 @@ async function handleTradeIndexes(
   };
 }
 
-async function handleDivDepositsIndexes(request: {
-  body: IndexesParams;
-}): Promise<IndexesResponse> {
-  const where = { accountId: request.body.parentId };
+async function handleDivDepositsIndexes(
+  body: IndexesParams,
+  state: TableState
+): Promise<IndexesResponse> {
+  const where = buildDivDepositWhere(state, body.parentId);
   const [ids, total] = await Promise.all([
     prisma.divDeposits.findMany({
       where,
-      orderBy: { date: 'desc' as const },
-      skip: request.body.startIndex,
-      take: request.body.length,
+      orderBy: buildDivDepositOrderBy(state),
+      skip: body.startIndex,
+      take: body.length,
       select: { id: true },
     }),
     prisma.divDeposits.count({ where }),
   ]);
   return {
-    startIndex: request.body.startIndex,
+    startIndex: body.startIndex,
     indexes: ids.map(function itemToString(item: { id: string }) {
       return item.id;
     }),
@@ -85,17 +131,21 @@ function handleGetAccountsIndexesRoute(fastify: FastifyInstance): void {
     '/',
     indexesSchema,
     async function handleGetIndexesRequest(
-      request,
+      request: FastifyRequest<{ Body: IndexesParams }>,
       _
     ): Promise<IndexesResponse> {
+      const allState = parseSortFilterHeader(request);
       if (request.body.childField === 'openTrades') {
-        return handleTradeIndexes(request, true);
+        const openState = getTableState(allState, 'trades-open');
+        return handleTradeIndexes(request.body, openState, true);
       }
       if (request.body.childField === 'soldTrades') {
-        return handleTradeIndexes(request, false);
+        const closedState = getTableState(allState, 'trades-closed');
+        return handleTradeIndexes(request.body, closedState, false);
       }
       if (request.body.childField === 'divDeposits') {
-        return handleDivDepositsIndexes(request);
+        const divState = getTableState(allState, 'div-deposits');
+        return handleDivDepositsIndexes(request.body, divState);
       }
       return {
         startIndex: request.body.startIndex,

--- a/apps/server/src/app/routes/accounts/indexes/indexes-sort-filter.spec.ts
+++ b/apps/server/src/app/routes/accounts/indexes/indexes-sort-filter.spec.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fastify, { FastifyInstance } from 'fastify';
+
+import registerAccountIndexesRoutes from './index';
+
+// Story AX.13: Tests verifying sort/filter state is parsed from headers
+// and passed through to the query builders for all three childField types
+
+const { mockPrismaTrades, mockPrismaDivDeposits } = vi.hoisted(() => ({
+  mockPrismaTrades: { findMany: vi.fn(), count: vi.fn() },
+  mockPrismaDivDeposits: { findMany: vi.fn(), count: vi.fn() },
+}));
+
+vi.mock('../../../prisma/prisma-client', () => ({
+  prisma: {
+    trades: mockPrismaTrades,
+    divDeposits: mockPrismaDivDeposits,
+  },
+}));
+
+describe('GET /indexes - sort/filter state passthrough (AX.13)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = fastify({ logger: false });
+    await app.register(registerAccountIndexesRoutes, {
+      prefix: '/api/accounts/indexes',
+    });
+    await app.ready();
+    mockPrismaTrades.findMany.mockReset();
+    mockPrismaTrades.count.mockReset();
+    mockPrismaDivDeposits.findMany.mockReset();
+    mockPrismaDivDeposits.count.mockReset();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('openTrades with sort header', () => {
+    it('should apply buy_date sort from x-sort-filter-state header', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([{ id: 't-1' }]);
+      mockPrismaTrades.count.mockResolvedValue(1);
+
+      const sortState = JSON.stringify({
+        'trades-open': { sort: { field: 'buy_date', order: 'desc' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'openTrades',
+        },
+      });
+
+      expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { buy_date: 'desc' },
+        })
+      );
+    });
+
+    it('should apply symbol sort from x-sort-filter-state header', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([]);
+      mockPrismaTrades.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'trades-open': { sort: { field: 'symbol', order: 'asc' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'openTrades',
+        },
+      });
+
+      expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { universe: { symbol: 'asc' } },
+        })
+      );
+    });
+
+    it('should apply computed sort (unrealizedGain) via in-memory sorting', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([
+        { id: 't-1', buy: 10, quantity: 5, universe: { last_price: 20 } },
+        { id: 't-2', buy: 10, quantity: 5, universe: { last_price: 30 } },
+      ]);
+      mockPrismaTrades.count.mockResolvedValue(2);
+
+      const sortState = JSON.stringify({
+        'trades-open': {
+          sort: { field: 'unrealizedGain', order: 'desc' },
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'openTrades',
+        },
+      });
+
+      const body = JSON.parse(response.body);
+      // t-2 has higher unrealized gain (100 vs 50), so desc order = t-2 first
+      expect(body.indexes).toEqual(['t-2', 't-1']);
+    });
+
+    it('should apply symbol filter from x-sort-filter-state header', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([]);
+      mockPrismaTrades.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'trades-open': { filters: { symbol: 'AAPL' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'openTrades',
+        },
+      });
+
+      expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            universe: { symbol: { contains: 'AAPL' } },
+          }),
+        })
+      );
+    });
+  });
+
+  describe('soldTrades with sort header', () => {
+    it('should apply sell_date sort from x-sort-filter-state header', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([{ id: 's-1' }]);
+      mockPrismaTrades.count.mockResolvedValue(1);
+
+      const sortState = JSON.stringify({
+        'trades-closed': {
+          sort: { field: 'sell_date', order: 'desc' },
+        },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'soldTrades',
+        },
+      });
+
+      expect(mockPrismaTrades.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { sell_date: 'desc' },
+        })
+      );
+    });
+
+    it('should apply date filter from x-sort-filter-state header for sold trades', async () => {
+      mockPrismaTrades.findMany.mockResolvedValue([]);
+      mockPrismaTrades.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'trades-closed': {
+          filters: { startDate: '2024-01-01', endDate: '2024-12-31' },
+        },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'soldTrades',
+        },
+      });
+
+      const call = mockPrismaTrades.findMany.mock.calls[0][0];
+      expect(call.where.sell_date).toEqual(
+        expect.objectContaining({
+          gte: expect.any(Date),
+          lte: expect.any(Date),
+        })
+      );
+    });
+  });
+
+  describe('divDeposits with sort header', () => {
+    it('should apply date sort from x-sort-filter-state header', async () => {
+      mockPrismaDivDeposits.findMany.mockResolvedValue([{ id: 'd-1' }]);
+      mockPrismaDivDeposits.count.mockResolvedValue(1);
+
+      const sortState = JSON.stringify({
+        'div-deposits': { sort: { field: 'date', order: 'asc' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'divDeposits',
+        },
+      });
+
+      expect(mockPrismaDivDeposits.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { date: 'asc' },
+        })
+      );
+    });
+
+    it('should apply amount sort from x-sort-filter-state header', async () => {
+      mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+      mockPrismaDivDeposits.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'div-deposits': { sort: { field: 'amount', order: 'desc' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'divDeposits',
+        },
+      });
+
+      expect(mockPrismaDivDeposits.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { amount: 'desc' },
+        })
+      );
+    });
+
+    it('should apply symbol sort from x-sort-filter-state header for div deposits', async () => {
+      mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+      mockPrismaDivDeposits.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'div-deposits': { sort: { field: 'symbol', order: 'asc' } },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'divDeposits',
+        },
+      });
+
+      expect(mockPrismaDivDeposits.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { universe: { symbol: 'asc' } },
+        })
+      );
+    });
+
+    it('should apply date filter from x-sort-filter-state header for div deposits', async () => {
+      mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+      mockPrismaDivDeposits.count.mockResolvedValue(0);
+
+      const sortState = JSON.stringify({
+        'div-deposits': {
+          filters: { startDate: '2024-06-01' },
+        },
+      });
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        headers: { 'x-sort-filter-state': sortState },
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'divDeposits',
+        },
+      });
+
+      const call = mockPrismaDivDeposits.findMany.mock.calls[0][0];
+      expect(call.where.date).toEqual(
+        expect.objectContaining({
+          gte: expect.any(Date),
+        })
+      );
+    });
+
+    it('should default to date desc when no sort header provided', async () => {
+      mockPrismaDivDeposits.findMany.mockResolvedValue([]);
+      mockPrismaDivDeposits.count.mockResolvedValue(0);
+
+      await app.inject({
+        method: 'POST',
+        url: '/api/accounts/indexes',
+        payload: {
+          startIndex: 0,
+          length: 10,
+          parentId: 'acc-1',
+          childField: 'divDeposits',
+        },
+      });
+
+      expect(mockPrismaDivDeposits.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { date: 'desc' },
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Bug Fix: Index Route Sort/Filter State Passthrough [AX.13]

### Problem
The indexes route (`/api/accounts/indexes`) was ignoring the `x-sort-filter-state` header, using hardcoded default state for all queries. This meant:
- Sorting applied on the frontend was not reflected in index queries
- Filtering was not applied to index results
- Computed sort fields (unrealizedGain, unrealizedGainPercent) were not supported

### Fix
- **Extract `getTradeComputedValue`** to a shared function file for reuse in both `build-account-response.function.ts` and `indexes/index.ts`
- **Parse `x-sort-filter-state` header** in the indexes route handler
- **Pass table state** to `buildTradeWhere`, `buildTradeOrderBy`, `buildDivDepositWhere`, and `buildDivDepositOrderBy`
- **Support computed sort fields** via in-memory sorting when `isComputedTradeSort` returns true

### Files Changed
- `apps/server/src/app/routes/accounts/indexes/index.ts` — Updated to parse sort/filter state from headers
- `apps/server/src/app/routes/accounts/build-account-response.function.ts` — Extracted `getTradeComputedValue` to shared file
- `apps/server/src/app/routes/accounts/get-trade-computed-value.function.ts` — New shared utility
- `apps/server/src/app/routes/accounts/indexes/indexes-sort-filter.spec.ts` — 11 new tests

### Testing
- 11 new tests covering sort/filter passthrough for openTrades, soldTrades, and divDeposits
- All 49 server test files pass (597 tests)
- No regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal account data computation logic for trade metrics and improved sorting/filtering state management in account indexes API.

* **Tests**
  * Added comprehensive test suite validating sort and filter behavior across trades and dividend deposits with various data states and ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->