### PR TITLE
style(theme): Replace Hardcoded Colors with Theme Variables - Story 5-3

### DIFF
--- a/apps/dms-material/src/app/account-panel/div-dep-modal/div-dep-modal.component.scss
+++ b/apps/dms-material/src/app/account-panel/div-dep-modal/div-dep-modal.component.scss
@@ -30,7 +30,7 @@
 }
 
 .validation-error {
-  color: #f44336;
+  color: var(--dms-error);
   font-size: 12px;
   margin-top: 4px;
   display: block;

--- a/apps/dms-material/src/app/account-panel/open-positions/add-position-dialog/add-position-dialog.component.scss
+++ b/apps/dms-material/src/app/account-panel/open-positions/add-position-dialog/add-position-dialog.component.scss
@@ -28,7 +28,7 @@
 }
 
 .validation-error {
-  color: #f44336;
+  color: var(--dms-error);
   font-size: 12px;
   margin-top: 4px;
   display: block;

--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.scss
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.scss
@@ -9,17 +9,17 @@ dms-base-table {
 .success-message {
   padding: 12px;
   margin: 8px 16px;
-  background-color: #d4edda;
-  color: #155724;
-  border: 1px solid #c3e6cb;
+  background-color: color-mix(in srgb, var(--dms-success) 15%, var(--dms-surface));
+  color: var(--dms-success);
+  border: 1px solid color-mix(in srgb, var(--dms-success) 30%, var(--dms-surface));
   border-radius: 4px;
 }
 
 .error-message {
   padding: 12px;
   margin: 8px 16px;
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
+  background-color: color-mix(in srgb, var(--dms-error) 15%, var(--dms-surface));
+  color: var(--dms-error);
+  border: 1px solid color-mix(in srgb, var(--dms-error) 30%, var(--dms-surface));
   border-radius: 4px;
 }

--- a/apps/dms-material/src/app/auth/login/login.scss
+++ b/apps/dms-material/src/app/auth/login/login.scss
@@ -27,7 +27,7 @@ mat-card-header {
   gap: 0.5rem;
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
-  background-color: rgba(239, 68, 68, 0.1);
+  background-color: color-mix(in srgb, var(--dms-error) 10%, transparent);
   border: 1px solid var(--dms-error);
   border-radius: 4px;
   color: var(--dms-error);

--- a/apps/dms-material/src/app/auth/profile/components/profile-info-card.scss
+++ b/apps/dms-material/src/app/auth/profile/components/profile-info-card.scss
@@ -28,11 +28,11 @@ mat-card {
 
 mat-icon {
   &.verified {
-    color: #4caf50;
+    color: var(--dms-success);
   }
 
   &.unverified {
-    color: #ff9800;
+    color: var(--dms-warning);
   }
 }
 
@@ -59,7 +59,7 @@ mat-icon {
 }
 
 .error-icon {
-  color: #ff9800;
+  color: var(--dms-warning);
   font-size: 2rem;
   width: 2rem;
   height: 2rem;

--- a/apps/dms-material/src/app/auth/profile/components/session-info-card.scss
+++ b/apps/dms-material/src/app/auth/profile/components/session-info-card.scss
@@ -23,10 +23,10 @@ mat-card {
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  color: #4caf50;
+  color: var(--dms-success);
   font-weight: 500;
 
   mat-icon {
-    color: #4caf50;
+    color: var(--dms-success);
   }
 }

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.scss
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.scss
@@ -32,8 +32,8 @@
   display: flex;
   gap: 12px;
   padding: 8px 16px;
-  background-color: var(--mat-toolbar-container-background-color, #fafafa);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.12);
+  background-color: var(--mat-toolbar-container-background-color, var(--dms-surface));
+  border-bottom: 1px solid color-mix(in srgb, var(--dms-text-primary) 12%, transparent);
   flex-shrink: 0;
 }
 
@@ -72,23 +72,23 @@
 
     // Ensure complete border on all sides for outline appearance
     .mdc-notched-outline__leading {
-      border-left: 1px solid rgba(0, 0, 0, 0.38);
-      border-top: 1px solid rgba(0, 0, 0, 0.38);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.38);
+      border-left: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
+      border-top: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
+      border-bottom: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
       border-right: none;
     }
 
     .mdc-notched-outline__notch {
-      border-top: 1px solid rgba(0, 0, 0, 0.38);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.38);
+      border-top: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
+      border-bottom: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
       border-left: none;
       border-right: none;
     }
 
     .mdc-notched-outline__trailing {
-      border-right: 1px solid rgba(0, 0, 0, 0.38);
-      border-top: 1px solid rgba(0, 0, 0, 0.38);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.38);
+      border-right: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
+      border-top: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
+      border-bottom: 1px solid color-mix(in srgb, var(--dms-text-primary) 38%, transparent);
       border-left: none;
     }
 
@@ -119,7 +119,7 @@
 }
 
 .expired-indicator {
-  color: var(--mat-warn-color, #f44336);
+  color: var(--mat-warn-color, var(--dms-error));
   font-weight: bold;
 }
 
@@ -133,7 +133,7 @@
 
   p {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--dms-text-secondary);
     font-size: 14px;
   }
 }
@@ -164,7 +164,7 @@
 
 .error-message {
   padding: 12px 16px;
-  background-color: var(--mat-warn-color, #f44336);
+  background-color: var(--mat-warn-color, var(--dms-error));
   color: white;
   margin: 0;
   font-size: 14px;
@@ -173,7 +173,7 @@
 // Dark theme support
 :host-context(.dark-theme) {
   .filter-row {
-    background-color: var(--mat-toolbar-container-background-color, #424242);
-    border-bottom-color: rgba(255, 255, 255, 0.12);
+    background-color: var(--mat-toolbar-container-background-color, var(--dms-surface));
+    border-bottom-color: color-mix(in srgb, var(--dms-text-primary) 12%, transparent);
   }
 }

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
@@ -37,12 +37,12 @@ tr.mat-mdc-row {
   cursor: pointer;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.04);
+    background-color: color-mix(in srgb, var(--dms-text-primary) 4%, transparent);
 
     td.mat-mdc-cell {
       // Must also set on td: opaque td background-color (set below) would
       // otherwise block the tr hover from showing through
-      background-color: color-mix(in srgb, var(--dms-surface) 96%, #000000);
+      background-color: color-mix(in srgb, var(--dms-surface) 96%, var(--dms-text-primary));
     }
   }
 
@@ -70,14 +70,14 @@ tr.mat-mdc-row {
 
   &.loss {
     td.mat-mdc-cell {
-      color: #c62828; // Material Red 800 — contrast ≥4.5:1 on white
+      color: var(--dms-error);
       font-weight: 600;
     }
   }
 
   &.neutral {
     td.mat-mdc-cell {
-      color: #757575;
+      color: var(--dms-text-secondary);
     }
   }
 }
@@ -90,7 +90,7 @@ th.mat-mdc-header-cell {
   z-index: 1;
   // box-shadow replaces the collapsed border line for sticky cells:
   // a border-bottom on a sticky th disappears during scroll; box-shadow persists
-  box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.12);
+  box-shadow: 0 1px 0 0 color-mix(in srgb, var(--dms-text-primary) 12%, transparent);
 }
 
 tr.filter-row th.mat-mdc-header-cell {
@@ -109,11 +109,11 @@ td.mat-mdc-cell {
 
 .dark-theme {
   tr.mat-mdc-row:hover {
-    background-color: rgba(255, 255, 255, 0.04);
+    background-color: color-mix(in srgb, var(--dms-text-primary) 4%, transparent);
 
     td.mat-mdc-cell {
-      // Dark theme: blend white at 4% opacity equivalent
-      background-color: color-mix(in srgb, var(--dms-surface) 96%, #ffffff);
+      // Dark theme: blend text-primary at 4% opacity equivalent
+      background-color: color-mix(in srgb, var(--dms-surface) 96%, var(--dms-text-primary));
     }
   }
 }

--- a/apps/dms-material/src/app/shared/components/editable-cell/editable-cell.component.scss
+++ b/apps/dms-material/src/app/shared/components/editable-cell/editable-cell.component.scss
@@ -5,7 +5,7 @@
 }
 
 .display-value:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: color-mix(in srgb, var(--dms-text-primary) 4%, transparent);
 }
 
 .edit-field {
@@ -32,10 +32,10 @@
 }
 
 .validation-error {
-  color: #f44336;
+  color: var(--dms-error);
   font-size: 12px;
   margin-top: 2px;
   padding: 4px 8px;
-  background-color: #ffebee;
+  background-color: color-mix(in srgb, var(--dms-error) 10%, var(--dms-surface));
   border-radius: 4px;
 }

--- a/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.scss
+++ b/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.scss
@@ -5,7 +5,7 @@
 }
 
 .display-value:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: color-mix(in srgb, var(--dms-text-primary) 4%, transparent);
 }
 
 .edit-field {

--- a/apps/dms-material/src/app/shell/shell.scss
+++ b/apps/dms-material/src/app/shell/shell.scss
@@ -8,8 +8,8 @@
   left: 0;
   z-index: 1000;
   padding: 8px 16px;
-  background: #1976d2;
-  color: #fff;
+  background: var(--dms-primary-700);
+  color: var(--dms-neutral-50);
   text-decoration: none;
   font-weight: 500;
 

--- a/apps/dms-material/src/app/universe-settings/add-symbol-dialog/add-symbol-dialog.scss
+++ b/apps/dms-material/src/app/universe-settings/add-symbol-dialog/add-symbol-dialog.scss
@@ -12,7 +12,7 @@ dms-symbol-autocomplete {
 .selected-symbol {
   margin: 1rem 0;
   padding: 0.75rem;
-  background-color: #f5f5f5;
+  background-color: var(--dms-surface);
   border-radius: 4px;
   font-size: 0.875rem;
 }


### PR DESCRIPTION
# Story 5-3: Replace Hardcoded Colors with Theme Variables\n\nResolves #715\n\n## Summary\n\nReplaces all hardcoded hex/RGB color values in component SCSS files with `--dms-*` CSS custom properties for proper dark mode support.\n\n## Changes\n\n### Semantic Color Replacements\n- `#f44336` / `#c62828` → `var(--dms-error)` (error states, validation errors, loss indicators)\n- `#4caf50` → `var(--dms-success)` (verified status, active status)\n- `#ff9800` → `var(--dms-warning)` (unverified status, warning icons)\n- `#757575` → `var(--dms-text-secondary)` (neutral text, muted text)\n- `#f5f5f5` → `var(--dms-surface)` (selected-symbol background)\n- `#1976d2` → `var(--dms-primary-700)` (skip-link background)\n\n### Banner/Alert Color Derivations\n- Success banners: `color-mix(in srgb, var(--dms-success) 15%, var(--dms-surface))` for background\n- Error banners: `color-mix(in srgb, var(--dms-error) 15%, var(--dms-surface))` for background\n- Similar `color-mix` for borders at 30% mix\n\n### RGBA → Theme-Aware Replacements\n- `rgba(0,0,0,0.04)` → `color-mix(in srgb, var(--dms-text-primary) 4%, transparent)` (hover states)\n- `rgba(0,0,0,0.12)` → `color-mix(in srgb, var(--dms-text-primary) 12%, transparent)` (shadows, borders)\n- `rgba(0,0,0,0.38)` → `color-mix(in srgb, var(--dms-text-primary) 38%, transparent)` (outlined borders)\n- `rgba(239,68,68,0.1)` → `color-mix(in srgb, var(--dms-error) 10%, transparent)` (error background)\n\n### Material Token Fallback Updates\n- Updated `var(--mat-warn-color, #f44336)` → `var(--mat-warn-color, var(--dms-error))`\n- Updated `var(--mat-toolbar-container-background-color, #424242/#fafafa)` → `var(..., var(--dms-surface))`\n\n## Files Modified (12)\neditable-cell, editable-date-cell, div-dep-modal, add-position-dialog, open-positions, base-table, profile-info-card, session-info-card, shell, add-symbol-dialog, login, global-universe\n\n## Validation\n- ✅ `dms-material:build` passes\n- ✅ `dms-material:lint` passes\n- ✅ `dms-material:test` passes\n- ✅ Zero hardcoded hex/rgba colors remain in component SCSS"