### PR TITLE
feat(storybook): Create Stories for Display-Only Components - Story 8-2

### DIFF
--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.stories.ts
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { BaseTableComponent } from './base-table.component';
+import type { ColumnDef } from './column-def.interface';
+
+interface SampleRow {
+  id: string;
+  symbol: string;
+  name: string;
+  price: number;
+  change: number;
+}
+
+const sampleColumns: ColumnDef[] = [
+  { field: 'symbol', header: 'Symbol', width: '100px', sortable: true },
+  { field: 'name', header: 'Name', width: '200px', sortable: true },
+  {
+    field: 'price',
+    header: 'Price',
+    width: '120px',
+    sortable: true,
+    type: 'currency',
+  },
+  {
+    field: 'change',
+    header: 'Change %',
+    width: '120px',
+    sortable: true,
+    type: 'number',
+  },
+];
+
+const sampleData: SampleRow[] = [
+  { id: '1', symbol: 'AAPL', name: 'Apple Inc.', price: 185.5, change: 1.23 },
+  {
+    id: '2',
+    symbol: 'MSFT',
+    name: 'Microsoft Corp.',
+    price: 420.75,
+    change: -0.45,
+  },
+  {
+    id: '3',
+    symbol: 'GOOGL',
+    name: 'Alphabet Inc.',
+    price: 175.2,
+    change: 2.1,
+  },
+  {
+    id: '4',
+    symbol: 'AMZN',
+    name: 'Amazon.com Inc.',
+    price: 198.3,
+    change: 0.87,
+  },
+  { id: '5', symbol: 'TSLA', name: 'Tesla Inc.', price: 245.6, change: -1.56 },
+];
+
+const meta: Meta<BaseTableComponent<SampleRow>> = {
+  title: 'Shared/BaseTableComponent',
+  component: BaseTableComponent,
+};
+
+export default meta;
+type Story = StoryObj<BaseTableComponent<SampleRow>>;
+
+export const Default: Story = {
+  args: {
+    data: sampleData,
+    columns: sampleColumns,
+    tableLabel: 'Stock Holdings',
+    rowHeight: 48,
+    bufferSize: 10,
+    selectable: false,
+    loading: false,
+  },
+};
+
+export const WithSelection: Story = {
+  args: {
+    data: sampleData,
+    columns: sampleColumns,
+    tableLabel: 'Selectable Table',
+    selectable: true,
+    multiSelect: true,
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    data: [],
+    columns: sampleColumns,
+    tableLabel: 'Loading Table',
+    loading: true,
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    data: [],
+    columns: sampleColumns,
+    tableLabel: 'Empty Table',
+    loading: false,
+  },
+};

--- a/apps/dms-material/src/app/shared/components/confirm-dialog/confirm-dialog.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/confirm-dialog/confirm-dialog.component.stories.ts
@@ -1,0 +1,68 @@
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import {
+  applicationConfig,
+  type Meta,
+  type StoryObj,
+} from '@storybook/angular';
+
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+const meta: Meta<ConfirmDialogComponent> = {
+  title: 'Shared/ConfirmDialogComponent',
+  component: ConfirmDialogComponent,
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: 'Confirm Action',
+            message: 'Are you sure you want to proceed?',
+            confirmText: 'Yes',
+            cancelText: 'No',
+          },
+        },
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: function noop() {
+              /* noop */
+            },
+          },
+        },
+      ],
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<ConfirmDialogComponent>;
+
+export const Default: Story = {};
+
+export const DeleteConfirmation: Story = {
+  decorators: [
+    applicationConfig({
+      providers: [
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: 'Delete Item',
+            message:
+              'This action cannot be undone. Are you sure you want to delete this item?',
+            confirmText: 'Delete',
+            cancelText: 'Cancel',
+          },
+        },
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: function noop() {
+              /* noop */
+            },
+          },
+        },
+      ],
+    }),
+  ],
+};

--- a/apps/dms-material/src/app/shared/components/edit/node-editor.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/edit/node-editor.component.stories.ts
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { NodeEditorComponent } from './node-editor.component';
+
+const meta: Meta<NodeEditorComponent> = {
+  title: 'Shared/NodeEditorComponent',
+  component: NodeEditorComponent,
+};
+
+export default meta;
+type Story = StoryObj<NodeEditorComponent>;
+
+export const Default: Story = {
+  args: {
+    mode: 'text',
+    label: 'Edit Value',
+    placeholder: 'Enter text...',
+  },
+};

--- a/apps/dms-material/src/app/shared/components/editable-cell/editable-cell.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/editable-cell/editable-cell.component.stories.ts
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { EditableCellComponent } from './editable-cell.component';
+
+const meta: Meta<EditableCellComponent> = {
+  title: 'Shared/EditableCellComponent',
+  component: EditableCellComponent,
+};
+
+export default meta;
+type Story = StoryObj<EditableCellComponent>;
+
+export const Default: Story = {
+  args: {
+    value: 42.5,
+    format: 'number',
+    step: 1,
+    decimalFormat: '1.2-2',
+  },
+};
+
+export const CurrencyFormat: Story = {
+  args: {
+    value: 1250.75,
+    format: 'currency',
+    step: 0.01,
+    decimalFormat: '1.2-2',
+  },
+};
+
+export const DecimalFormat: Story = {
+  args: {
+    value: 3.14159,
+    format: 'decimal',
+    step: 0.001,
+    decimalFormat: '1.4-4',
+  },
+};
+
+export const WithMinMax: Story = {
+  args: {
+    value: 50,
+    min: 0,
+    max: 100,
+    step: 5,
+    format: 'number',
+  },
+};
+
+export const ZeroValue: Story = {
+  args: {
+    value: 0,
+    format: 'number',
+  },
+};

--- a/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.stories.ts
@@ -1,0 +1,33 @@
+import { provideNativeDateAdapter } from '@angular/material/core';
+import {
+  applicationConfig,
+  type Meta,
+  type StoryObj,
+} from '@storybook/angular';
+
+import { EditableDateCellComponent } from './editable-date-cell.component';
+
+const meta: Meta<EditableDateCellComponent> = {
+  title: 'Shared/EditableDateCellComponent',
+  component: EditableDateCellComponent,
+  decorators: [
+    applicationConfig({
+      providers: [provideNativeDateAdapter()],
+    }),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<EditableDateCellComponent>;
+
+export const Default: Story = {
+  args: {
+    value: new Date('2026-01-15'),
+  },
+};
+
+export const EmptyValue: Story = {
+  args: {
+    value: null,
+  },
+};

--- a/apps/dms-material/src/app/shared/components/splitter/splitter.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/splitter/splitter.component.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { SplitterComponent } from './splitter.component';
+
+const meta: Meta<SplitterComponent> = {
+  title: 'Shared/SplitterComponent',
+  component: SplitterComponent,
+};
+
+export default meta;
+type Story = StoryObj<SplitterComponent>;
+
+export const Default: Story = {
+  args: {
+    stateKey: 'demo-splitter',
+    initialLeftWidth: 20,
+  },
+};
+
+export const WideLeft: Story = {
+  args: {
+    stateKey: 'demo-splitter-wide',
+    initialLeftWidth: 50,
+  },
+};
+
+export const NarrowLeft: Story = {
+  args: {
+    stateKey: 'demo-splitter-narrow',
+    initialLeftWidth: 10,
+  },
+};

--- a/apps/dms-material/src/app/shared/components/summary-display/summary-display.stories.ts
+++ b/apps/dms-material/src/app/shared/components/summary-display/summary-display.stories.ts
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+import type { ChartData } from 'chart.js';
+
+import { SummaryDisplayComponent } from './summary-display';
+
+const samplePieData: ChartData = {
+  labels: ['Equities', 'Bonds', 'Cash', 'Real Estate'],
+  datasets: [
+    {
+      data: [45, 25, 15, 15],
+      backgroundColor: ['#4CAF50', '#2196F3', '#FFC107', '#FF5722'],
+    },
+  ],
+};
+
+const sampleBarData: ChartData = {
+  labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+  datasets: [
+    {
+      label: 'Returns',
+      data: [2.5, -1.2, 3.8, 1.5, -0.5, 4.2],
+      backgroundColor: '#4CAF50',
+    },
+  ],
+};
+
+const meta: Meta<SummaryDisplayComponent> = {
+  title: 'Shared/SummaryDisplayComponent',
+  component: SummaryDisplayComponent,
+};
+
+export default meta;
+type Story = StoryObj<SummaryDisplayComponent>;
+
+export const PieChart: Story = {
+  args: {
+    chartType$: 'pie',
+    data$: samplePieData,
+    title$: 'Portfolio Allocation',
+    height$: '300px',
+    showLegend$: true,
+    legendPosition$: 'bottom',
+  },
+};
+
+export const BarChart: Story = {
+  args: {
+    chartType$: 'bar',
+    data$: sampleBarData,
+    title$: 'Monthly Returns',
+    height$: '300px',
+    showLegend$: true,
+    legendPosition$: 'bottom',
+  },
+};
+
+export const NoLegend: Story = {
+  args: {
+    chartType$: 'pie',
+    data$: samplePieData,
+    title$: 'Compact Chart',
+    height$: '200px',
+    showLegend$: false,
+  },
+};
+
+export const EmptyData: Story = {
+  args: {
+    chartType$: 'pie',
+    data$: { labels: [], datasets: [{ data: [] }] },
+    title$: 'No Data Available',
+    height$: '300px',
+  },
+};

--- a/apps/dms-material/src/app/shared/components/symbol-autocomplete/symbol-autocomplete.component.stories.ts
+++ b/apps/dms-material/src/app/shared/components/symbol-autocomplete/symbol-autocomplete.component.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/angular';
+
+import { SymbolAutocompleteComponent } from './symbol-autocomplete.component';
+import type { SymbolOption } from './symbol-option.interface';
+
+const mockSearchFn = async function mockSearch(
+  query: string
+): Promise<SymbolOption[]> {
+  const allOptions: SymbolOption[] = [
+    { symbol: 'AAPL', name: 'Apple Inc.' },
+    { symbol: 'MSFT', name: 'Microsoft Corporation' },
+    { symbol: 'GOOGL', name: 'Alphabet Inc.' },
+    { symbol: 'AMZN', name: 'Amazon.com Inc.' },
+    { symbol: 'TSLA', name: 'Tesla Inc.' },
+  ];
+  const results = await Promise.resolve(
+    allOptions.filter(function filterByQuery(opt) {
+      return (
+        opt.symbol.toLowerCase().includes(query.toLowerCase()) ||
+        opt.name.toLowerCase().includes(query.toLowerCase())
+      );
+    })
+  );
+  return results;
+};
+
+const meta: Meta<SymbolAutocompleteComponent> = {
+  title: 'Shared/SymbolAutocompleteComponent',
+  component: SymbolAutocompleteComponent,
+};
+
+export default meta;
+type Story = StoryObj<SymbolAutocompleteComponent>;
+
+export const Default: Story = {
+  args: {
+    searchFn: mockSearchFn,
+    label: 'Symbol',
+    placeholder: 'Search for a symbol...',
+    minLength: 2,
+    forceSelection: true,
+  },
+};


### PR DESCRIPTION
## Summary

Creates Storybook stories for all display-only (presentational) components in `dms-material` as part of Epic 8.

## Changes

Created co-located `*.stories.ts` files for 8 display-only components:

- **EditableCellComponent** — Default, CurrencyFormat, DecimalFormat, WithMinMax, ZeroValue
- **EditableDateCellComponent** — Default, EmptyValue
- **SplitterComponent** — Default, WideLeft, NarrowLeft
- **SummaryDisplayComponent** — PieChart, BarChart, NoLegend, EmptyData
- **NodeEditorComponent** — Default
- **SymbolAutocompleteComponent** — Default with mock search function
- **BaseTableComponent** — Default, WithSelection, Loading, EmptyState
- **ConfirmDialogComponent** — Default, DeleteConfirmation (with mocked MAT_DIALOG_DATA)

## Testing

- `pnpm all` passes (lint + build + unit tests) for dms-material
- `pnpm storybook:build` produces a static bundle with all stories
- `pnpm dupcheck` reports 0 clones

Closes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests & Documentation**
  * Added Storybook stories documenting eight shared UI components with multiple interactive test scenarios. Includes variations covering default states, selection modes, loading states, empty data states, formatting options (currency, decimal), date handling, responsive layouts, chart types, legend configurations, and autocomplete search. Enhances testing infrastructure and provides comprehensive component documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->