### PR TITLE
feat(story-24.1): extend sort state model for multi-column sort

### DIFF
--- a/_bmad-output/implementation-artifacts/24-1-extend-sort-state-model-for-multi-column-sort.md
+++ b/_bmad-output/implementation-artifacts/24-1-extend-sort-state-model-for-multi-column-sort.md
@@ -1,6 +1,6 @@
 # Story 24.1: Extend Sort State Model for Multi-Column Sort
 
-Status: Approved
+Status: Review
 
 ## Story
 
@@ -18,39 +18,39 @@ so that the sort state can represent an ordered list of sort columns rather than
 
 ## Definition of Done
 
-- [ ] `SortColumn` type added (with `column: string; direction: 'asc' | 'desc'`)
-- [ ] `TableState.sortColumns?: SortColumn[]` field added
-- [ ] Legacy migration utility function written and tested
-- [ ] Sort interceptor updated to use `sortColumns` when present
-- [ ] All TypeScript compilation errors resolved
-- [ ] Unit tests for migration logic achieve 100% branch coverage
-- [ ] Run `pnpm all`
-- [ ] Run `pnpm format`
-- [ ] Repeat all of these if any fail until they all pass
+- [x] `SortColumn` type added (with `column: string; direction: 'asc' | 'desc'`)
+- [x] `TableState.sortColumns?: SortColumn[]` field added
+- [x] Legacy migration utility function written and tested
+- [x] Sort interceptor updated to use `sortColumns` when present
+- [x] All TypeScript compilation errors resolved
+- [x] Unit tests for migration logic achieve 100% branch coverage
+- [x] Run `pnpm all`
+- [x] Run `pnpm format`
+- [x] Repeat all of these if any fail until they all pass
 
 ## Tasks / Subtasks
 
-- [ ] Add `SortColumn` interface (AC: #1)
-  - [ ] Create or update `apps/dms-material/src/app/shared/services/sort-config.interface.ts`
-  - [ ] Export `SortColumn { column: string; direction: 'asc' | 'desc' }`
-  - [ ] Keep existing `SortConfig` export for backward compatibility (or alias it)
-- [ ] Update `TableState` interface (AC: #1)
-  - [ ] Add `sortColumns?: SortColumn[]` to `apps/dms-material/src/app/shared/services/table-state.interface.ts`
-  - [ ] Keep existing `sort?: SortConfig` property (for migration compatibility)
-- [ ] Write legacy migration utility (AC: #2, #3)
-  - [ ] Create `apps/dms-material/src/app/shared/utils/migrate-table-state.ts`
-  - [ ] Function `migrateTableState(state: TableState): TableState`:
+- [x] Add `SortColumn` interface (AC: #1)
+  - [x] Create or update `apps/dms-material/src/app/shared/services/sort-config.interface.ts`
+  - [x] Export `SortColumn { column: string; direction: 'asc' | 'desc' }`
+  - [x] Keep existing `SortConfig` export for backward compatibility (or alias it)
+- [x] Update `TableState` interface (AC: #1)
+  - [x] Add `sortColumns?: SortColumn[]` to `apps/dms-material/src/app/shared/services/table-state.interface.ts`
+  - [x] Keep existing `sort?: SortConfig` property (for migration compatibility)
+- [x] Write legacy migration utility (AC: #2, #3)
+  - [x] Create `apps/dms-material/src/app/shared/utils/migrate-table-state.ts`
+  - [x] Function `migrateTableState(state: TableState): TableState`:
     - If `sortColumns` is present, return state as-is
     - If only `sort` is present, convert to `sortColumns: [{ column: state.sort.field, direction: state.sort.order }]`
     - If neither is present, return state unchanged
-- [ ] Update sort interceptor (AC: #4)
-  - [ ] Open `apps/dms-material/src/app/auth/interceptors/sort.interceptor.ts`
-  - [ ] When reading sort state, prefer `sortColumns` over legacy `sort`
-  - [ ] Ensure serialization handles empty `sortColumns` array gracefully
-- [ ] Write unit tests (AC: #5)
-  - [ ] Create `apps/dms-material/src/app/shared/utils/migrate-table-state.spec.ts`
-  - [ ] Cover all 3 branches: `sortColumns` present, only `sort` present, neither present
-  - [ ] Cover sort interceptor changes if logic is non-trivial
+- [x] Update sort interceptor (AC: #4)
+  - [x] Open `apps/dms-material/src/app/auth/interceptors/sort.interceptor.ts`
+  - [x] When reading sort state, prefer `sortColumns` over legacy `sort`
+  - [x] Ensure serialization handles empty `sortColumns` array gracefully
+- [x] Write unit tests (AC: #5)
+  - [x] Create `apps/dms-material/src/app/shared/utils/migrate-table-state.spec.ts`
+  - [x] Cover all 3 branches: `sortColumns` present, only `sort` present, neither present
+  - [x] Cover sort interceptor changes if logic is non-trivial
 
 ## Dev Notes
 
@@ -87,7 +87,7 @@ export interface SortColumn {
 }
 
 export interface TableState {
-  sort?: SortConfig;         // kept for migration compatibility
+  sort?: SortConfig; // kept for migration compatibility
   sortColumns?: SortColumn[]; // new canonical field
   filters?: FilterConfig;
 }
@@ -114,8 +114,31 @@ export interface TableState {
 
 ### Agent Model Used
 
+Claude Opus 4.6
+
 ### Debug Log References
+
+None.
 
 ### Completion Notes List
 
+- Created `SortColumn` interface in its own file (`sort-column.interface.ts`) per `@smarttools/one-exported-item-per-file` rule
+- Added `sortColumns?: SortColumn[]` to `TableState` interface alongside existing `sort?: SortConfig`
+- Created `migrateTableState` function in `shared/utils/migrate-table-state.function.ts` with 3 branches:
+  1. `sortColumns` present → return as-is (sortColumns takes precedence)
+  2. Only `sort` present → convert to `sortColumns` array
+  3. Neither → return unchanged
+- Updated sort interceptor to run migration on each table state, then prefer `sortColumns` for output
+- Edge case: empty `sortColumns[]` with `sort` present falls back to legacy `sort` output
+- Fixed `@smarttools/no-anonymous-functions` lint error in `.map()` callback
+- All 100% coverage maintained across branches, functions, lines, statements
+- `pnpm dupcheck`: 0.08% (1 clone, under 0.1% threshold)
+
 ### File List
+
+- `apps/dms-material/src/app/shared/services/sort-column.interface.ts` — new
+- `apps/dms-material/src/app/shared/services/table-state.interface.ts` — added `sortColumns` field
+- `apps/dms-material/src/app/shared/utils/migrate-table-state.function.ts` — new
+- `apps/dms-material/src/app/shared/utils/migrate-table-state.function.spec.ts` — new
+- `apps/dms-material/src/app/auth/interceptors/sort.interceptor.ts` — updated to use `sortColumns`
+- `apps/dms-material/src/app/auth/interceptors/sort.interceptor.spec.ts` — updated tests for `sortColumns`

--- a/apps/dms-material/src/app/auth/interceptors/sort.interceptor.spec.ts
+++ b/apps/dms-material/src/app/auth/interceptors/sort.interceptor.spec.ts
@@ -34,7 +34,7 @@ describe('sortInterceptor', () => {
   });
 
   describe('sends all state as JSON header', () => {
-    it('should add X-Sort-Filter-State header with all table states', () => {
+    it('should add X-Sort-Filter-State header with all table states using sortColumns', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
         universes: { sort: { field: 'symbol', order: 'asc' } },
         'trades-open': { sort: { field: 'buyDate', order: 'desc' } },
@@ -50,17 +50,41 @@ describe('sortInterceptor', () => {
       const headerValue = interceptedReq.headers.get('X-Sort-Filter-State');
       expect(headerValue).not.toBeNull();
       const parsed = JSON.parse(headerValue!);
-      expect(parsed.universes.sort).toEqual({
-        field: 'symbol',
-        order: 'asc',
-      });
-      expect(parsed['trades-open'].sort).toEqual({
-        field: 'openDate',
-        order: 'desc',
-      });
+      expect(parsed.universes.sortColumns).toEqual([
+        { column: 'symbol', direction: 'asc' },
+      ]);
+      expect(parsed['trades-open'].sortColumns).toEqual([
+        { column: 'openDate', direction: 'desc' },
+      ]);
     });
 
-    it('should include filter state in the header', () => {
+    it('should use sortColumns directly when present in state', () => {
+      mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
+        universes: {
+          sortColumns: [
+            { column: 'symbol', direction: 'asc' },
+            { column: 'yield_percent', direction: 'desc' },
+          ],
+        },
+      });
+
+      const req = new HttpRequest('GET', '/api/universe');
+
+      TestBed.runInInjectionContext(() => {
+        sortInterceptor(req, mockNext);
+      });
+
+      const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
+      const parsed = JSON.parse(
+        interceptedReq.headers.get('X-Sort-Filter-State')!
+      );
+      expect(parsed.universes.sortColumns).toEqual([
+        { column: 'symbol', direction: 'asc' },
+        { column: 'yield_percent', direction: 'desc' },
+      ]);
+    });
+
+    it('should include filter state in the header alongside sortColumns', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
         universes: {
           sort: { field: 'symbol', order: 'asc' },
@@ -79,6 +103,9 @@ describe('sortInterceptor', () => {
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
       expect(parsed.universes.filters).toEqual({ symbol: 'AAPL' });
+      expect(parsed.universes.sortColumns).toEqual([
+        { column: 'symbol', direction: 'asc' },
+      ]);
     });
 
     it('should send state on any GET request regardless of endpoint', () => {
@@ -98,7 +125,7 @@ describe('sortInterceptor', () => {
   });
 
   describe('field name mapping', () => {
-    it('should pass through risk_group field for universes', () => {
+    it('should pass through risk_group field for universes via sortColumns', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
         universes: { sort: { field: 'risk_group', order: 'asc' } },
       });
@@ -113,10 +140,10 @@ describe('sortInterceptor', () => {
       const parsed = JSON.parse(
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
-      expect(parsed.universes.sort.field).toBe('risk_group');
+      expect(parsed.universes.sortColumns[0].column).toBe('risk_group');
     });
 
-    it('should map buyDate to openDate for trades-open', () => {
+    it('should map buyDate to openDate for trades-open via sortColumns', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
         'trades-open': { sort: { field: 'buyDate', order: 'desc' } },
       });
@@ -131,10 +158,10 @@ describe('sortInterceptor', () => {
       const parsed = JSON.parse(
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
-      expect(parsed['trades-open'].sort.field).toBe('openDate');
+      expect(parsed['trades-open'].sortColumns[0].column).toBe('openDate');
     });
 
-    it('should map sell_date to closeDate for trades-closed', () => {
+    it('should map sell_date to closeDate for trades-closed via sortColumns', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
         'trades-closed': { sort: { field: 'sell_date', order: 'desc' } },
       });
@@ -149,7 +176,7 @@ describe('sortInterceptor', () => {
       const parsed = JSON.parse(
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
-      expect(parsed['trades-closed'].sort.field).toBe('closeDate');
+      expect(parsed['trades-closed'].sortColumns[0].column).toBe('closeDate');
     });
 
     it('should pass through unmapped sort fields for known tables', () => {
@@ -168,7 +195,7 @@ describe('sortInterceptor', () => {
       const parsed = JSON.parse(
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
-      expect(parsed.universes.sort.field).toBe('yield_percent');
+      expect(parsed.universes.sortColumns[0].column).toBe('yield_percent');
     });
 
     it('should pass through fields for tables without a field map', () => {
@@ -186,14 +213,40 @@ describe('sortInterceptor', () => {
       const parsed = JSON.parse(
         interceptedReq.headers.get('X-Sort-Filter-State')!
       );
-      expect(parsed['other-table'].sort.field).toBe('name');
+      expect(parsed['other-table'].sortColumns[0].column).toBe('name');
+    });
+
+    it('should map fields in multi-column sortColumns', () => {
+      mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
+        'trades-open': {
+          sortColumns: [
+            { column: 'buyDate', direction: 'asc' },
+            { column: 'symbol', direction: 'desc' },
+          ],
+        },
+      });
+
+      const req = new HttpRequest('GET', '/api/trades/open');
+
+      TestBed.runInInjectionContext(() => {
+        sortInterceptor(req, mockNext);
+      });
+
+      const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
+      const parsed = JSON.parse(
+        interceptedReq.headers.get('X-Sort-Filter-State')!
+      );
+      expect(parsed['trades-open'].sortColumns).toEqual([
+        { column: 'openDate', direction: 'asc' },
+        { column: 'symbol', direction: 'desc' },
+      ]);
     });
   });
 
   describe('non-GET requests', () => {
     it('should add headers to POST requests', () => {
       mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
-        universes: { sort: { field: 'symbol', order: 'asc' } },
+        universes: { sortColumns: [{ column: 'symbol', direction: 'asc' }] },
       });
 
       const req = new HttpRequest('POST', '/api/universe', {});
@@ -219,6 +272,65 @@ describe('sortInterceptor', () => {
 
       const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
       expect(interceptedReq.headers.has('X-Sort-Filter-State')).toBe(false);
+    });
+
+    it('should not add header when table has empty sortColumns and no sort or filters', () => {
+      mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
+        universes: { sortColumns: [] },
+      });
+
+      const req = new HttpRequest('GET', '/api/universe');
+
+      TestBed.runInInjectionContext(() => {
+        sortInterceptor(req, mockNext);
+      });
+
+      const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
+      expect(interceptedReq.headers.has('X-Sort-Filter-State')).toBe(false);
+    });
+
+    it('should fall back to legacy sort when sortColumns is empty but sort is present', () => {
+      mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
+        universes: {
+          sortColumns: [],
+          sort: { field: 'symbol', order: 'asc' },
+        },
+      });
+
+      const req = new HttpRequest('GET', '/api/universe');
+
+      TestBed.runInInjectionContext(() => {
+        sortInterceptor(req, mockNext);
+      });
+
+      const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
+      const parsed = JSON.parse(
+        interceptedReq.headers.get('X-Sort-Filter-State')!
+      );
+      expect(parsed.universes.sort).toEqual({
+        field: 'symbol',
+        order: 'asc',
+      });
+    });
+
+    it('should include only filters when sortColumns is empty and no sort', () => {
+      mockSortFilterStateService.loadAllSortFilterState.mockReturnValue({
+        universes: { sortColumns: [], filters: { active: true } },
+      });
+
+      const req = new HttpRequest('GET', '/api/universe');
+
+      TestBed.runInInjectionContext(() => {
+        sortInterceptor(req, mockNext);
+      });
+
+      const interceptedReq = mockNext.mock.calls[0][0] as HttpRequest<unknown>;
+      const parsed = JSON.parse(
+        interceptedReq.headers.get('X-Sort-Filter-State')!
+      );
+      expect(parsed.universes.filters).toEqual({ active: true });
+      expect(parsed.universes.sortColumns).toBeUndefined();
+      expect(parsed.universes.sort).toBeUndefined();
     });
   });
 });

--- a/apps/dms-material/src/app/auth/interceptors/sort.interceptor.ts
+++ b/apps/dms-material/src/app/auth/interceptors/sort.interceptor.ts
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs';
 
 import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { TableState } from '../../shared/services/table-state.interface';
+import { migrateTableState } from '../../shared/utils/migrate-table-state.function';
 
 const FIELD_NAME_MAP: Record<string, Record<string, string>> = {
   universes: {
@@ -34,15 +35,27 @@ function buildMappedEntry(
   table: string,
   tableState: TableState
 ): TableState | null {
+  const migrated = migrateTableState(tableState);
   const entry: TableState = {};
-  if (tableState.sort !== undefined) {
-    const serverField = mapSortField(table, tableState.sort.field);
-    entry.sort = { field: serverField, order: tableState.sort.order };
+  if (migrated.sortColumns !== undefined && migrated.sortColumns.length > 0) {
+    entry.sortColumns = migrated.sortColumns.map(function mapColumn(sc) {
+      return {
+        column: mapSortField(table, sc.column),
+        direction: sc.direction,
+      };
+    });
+  } else if (migrated.sort !== undefined) {
+    const serverField = mapSortField(table, migrated.sort.field);
+    entry.sort = { field: serverField, order: migrated.sort.order };
   }
-  if (tableState.filters !== undefined) {
-    entry.filters = tableState.filters;
+  if (migrated.filters !== undefined) {
+    entry.filters = migrated.filters;
   }
-  return entry.sort !== undefined || entry.filters !== undefined ? entry : null;
+  return entry.sortColumns !== undefined ||
+    entry.sort !== undefined ||
+    entry.filters !== undefined
+    ? entry
+    : null;
 }
 
 function buildMappedState(

--- a/apps/dms-material/src/app/shared/services/sort-column.interface.ts
+++ b/apps/dms-material/src/app/shared/services/sort-column.interface.ts
@@ -1,0 +1,4 @@
+export interface SortColumn {
+  column: string;
+  direction: 'asc' | 'desc';
+}

--- a/apps/dms-material/src/app/shared/services/table-state.interface.ts
+++ b/apps/dms-material/src/app/shared/services/table-state.interface.ts
@@ -1,7 +1,9 @@
 import { FilterConfig } from './filter-config.interface';
+import { SortColumn } from './sort-column.interface';
 import { SortConfig } from './sort-config.interface';
 
 export interface TableState {
   sort?: SortConfig;
+  sortColumns?: SortColumn[];
   filters?: FilterConfig;
 }

--- a/apps/dms-material/src/app/shared/utils/migrate-table-state.function.spec.ts
+++ b/apps/dms-material/src/app/shared/utils/migrate-table-state.function.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+import { TableState } from '../services/table-state.interface';
+import { migrateTableState } from './migrate-table-state.function';
+
+describe('migrateTableState', () => {
+  it('should return state unchanged when sortColumns is present', () => {
+    const state: TableState = {
+      sortColumns: [{ column: 'symbol', direction: 'asc' }],
+      sort: { field: 'name', order: 'desc' },
+    };
+    const result = migrateTableState(state);
+    expect(result).toBe(state);
+  });
+
+  it('should convert legacy sort to sortColumns when only sort is present', () => {
+    const state: TableState = {
+      sort: { field: 'buyDate', order: 'desc' },
+      filters: { symbol: 'AAPL' },
+    };
+    const result = migrateTableState(state);
+    expect(result.sortColumns).toEqual([
+      { column: 'buyDate', direction: 'desc' },
+    ]);
+    expect(result.sort).toEqual({ field: 'buyDate', order: 'desc' });
+    expect(result.filters).toEqual({ symbol: 'AAPL' });
+  });
+
+  it('should return state unchanged when neither sort nor sortColumns is present', () => {
+    const state: TableState = {
+      filters: { active: true },
+    };
+    const result = migrateTableState(state);
+    expect(result).toBe(state);
+  });
+
+  it('should return empty state unchanged', () => {
+    const state: TableState = {};
+    const result = migrateTableState(state);
+    expect(result).toBe(state);
+  });
+
+  it('should prefer sortColumns over sort when both are present', () => {
+    const state: TableState = {
+      sortColumns: [
+        { column: 'yield', direction: 'desc' },
+        { column: 'symbol', direction: 'asc' },
+      ],
+      sort: { field: 'name', order: 'asc' },
+    };
+    const result = migrateTableState(state);
+    expect(result.sortColumns).toEqual([
+      { column: 'yield', direction: 'desc' },
+      { column: 'symbol', direction: 'asc' },
+    ]);
+  });
+
+  it('should handle empty sortColumns array by returning state as-is', () => {
+    const state: TableState = {
+      sortColumns: [],
+    };
+    const result = migrateTableState(state);
+    expect(result).toBe(state);
+  });
+});

--- a/apps/dms-material/src/app/shared/utils/migrate-table-state.function.ts
+++ b/apps/dms-material/src/app/shared/utils/migrate-table-state.function.ts
@@ -1,0 +1,14 @@
+import { TableState } from '../services/table-state.interface';
+
+export function migrateTableState(state: TableState): TableState {
+  if (state.sortColumns !== undefined) {
+    return state;
+  }
+  if (state.sort !== undefined) {
+    return {
+      ...state,
+      sortColumns: [{ column: state.sort.field, direction: state.sort.order }],
+    };
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary

Extends the sort state model to support multi-column sorting by adding a `SortColumn` interface and `sortColumns` field to `TableState`. Includes a migration utility for backward compatibility and updates the sort interceptor to prefer `sortColumns` over legacy `sort`.

## Changes

- **New:** `SortColumn` interface (`column: string; direction: 'asc' | 'desc'`)
- **New:** `TableState.sortColumns?: SortColumn[]` field
- **New:** `migrateTableState()` utility — converts legacy `sort` to `sortColumns` array
- **Updated:** Sort interceptor — uses `sortColumns` when present, maps field names per column, falls back to legacy `sort` when `sortColumns` is empty
- **Updated:** Interceptor tests — all assertions updated for `sortColumns` output, new tests for multi-column and edge cases

## Testing

- 100% coverage on all new and modified files
- `pnpm all` passes
- `pnpm dupcheck` passes (0.08%)
- `pnpm format` clean

## Story File
`_bmad-output/implementation-artifacts/24-1-extend-sort-state-model-for-multi-column-sort.md`

Closes #806