### PR TITLE
ci: add Storybook build and visual regression tests to CI pipeline (#748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         id: storybook-cache
         with:
           path: dist/storybook
-          key: storybook-${{ hashFiles('apps/dms-material/src/**', 'apps/dms-material/.storybook/**') }}
+          key: storybook-${{ hashFiles('pnpm-lock.yaml', 'apps/dms-material/src/**', 'apps/dms-material/.storybook/**') }}
 
       - name: Build Storybook
         if: steps.storybook-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Story 8-5: Update CI Pipeline to Include Storybook Build and Visual Tests

### Changes
- **Cached Storybook build step** — keyed by source hash of `apps/dms-material/src/**` and `.storybook/**`, skips rebuild when sources haven't changed
- **Visual regression test step** — runs `nx run dms-material-e2e:e2e-storybook` (Playwright serves dist/storybook automatically via webServer config)
- **Artifact upload on failure** — uploads `test-results/storybook-visual/` and `apps/dms-material-e2e/playwright-report/` as downloadable CI artifacts
- **GitHub Actions reporter** — failure annotations via the `github` reporter configured in playwright-storybook.config.ts

### Pipeline Order (preserved)
1. Format check
2. Duplicate check
3. Lint + Build + Unit tests
4. **Storybook build** (new, cached)
5. **Storybook visual regression tests** (new)

All existing steps unchanged.

Closes #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI stage that runs Storybook-based visual regression tests.
  * Introduced caching for built Storybook assets to speed CI runs.
  * Builds Storybook only when cache is missed (conditional build).
  * Uploads visual-regression diff artifacts when the workflow step sequence fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->