### PR TITLE
fix: Story 13.1 - Restore Global Summary responsive layout (lg breakpoint)

### DIFF
--- a/apps/dms-material/src/app/global/global-summary.html
+++ b/apps/dms-material/src/app/global/global-summary.html
@@ -25,10 +25,10 @@
     </div>
     }
     <div
-      class="flex flex-col md:flex-row items-stretch w-full gap-8 charts-container flex-1 min-h-0"
+      class="flex flex-col lg:flex-row items-stretch w-full gap-8 charts-container flex-1 min-h-0"
     >
       <!-- Left: Dropdown, stats, pie chart -->
-      <div class="flex flex-col items-start w-full md:w-1/2 max-w-md">
+      <div class="flex flex-col items-start w-full lg:w-1/2 max-w-md">
         <!-- Dropdown -->
         <div class="mb-4">
           <mat-select


### PR DESCRIPTION
## Summary

Restores the responsive side-by-side layout on the Global Summary screen so the line graph appears to the right of summary information on desktop (≥1024px) and stacks vertically on smaller screens.

## Changes

- Changed flex row breakpoint from `md` (768px) to `lg` (1024px) in the charts container
- Updated left column width class from `md:w-1/2` to `lg:w-1/2` to match

**File changed:** `apps/dms-material/src/app/global/global-summary.html`

## Testing

- Layout verified: `flex flex-col lg:flex-row` applied to charts container
- lint, build, and 1644 unit tests pass
- Global Summary e2e tests pass (core functionality, accessibility)

Closes #760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted responsive design breakpoints for the global summary view to optimize the layout of chart containers and content sections across various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->