### PR TITLE
feat(epic-6): Migrate tailwind.config.js to v4 Format - Story 6-3

### DIFF
--- a/apps/dms-material/tailwind.config.js
+++ b/apps/dms-material/tailwind.config.js
@@ -1,12 +1,8 @@
-const { createGlobPatternsForDependencies } = require('@nx/angular/tailwind');
 const { join } = require('path');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    join(__dirname, 'src/**/!(*.stories|*.spec).{ts,html}'),
-    ...createGlobPatternsForDependencies(__dirname),
-  ],
+  content: [join(__dirname, 'src/**/*.{ts,html}')],
   darkMode: ['class', '.dark-theme'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary

Updated `tailwind.config.js` to be compatible with Tailwind CSS v4, removing the Nx-specific `createGlobPatternsForDependencies` helper and using explicit content paths.

## Changes

- **apps/dms-material/tailwind.config.js**: Removed `@nx/angular/tailwind` dependency (`createGlobPatternsForDependencies`), simplified content path to `src/**/*.{ts,html}`, preserved `darkMode: ['class', '.dark-theme']` configuration

## Verification

- Production build succeeds with Tailwind utility classes in the CSS bundle
- Dark mode configuration preserved (`.dark-theme` selector in output CSS)
- dms-material lint and unit tests pass

Closes #723