### PR TITLE
docs: diagnose dividend deposits table rendering issue

### DIFF
--- a/_bmad-output/implementation-artifacts/18-1-diagnose-dividend-deposits-table-rendering-issue.md
+++ b/_bmad-output/implementation-artifacts/18-1-diagnose-dividend-deposits-table-rendering-issue.md
@@ -63,7 +63,7 @@ So that I can apply a targeted fix rather than guessing.
   - [x] Scroll the Dividend Deposits table and observe behavior change
 - [x] Identify root cause (AC: 2)
   - [x] Document whether the issue is: container height = 0, CDK viewport miscalculation, CSS difference, or other
-  - [x] Trace where the 1-vs-2 header row difference creates a measurement error
+  - [x] Trace root cause: sparse-array holes + CDK virtual-scroll rendered range overrun
 - [x] Write diagnosis document (AC: 3)
   - [x] Create: `_bmad-output/implementation-artifacts/dividend-deposits-diagnosis.md`
   - [x] Include: root cause statement, evidence from inspection, proposed fix approach
@@ -124,7 +124,7 @@ See `_bmad-output/implementation-artifacts/12-1-restore-account-screen-table-vis
 
 A common pattern is:
 
-```
+```text
 viewport height = total container height - (number_of_header_rows × row_height)
 ```
 

--- a/_bmad-output/implementation-artifacts/dividend-deposits-diagnosis.md
+++ b/_bmad-output/implementation-artifacts/dividend-deposits-diagnosis.md
@@ -123,7 +123,7 @@ All three create sparse arrays with only the visible range populated. The differ
 
 ### CDK Buffer Calculation
 
-```
+```text
 CDK rendered items = ceil(viewport / itemSize) + ceil(maxBufferPx / itemSize)
 
 Open Positions:  ceil(911/52) + ceil(1040/52) = 18 + 20 = 38  ← under 50 ✅


### PR DESCRIPTION
## Story 18.1 — Diagnostic Investigation (No Code Changes)

### Root Cause
The Dividend Deposits table fails to render rows because the CDK virtual scroll buffer range exceeds the service's initial visible-window range. The sparse-array optimization creates undefined holes that crash `trackByFn`.

**Failure chain:**
1. Service creates sparse array (length 336, only indices 0-49 filled)
2. CDK calculates rendered range as {start:0, end:59} due to bufferSize=20
3. Items at indices 50-58 are `undefined`
4. `trackByFn(index, item)` → `item.id` → TypeError
5. Table renders 0 rows

### Why Open/Sold Positions Work
Default bufferSize=10 keeps CDK range (38) within the visible window (50). Working by luck, not by design.

### Deliverable
- `_bmad-output/implementation-artifacts/dividend-deposits-diagnosis.md` — full diagnosis with evidence, structural comparison, and 3 fix proposals for Story 18.2

### Validation
- `pnpm all` ✅
- `pnpm dupcheck` ✅ (0 clones)
- `pnpm format` ✅
- Chromium e2e: 40 pre-existing failures (universe-table-workflows, cusip-cache-admin)
- Firefox e2e: 401 pre-existing failures (OS/Playwright compatibility - nearly all tests timeout at 30s)

Closes #779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Completed diagnostic investigation of Dividend Deposits table rendering issue with root-cause analysis and recommended fixes.
  * Added a detailed diagnostic document including error evidence, structural comparisons, metrics, and remediation options (dense arrays, visibleRange adjustment, tolerant trackBy).
  * Updated the diagnosis template and developer notes formatting and marked all related story subtasks as done.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->