### PR TITLE
feat(story-21.1): Audit and Update Agent Prompt Files for Rate-Limit Directives

### DIFF
--- a/.github/instructions/code-review.md
+++ b/.github/instructions/code-review.md
@@ -510,3 +510,7 @@ When performing a code review, apply these prompt engineering principles from th
 - **Code Style**: ESLint with `@angular-eslint`, `@smarttools/no-anonymous-functions`, and project-specific rules. Prettier for formatting.
 - **Architecture**: refer to [docs/architecture/index.md](docs/architecture/index.md) for detailed architecture documentation
 - **Coding Standards**: refer to [docs/architecture/coding-standards.md](docs/architecture/coding-standards.md) for mandatory rules
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/instructions/shell-execution.md
+++ b/.github/instructions/shell-execution.md
@@ -32,13 +32,13 @@ When executing commands, use `timeout: 0` (no timeout) and wait for the command 
 ```typescript
 // Run command and wait for completion
 mcp_bash_run({
-  command: "pnpm test > test-output.txt 2>&1",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0  // Wait for completion
+  command: 'pnpm test > test-output.txt 2>&1',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0, // Wait for completion
 });
 
 // After command completes, read the file ONCE
-read_file({ filePath: "test-output.txt", startLine: 1, endLine: 100 });
+read_file({ filePath: 'test-output.txt', startLine: 1, endLine: 100 });
 ```
 
 ### ❌ INCORRECT: Monitor file while command runs
@@ -77,9 +77,9 @@ Use `mcp_bash_run_background` ONLY for:
 
 ```typescript
 mcp_bash_run({
-  command: "pnpm build",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0  // Wait for build to complete
+  command: 'pnpm build',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0, // Wait for build to complete
 });
 ```
 
@@ -87,9 +87,9 @@ mcp_bash_run({
 
 ```typescript
 mcp_bash_run({
-  command: "pnpm test",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0  // Wait for tests to complete
+  command: 'pnpm test',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0, // Wait for tests to complete
 });
 ```
 
@@ -97,9 +97,9 @@ mcp_bash_run({
 
 ```typescript
 mcp_bash_run({
-  command: "pnpm lint",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0  // Wait for linting to complete
+  command: 'pnpm lint',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0, // Wait for linting to complete
 });
 ```
 
@@ -107,9 +107,9 @@ mcp_bash_run({
 
 ```typescript
 mcp_bash_run({
-  command: "git status",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0
+  command: 'git status',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0,
 });
 ```
 
@@ -117,8 +117,8 @@ mcp_bash_run({
 
 ```typescript
 mcp_bash_run_background({
-  command: "pnpm dev",
-  cwd: "/home/dave/code/dms-workspace"
+  command: 'pnpm dev',
+  cwd: '/home/dave/code/dms-workspace',
 });
 ```
 
@@ -131,23 +131,23 @@ If a command produces large output, use shell redirection and read selectively:
 ```typescript
 // Run command, redirect output
 mcp_bash_run({
-  command: "pnpm test 2>&1 | tee test-results.txt",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0
+  command: 'pnpm test 2>&1 | tee test-results.txt',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0,
 });
 
 // Read relevant portions
 read_file({
-  filePath: "test-results.txt",
+  filePath: 'test-results.txt',
   startLine: 1,
-  endLine: 50  // Read first 50 lines
+  endLine: 50, // Read first 50 lines
 });
 
 // If needed, read more specific sections
 read_file({
-  filePath: "test-results.txt",
+  filePath: 'test-results.txt',
   startLine: 100,
-  endLine: 150
+  endLine: 150,
 });
 ```
 
@@ -158,8 +158,8 @@ Use tools like `grep`, `head`, `tail`, or `jq` to filter output before capture:
 ```typescript
 mcp_bash_run({
   command: "pnpm test 2>&1 | grep -E '(PASS|FAIL|Error)' > test-summary.txt",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0,
 });
 ```
 
@@ -169,9 +169,9 @@ Always check command results and handle errors appropriately:
 
 ```typescript
 const result = mcp_bash_run({
-  command: "pnpm build",
-  cwd: "/home/dave/code/dms-workspace",
-  timeout: 0
+  command: 'pnpm build',
+  cwd: '/home/dave/code/dms-workspace',
+  timeout: 0,
 });
 
 // The bash MCP server returns structured output with exit code and stderr
@@ -188,8 +188,13 @@ const result = mcp_bash_run({
 6. **Never monitor files** while a command is still running - this wastes tokens and money
 
 These practices ensure:
+
 - ✅ Efficient token usage
 - ✅ Fewer API calls
 - ✅ Lower costs
 - ✅ More reliable execution
 - ✅ Cleaner, more maintainable code
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/code-rabbit.prompt.md
+++ b/.github/prompts/code-rabbit.prompt.md
@@ -63,4 +63,8 @@ Notes:
 - Make operations idempotent: re-running should continue safely
 - All detailed instructions are in the "CodeRabbit Review Loop Pattern" section of bmad-workflow skill
 
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.
+
 ````

--- a/.github/prompts/code-story.prompt.md
+++ b/.github/prompts/code-story.prompt.md
@@ -27,3 +27,7 @@ mcp_bash_run({ command: "pnpm i", cwd: "../dms/story-${story}", timeout: 0 })
 Invoke the `#skill:bmad-dev-story` skill to implement the story from within the worktree directory.
 
 When implementation is complete, return immediately — the parent workflow handles committing, PR creation, and merge.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/commit-and-pr.prompt.md
+++ b/.github/prompts/commit-and-pr.prompt.md
@@ -52,3 +52,7 @@ EOF
 
 echo "WROTE $GIT_COMMON_DIR/tmp/story-${story}-meta.json"
 ```
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/create-stories-for-epic.prompt.md
+++ b/.github/prompts/create-stories-for-epic.prompt.md
@@ -25,3 +25,7 @@ Make sure the Definition of Done for each story includes:
   - Run `pnpm dupcheck`
   - Run `pnpm format`
   - Repeat all of these if any fail until they all pass
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/debug-merge-finalize.prompt.md
+++ b/.github/prompts/debug-merge-finalize.prompt.md
@@ -75,3 +75,7 @@ Return a concise summary containing:
 - cleanup result
 
 If merge/finalization fails after required retries and escalations, return `MERGE FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/debug-pr-lifecycle.prompt.md
+++ b/.github/prompts/debug-pr-lifecycle.prompt.md
@@ -64,3 +64,7 @@ Return a concise summary containing:
 - whether re-validation was required
 
 If PR creation or the CodeRabbit loop fails after required retries and escalations, return `PR FLOW FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/debug-setup.prompt.md
+++ b/.github/prompts/debug-setup.prompt.md
@@ -45,3 +45,7 @@ Return a concise summary containing:
 - created branch name
 
 If setup fails after required retries and escalations, return `SETUP FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/debug.prompt.md
+++ b/.github/prompts/debug.prompt.md
@@ -189,3 +189,7 @@ This keeps the debug workflow context small while the merge subagent handles:
 - Human involvement only via prompt.sh through the bash MCP server (with `timeout: 0`) when decisions/help needed
 - Maintains quality gates while maximizing autonomy
 - See bmad-workflow skill for detailed patterns and best practices
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/develop-epic.prompt.md
+++ b/.github/prompts/develop-epic.prompt.md
@@ -13,6 +13,7 @@ Shell execution rule: every shell command in this workflow and its delegated ste
 Each phase of the epic development process must be handled by a separate subAgent. This ensures modularity, better error handling, clear separation of concerns, and avoids loss of overall context
 
 1. **Discover Stories for Epic ${epic}**
+
    - Search for all story files matching: `_bmad-output/implementation-artifacts/${epic}-*.md`
    - Parse story numbers from filenames (e.g., AD.1, AD.2, AD.3)
    - Sort stories by numeric value (1, 2, 3, ...)
@@ -30,12 +31,14 @@ Each phase of the epic development process must be handled by a separate subAgen
 For each story in the ordered list:
 
 1. **Classify Story Type**
+
    - Read the story file and check the title/filename for keywords
    - **Bug fix story**: Title or filename contains "bug fix", "bug-fix", "bugfix", or "debug" → Use `debug.prompt.md`
    - **Standard story**: All other stories → Use `develop-story.prompt.md`
    - Add a todo item for each story indicating its type (standard/bug-fix) before starting implementation
 
 2. **Execute Story Development**
+
    - **CRITICAL**: You MUST delegate to the correct workflow file below. Do NOT attempt to implement the story yourself inline. Do NOT start servers, run manual tests, do code reviews, or perform any implementation work outside of the delegated workflow. The workflow file contains the complete instructions — follow them exactly.
    - **For standard stories**: Run `run #file:./develop-story.prompt.md story=${current_story}`
    - **For bug fix stories**: Run `run #file:./debug.prompt.md epic=${epic} story=${current_story}`
@@ -65,3 +68,7 @@ All ${N} stories implemented and merged to main.
 - **Story fails**: prompt.sh decides abort epic / skip story / retry with help
 - **Status validation fails**: prompt.sh decides whether to continue anyway
 - **Rate limits or conflicts**: Individual stories handle via develop-story.prompt.md
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/develop-story.prompt.md
+++ b/.github/prompts/develop-story.prompt.md
@@ -166,3 +166,7 @@ When it returns `MERGE COMPLETE`: the story workflow is complete.
 - All quality gates maintained while maximizing autonomy
 - MCP servers provide validation and documentation resources
 - See bmad-workflow skill for detailed patterns and best practices
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/gate.prompt.md
+++ b/.github/prompts/gate.prompt.md
@@ -18,3 +18,7 @@ Use `git diff --name-only origin/main...HEAD` to identify the changed files and 
 Invoke the `#skill:bmad-code-review` skill now.
 
 Do not commit until gate result is evaluated by the calling workflow.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/merge-finalize.prompt.md
+++ b/.github/prompts/merge-finalize.prompt.md
@@ -74,3 +74,7 @@ Return a concise summary containing:
 - cleanup result
 
 If merge/finalization fails after required retries and escalations, return `MERGE FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/qa-review-loop.prompt.md
+++ b/.github/prompts/qa-review-loop.prompt.md
@@ -58,3 +58,7 @@ Return a concise summary containing:
 - whether re-validation was required
 
 If the QA loop exhausts its retries, return `QA FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/quality-validation.prompt.md
+++ b/.github/prompts/quality-validation.prompt.md
@@ -55,3 +55,7 @@ Return a concise summary containing:
 - brief summary of any auto-fixes applied
 
 If validation fails after exhausting the loop rules, return `VALIDATION FAILED: <reason>` after handling required `prompt.sh` escalation.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/.github/prompts/update-epic.prompt.md
+++ b/.github/prompts/update-epic.prompt.md
@@ -13,3 +13,7 @@ Also, most of our epics have and e2e test story at the end. Create a story just 
 All stories should be renumbered sequentially 1, 2, 3 etc.
 
 Once you've done this, run #file:./create-stories-for-epic.prompt.md to create the stories for the epic.
+
+## Rate Limits
+
+If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

--- a/_bmad-output/implementation-artifacts/21-1-audit-and-update-agent-prompt-files-for-rate-limit-directives.md
+++ b/_bmad-output/implementation-artifacts/21-1-audit-and-update-agent-prompt-files-for-rate-limit-directives.md
@@ -1,6 +1,6 @@
 # Story 21.1: Audit and Update Agent Prompt Files for Rate-Limit Directives
 
-Status: Approved
+Status: Review
 
 ## Story
 
@@ -13,6 +13,7 @@ So that the AI agent completes long-running tasks without being interrupted by C
 1. **Given** the workspace's `.github/instructions/` folder, `_bmad/` config files, and any `copilot-instructions.md`
    **When** I review each file for rate-limit guidance
    **Then** every file that governs agent behaviour includes a "Rate Limits" section (or equivalent inline instructions) that states:
+
    - Do not call the Copilot API more than once every 2 minutes if rate limiting is detected.
    - Insert a wait/pause step between API-dependent operations when processing multi-step tasks.
    - Prefer slow task completion over aborting a task mid-execution due to rate limits.
@@ -27,30 +28,30 @@ So that the AI agent completes long-running tasks without being interrupted by C
 
 ## Definition of Done
 
-- [ ] All agent instruction/prompt files in `.github/instructions/` audited
-- [ ] All agent instruction/prompt files in `.github/prompts/` audited
-- [ ] `_bmad/` config yaml files audited
-- [ ] Any `copilot-instructions.md` file audited
-- [ ] Rate-limit directive added to every file that governs agent behaviour
-- [ ] Instructions are imperative, specific, and LLM-followable
-- [ ] `pnpm all` passes
+- [x] All agent instruction/prompt files in `.github/instructions/` audited
+- [x] All agent instruction/prompt files in `.github/prompts/` audited
+- [x] `_bmad/` config yaml files audited
+- [x] Any `copilot-instructions.md` file audited
+- [x] Rate-limit directive added to every file that governs agent behaviour
+- [x] Instructions are imperative, specific, and LLM-followable
+- [x] `pnpm all` passes
 
 ## Tasks / Subtasks
 
-- [ ] Identify all agent-governance files to update (AC: 1)
-  - [ ] List `.github/instructions/*.md` — these are the primary instruction files
-  - [ ] List `.github/prompts/*.prompt.md` — prompt files that control agent behaviour
-  - [ ] Check `.github/instructions/` for any `copilot-instructions.md`
-  - [ ] Check `_bmad/bmm/config.yaml` and `_bmad/_config/` for any agent behaviour config
-- [ ] For each file that governs agent task execution, add rate-limit section (AC: 1, 2)
-  - [ ] For `.github/prompts/develop-story.prompt.md` — add "Rate Limits" section stating the pause/wait rules
-  - [ ] For `.github/prompts/quality-validation.prompt.md` — add same
-  - [ ] For `.github/prompts/debug.prompt.md` — add same
-  - [ ] For `.github/instructions/code-review.md` — add if applicable
-  - [ ] For any other instruction file that runs multi-step tasks
-  - [ ] Wording: "If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure."
-- [ ] Validate no build impact (AC: 3)
-  - [ ] Run `pnpm all`
+- [x] Identify all agent-governance files to update (AC: 1)
+  - [x] List `.github/instructions/*.md` — these are the primary instruction files
+  - [x] List `.github/prompts/*.prompt.md` — prompt files that control agent behaviour
+  - [x] Check `.github/instructions/` for any `copilot-instructions.md`
+  - [x] Check `_bmad/bmm/config.yaml` and `_bmad/_config/` for any agent behaviour config
+- [x] For each file that governs agent task execution, add rate-limit section (AC: 1, 2)
+  - [x] For `.github/prompts/develop-story.prompt.md` — add "Rate Limits" section stating the pause/wait rules
+  - [x] For `.github/prompts/quality-validation.prompt.md` — add same
+  - [x] For `.github/prompts/debug.prompt.md` — add same
+  - [x] For `.github/instructions/code-review.md` — add if applicable
+  - [x] For any other instruction file that runs multi-step tasks
+  - [x] Wording: "If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure."
+- [x] Validate no build impact (AC: 3)
+  - [x] Run `pnpm all`
 
 ## Dev Notes
 
@@ -78,10 +79,44 @@ This story involves only markdown prompt/instruction files. There are no TypeScr
 
 ### Agent Model Used
 
-_to be filled on implementation_
+Claude Opus 4.6
 
 ### Debug Log References
 
 ### Completion Notes List
 
+- All 17 agent-governance files updated with consistent rate-limit directive
+- Epics reference files and \_bmad config YAML files intentionally excluded (not agent execution files)
+- No copilot-instructions.md found in workspace
+- code-rabbit.prompt.md required special handling due to ```` prompt wrapper syntax
+
 ### File List
+
+- `.github/prompts/code-story.prompt.md`
+- `.github/prompts/develop-story.prompt.md`
+- `.github/prompts/quality-validation.prompt.md`
+- `.github/prompts/debug.prompt.md`
+- `.github/prompts/gate.prompt.md`
+- `.github/prompts/develop-epic.prompt.md`
+- `.github/prompts/code-rabbit.prompt.md`
+- `.github/prompts/commit-and-pr.prompt.md`
+- `.github/prompts/create-stories-for-epic.prompt.md`
+- `.github/prompts/debug-merge-finalize.prompt.md`
+- `.github/prompts/debug-pr-lifecycle.prompt.md`
+- `.github/prompts/debug-setup.prompt.md`
+- `.github/prompts/merge-finalize.prompt.md`
+- `.github/prompts/qa-review-loop.prompt.md`
+- `.github/prompts/update-epic.prompt.md`
+- `.github/instructions/shell-execution.md`
+- `.github/instructions/code-review.md`
+
+### Change Log
+
+- Audited all `.github/instructions/` files: `code-review.md`, `shell-execution.md`, `epics-*.md`, `epics-next.md`
+  - `code-review.md` and `shell-execution.md` govern agent behaviour — added Rate Limits section
+  - `epics-*.md` and `epics-next.md` are reference/backlog docs — no directive needed
+- Audited all 15 `.github/prompts/*.prompt.md` files — all govern agent workflow execution — added Rate Limits section to each
+- Audited `_bmad/bmm/config.yaml` and `_bmad/_config/` YAML files — these are project metadata/config, not agent execution instructions — no directive needed
+- Checked for `copilot-instructions.md` — none found in workspace
+- Rate-limit directive wording: "If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure."
+- Total files modified: 17 (15 prompt files + 2 instruction files)


### PR DESCRIPTION
## Summary

Audited all agent instruction and prompt files in the workspace and added a consistent "Rate Limits" section to every file that governs agent behaviour.

## Changes

- Added Rate Limits section to 15 prompt files in `.github/prompts/`
- Added Rate Limits section to 2 instruction files in `.github/instructions/` (`code-review.md`, `shell-execution.md`)
- Updated story file with completion status, file list, and change log

## Rate-Limit Directive

> If GitHub Copilot rate limiting is detected or approached: (1) pause for at least 2 minutes before the next API call, (2) do not abort the task — resume from the last completed step after the pause, (3) prefer slow completion over fast failure.

## Files Audited (No Changes Needed)

- `.github/instructions/epics-*.md` — reference/backlog docs, not agent execution
- `_bmad/bmm/config.yaml` and `_bmad/_config/` YAML files — project metadata/config
- No `copilot-instructions.md` found in workspace

## Testing

- `pnpm all` — passes (no affected build/lint/test tasks; markdown-only changes)
- `pnpm e2e:dms-material:chromium` — 303 tests passed
- `pnpm e2e:dms-material:firefox` — passed (pre-existing confirm-dialog flakes unrelated)
- `pnpm dupcheck` — 0 clones
- `pnpm format` — clean

Closes #795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a unified “Rate Limits” guidance to workflow and prompt instructions across automation scenarios: require ≥2‑minute pause when rate limits are reached/approached, resume from the last completed step rather than aborting, and prefer slower completion over fast failure.
  * Updated implementation artifact docs to record completion of the governance audit and deployment of the rate‑limit directive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->