### PR TITLE
fix(cusip-cache): white-on-white text in Recently Added section (#731)

### DIFF
--- a/apps/dms-material/src/app/global/cusip-cache/cusip-cache.html
+++ b/apps/dms-material/src/app/global/cusip-cache/cusip-cache.html
@@ -67,12 +67,17 @@
       </div>
 
       @if (statsData.recentlyAdded.length > 0) {
-      <h3 class="mt-6 mb-2 text-sm font-medium text-gray-700">
+      <h3
+        class="mt-6 mb-2 text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
         Recently Added
       </h3>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
         @for (recent of statsData.recentlyAdded; track recent.cusip) {
-        <div class="text-xs p-2 bg-gray-50 rounded" data-testid="recent-entry">
+        <div
+          class="text-xs p-2 bg-gray-50 dark:bg-gray-800 dark:text-gray-300 rounded"
+          data-testid="recent-entry"
+        >
           {{ recent.cusip }} → {{ recent.symbol }} ({{ recent.source }})
         </div>
         }


### PR DESCRIPTION
Closes #731

## Changes
- Add `dark:text-gray-300` to "Recently Added" heading for dark mode contrast
- Add `dark:bg-gray-800 dark:text-gray-300` to recently added items
- Fixes contrast ratio to meet WCAG AA (≥4.5:1) in dark mode
- No light mode regression — existing Tailwind classes preserved

## Defects Addressed
- Audit Defect 1: White-on-white text in "Recently Added" heading  
- Audit Defect 2: Bright white card (`bg-gray-50`) on dark background

## Testing
- `pnpm all` passes (lint, test, build for dms-material and server)
- E2E tests have pre-existing `@tailwindcss/postcss` module resolution failure on main; not related to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode appearance for the "Recently Added" section with improved text and background contrast for better visual readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->