### PR TITLE
docs(story-23.3): add quality tool governance section to architecture document

### DIFF
--- a/_bmad-output/implementation-artifacts/23-3-add-quality-tool-governance-section-to-architecture-document.md
+++ b/_bmad-output/implementation-artifacts/23-3-add-quality-tool-governance-section-to-architecture-document.md
@@ -1,6 +1,6 @@
 # Story 23.3: Add Quality Tool Governance Section to Architecture Document
 
-Status: Approved
+Status: Review
 
 ## Story
 
@@ -16,36 +16,36 @@ so that the rules for configuring and maintaining `jscpd`, `vitest` coverage, an
 
 ## Definition of Done
 
-- [ ] Quality Tool Governance section added to `_bmad-output/planning-artifacts/architecture.md`
-- [ ] Section covers: jscpd (duplication), vitest (coverage), eslint (linting), and any other active quality gates
-- [ ] Rules for each tool clearly described (what is allowed vs. not allowed)
-- [ ] Run `pnpm format`
-- [ ] Repeat if any fails until it passes
+- [x] Quality Tool Governance section added to `_bmad-output/planning-artifacts/architecture.md`
+- [x] Section covers: jscpd (duplication), vitest (coverage), eslint (linting), and any other active quality gates
+- [x] Rules for each tool clearly described (what is allowed vs. not allowed)
+- [x] Run `pnpm format`
+- [x] Repeat if any fails until it passes
 
 ## Tasks / Subtasks
 
-- [ ] Review current architecture document structure (AC: #1)
-  - [ ] Read `_bmad-output/planning-artifacts/architecture.md` to find appropriate insertion point
-  - [ ] Identify existing quality-related sections (if any) to avoid duplication
-- [ ] Draft Quality Tool Governance section (AC: #1, #2)
-  - [ ] Add `## Quality Tool Governance` (or equivalent heading level) section
-  - [ ] Write sub-section for **jscpd** (duplication checker):
+- [x] Review current architecture document structure (AC: #1)
+  - [x] Read `_bmad-output/planning-artifacts/architecture.md` to find appropriate insertion point
+  - [x] Identify existing quality-related sections (if any) to avoid duplication
+- [x] Draft Quality Tool Governance section (AC: #1, #2)
+  - [x] Add `## Quality Tool Governance` (or equivalent heading level) section
+  - [x] Write sub-section for **jscpd** (duplication checker):
     - Config file: `.jscpd.json`
     - Rule: all ignore paths must point to existing files; invalid paths must be removed
     - Rule: duplication violations must be resolved by refactoring, never by adding suppressions
-  - [ ] Write sub-section for **Vitest coverage**:
+  - [x] Write sub-section for **Vitest coverage**:
     - Config file: `vitest.config.ts`
     - Required threshold: `100` for `branches` globally
     - Rule: `/* v8 ignore */` comments are only permitted for provably unreachable branches, with an explanatory comment
     - Rule: the `exclude` list in the coverage config must not be modified to hide gaps
-  - [ ] Write sub-section for **ESLint**:
+  - [x] Write sub-section for **ESLint**:
     - Config file: `eslint.config.mjs`
     - Rule: `eslint-disable` suppression comments require a brief justification comment
-  - [ ] Include a **Governance Enforcement** paragraph explaining that `pnpm all` runs all checks and all checks must pass before a story is considered done
-- [ ] Insert section into document (AC: #1)
-  - [ ] Place after the existing "Testing Strategy" or "Architecture Decisions" section (whichever is more appropriate)
-- [ ] Validate document (AC: #3)
-  - [ ] Run `pnpm format` and confirm no errors
+  - [x] Include a **Governance Enforcement** paragraph explaining that `pnpm all` runs all checks and all checks must pass before a story is considered done
+- [x] Insert section into document (AC: #1)
+  - [x] Place after the existing "Testing Strategy" or "Architecture Decisions" section (whichever is more appropriate)
+- [x] Validate document (AC: #3)
+  - [x] Run `pnpm format` and confirm no errors
 
 ## Dev Notes
 
@@ -73,8 +73,20 @@ so that the rules for configuring and maintaining `jscpd`, `vitest` coverage, an
 
 ### Agent Model Used
 
+Claude Opus 4.6
+
 ### Debug Log References
+
+None — documentation-only change.
 
 ### Completion Notes List
 
+- Added `## Quality Tool Governance` section to `architecture.md` between "Project Structure & Boundaries" and "Architecture Validation Results"
+- Section covers 4 tools: jscpd, Vitest, ESLint, Prettier
+- Each sub-section includes config file location, CI command, and prescriptive rules
+- Added Governance Enforcement paragraph tying all checks to `pnpm all` and story DoD
+- `pnpm format` passes with no changes needed
+
 ### File List
+
+- `_bmad-output/planning-artifacts/architecture.md` — added Quality Tool Governance section

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -688,6 +688,62 @@ POST /api/admin/cusip-cache/resolve
 
 ---
 
+## Quality Tool Governance
+
+This section defines the rules for configuring and maintaining the quality enforcement tools in the workspace. All tools run as part of `pnpm all` or as separate CI steps; every check must pass before a story is considered done.
+
+### jscpd (Code Duplication)
+
+**Config file:** `.jscpd.json`
+**CI command:** `pnpm dupcheck`
+**Threshold:** 0.1% maximum duplication across the scanned codebase
+
+**Rules:**
+
+- Every path in the `ignore` array must resolve to an existing file or directory in the repository. Invalid (non-existent) paths must be removed immediately.
+- Duplication violations must be resolved by refactoring duplicated code into shared utilities, services, or base abstractions — never by adding new suppression entries to the `ignore` array.
+- The `ignore` array may only contain infrastructure/config patterns (e.g., `node_modules`, `dist`, `coverage`, spec files, config files) and generated output directories (e.g., `_bmad-output`, `docs`). Application source code paths must not be suppressed.
+- When new shared code is extracted, each file must export exactly one item (per the `@smarttools/one-exported-item-per-file` ESLint rule) and include a corresponding spec file if it contains non-trivial logic.
+
+### Vitest (Unit Test Coverage)
+
+**Config file:** `vitest.config.ts` (root), per-project configs in `apps/*/vitest.config.ts`
+**CI command:** runs as part of `pnpm all` via `nx affected -t test --coverage`
+**Thresholds:** 100% for `branches`, `functions`, `lines`, and `statements`
+
+**Rules:**
+
+- Coverage thresholds must not be lowered. All four metrics (branches, functions, lines, statements) must remain at 100%.
+- `/* v8 ignore next */` (or `/* v8 ignore start/stop */`) comments are only permitted for provably unreachable branches (e.g., TypeScript exhaustive switch default cases). Each ignore comment must include an explanatory comment on the preceding line stating why the branch is unreachable.
+- The `exclude` list in the coverage config must not be modified to hide coverage gaps in application source code. Only test infrastructure, config files, type definitions, and build artifacts may be excluded.
+- Tests run through Nx (`npx nx test <project> --coverage`), not directly via the `vitest` CLI, to ensure project-level isolation and correct configuration.
+
+### ESLint (Static Analysis)
+
+**Config file:** `eslint.config.mjs` (root), per-project configs in `apps/*/eslint.config.mjs`
+**CI command:** runs as part of `pnpm all` via `nx affected -t lint`
+
+**Rules:**
+
+- `eslint-disable` suppression comments (inline or block) require a brief justification comment explaining why the rule is disabled for that specific line or block.
+- New ESLint rules or rule changes must be documented in `docs/lint-rules-diff.md` with the rule name, old severity, new severity, and rationale.
+- The `@smarttools/one-exported-item-per-file` rule is enforced workspace-wide: every TypeScript file must export exactly one item. No exceptions without documented justification.
+
+### Prettier (Code Formatting)
+
+**CI command:** `pnpm format` (runs `prettier --write .` followed by verification)
+
+**Rules:**
+
+- All committed code must pass `pnpm format` without changes. Run `pnpm format` before committing.
+- Prettier configuration is workspace-level only. Per-file or per-directory overrides are not permitted.
+
+### Governance Enforcement
+
+All quality checks are enforced through the CI pipeline. The `pnpm all` command runs lint, build, and test (with coverage) for all affected projects. Additionally, `pnpm dupcheck` and `pnpm format` run as separate steps. Every story's Definition of Done requires all checks to pass. No PR may be merged with failing quality gates.
+
+---
+
 ## Architecture Validation Results
 
 ### Coherence Validation ✅


### PR DESCRIPTION
## Summary

Adds a Quality Tool Governance section to the architecture document (`_bmad-output/planning-artifacts/architecture.md`) defining the rules for configuring and maintaining the quality enforcement tools in the workspace.

## Changes

- Added `## Quality Tool Governance` section between "Project Structure & Boundaries" and "Architecture Validation Results"
- Covers 4 tools: **jscpd** (duplication), **Vitest** (coverage), **ESLint** (static analysis), **Prettier** (formatting)
- Each sub-section documents: config file location, CI command, and prescriptive rules
- Added Governance Enforcement paragraph tying all checks to `pnpm all` and story Definition of Done

## Story File

`_bmad-output/implementation-artifacts/23-3-add-quality-tool-governance-section-to-architecture-document.md`

Closes #804