### PR TITLE
feat(epic-6): Fix deprecated Tailwind v4 utility classes - Story 6-4

### DIFF
--- a/apps/dms-material/src/app/shell/shell.html
+++ b/apps/dms-material/src/app/shell/shell.html
@@ -35,8 +35,16 @@
 </nav>
 
 <!-- eslint-disable @angular-eslint/template/no-call-expression -->
-<main id="main-content" role="main" class="flex-1 overflow-hidden flex flex-col">
-  <dms-splitter class="flex-1 overflow-hidden" stateKey="dms-main-splitter" [initialLeftWidth]="20">
+<main
+  id="main-content"
+  role="main"
+  class="flex-1 overflow-hidden flex flex-col"
+>
+  <dms-splitter
+    class="flex-1 overflow-hidden"
+    stateKey="dms-main-splitter"
+    [initialLeftWidth]="20"
+  >
     <div leftPanel class="accounts-panel">
       <router-outlet name="accounts"></router-outlet>
     </div>
@@ -50,7 +58,7 @@
 @if (isLoading()) {
 <div
   data-testid="loading-overlay"
-  class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999]"
+  class="fixed inset-0 bg-black/50 flex items-center justify-center z-[9999]"
   style="margin: 0; padding: 0"
 >
   <div class="flex flex-col items-center justify-center p-6">


### PR DESCRIPTION
## Story 6-4: Fix All v4 Utility Class Breakages

### Changes
- Replace deprecated `bg-black bg-opacity-50` with Tailwind v4 opacity modifier syntax `bg-black/50` in `shell.html` loading overlay

### Background
In Tailwind CSS v4, the separate opacity utilities (`bg-opacity-*`, `text-opacity-*`, etc.) have been removed in favor of the color opacity modifier syntax (e.g., `bg-black/50`). This change was identified in the Story 6-1 migration analysis.

### Verification
- ✅ Build passes (`nx build dms-material`)
- ✅ Lint passes (`nx run dms-material:lint`)
- ✅ Unit tests pass (80 passed, 1 skipped — 1642 tests, 5 skipped)
- ✅ `bg-black/50` class confirmed present in production bundle

Closes #725