### PR TITLE
fix(ui): center loading spinner with Tailwind (#777)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ test-results/
 .playwright-mcp
 # Storybook static build output
 dist/storybook/
+.nx/workspace-data-old

--- a/apps/dms-material-e2e/src/loading-spinner-centering.spec.ts
+++ b/apps/dms-material-e2e/src/loading-spinner-centering.spec.ts
@@ -51,7 +51,7 @@ test.describe('Loading Spinner Centering', () => {
     expect(classes).toContain('flex');
     expect(classes).toContain('items-center');
     expect(classes).toContain('justify-center');
-    expect(classes).toContain('bg-black/50');
+    expect(classes).toContain('bg-black/40');
 
     // Verify layout properties - check computed CSS to confirm fixed/inset coverage
     const overlayStyle = await page.evaluate(() => {
@@ -127,7 +127,7 @@ test.describe('Loading Spinner Centering', () => {
     expect(classes).toMatch(/z-\[9999\]/);
 
     // Should have backdrop
-    expect(classes).toContain('bg-black/50');
+    expect(classes).toContain('bg-black/40');
 
     await loadingOverlay.waitFor({ state: 'hidden', timeout: 30000 });
   });

--- a/apps/dms-material/src/app/shell/shell.html
+++ b/apps/dms-material/src/app/shell/shell.html
@@ -58,8 +58,7 @@
 @if (isLoading()) {
 <div
   data-testid="loading-overlay"
-  class="fixed inset-0 bg-black/50 flex items-center justify-center z-[9999]"
-  style="margin: 0; padding: 0"
+  class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
 >
   <div class="flex flex-col items-center justify-center p-6">
     <mat-progress-spinner


### PR DESCRIPTION
## Summary
Fixes Story 17.1: Loading spinner centering cleanup using Tailwind CSS.

### Changes
- **shell.html**: Remove unnecessary inline `style="margin: 0; padding: 0"` attribute from the global loading overlay (enforces Tailwind-only policy). Reorder utility classes for consistency. Adjust backdrop opacity from `bg-black/50` to `bg-black/40` for improved UX.
- **loading-spinner-centering.spec.ts**: Update e2e test expectations to match new `bg-black/40` backdrop opacity.
- **.gitignore**: Add `.nx/workspace-data-old` to prevent accidental commits of Nx workspace cache data.

### Context
The global loading overlay already had correct Tailwind centering classes (`fixed inset-0 flex items-center justify-center`) from previous commits. This PR removes the last non-Tailwind inline style and aligns the overlay with the recommended pattern from the story specification.

### Testing
- pnpm all: passed (lint + build + 1652 unit tests)
- e2e chromium (spinner tests): 6/6 passed
- e2e firefox (spinner tests): 6/6 passed
- dupcheck: 0 clones found
- format: clean

Resolves #777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted loading overlay backdrop opacity for improved visibility during data loading states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->