### PR TITLE
feat(universe): implement multi-column sort UI with Shift+click (Story 24.3)

### DIFF
--- a/apps/dms-material-e2e/src/multi-column-sort.spec.ts
+++ b/apps/dms-material-e2e/src/multi-column-sort.spec.ts
@@ -1,0 +1,159 @@
+import { expect, Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+
+/**
+ * Helper: read sortColumns state from localStorage.
+ */
+async function getSortColumnsState(
+  page: Page,
+  table: string
+): Promise<{ column: string; direction: string }[] | null> {
+  return page.evaluate(function readSortColumnsState(t: string) {
+    const raw = localStorage.getItem('dms-sort-filter-state');
+    if (raw === null) {
+      return null;
+    }
+    const state = JSON.parse(raw);
+    return (
+      (state[t]?.sortColumns as { column: string; direction: string }[]) ?? null
+    );
+  }, table);
+}
+
+/**
+ * Helper: clear all sort/filter state from localStorage.
+ */
+async function clearSortState(page: Page): Promise<void> {
+  await page.evaluate(function removeSortState(): void {
+    localStorage.removeItem('dms-sort-filter-state');
+  });
+}
+
+// ─── Multi-Column Sort on Universe Screen ────────────────────────────────────
+
+test.describe('Universe Table - Multi-Column Sort', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await clearSortState(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('single click sets sole sort column (AC #1)', async ({ page }) => {
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
+  });
+
+  test('Shift+click appends secondary sort column (AC #2)', async ({
+    page,
+  }) => {
+    // Primary sort: Symbol asc
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    // Secondary sort: Risk Group asc (Shift+click)
+    const riskGroupHeader = page.getByRole('button', { name: 'Risk Group' });
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([
+      { column: 'symbol', direction: 'asc' },
+      { column: 'risk_group', direction: 'asc' },
+    ]);
+  });
+
+  test('rank indicators visible for multi-column sort (AC #3)', async ({
+    page,
+  }) => {
+    // Primary sort: Symbol
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    // Secondary sort: Risk Group
+    const riskGroupHeader = page.getByRole('button', { name: 'Risk Group' });
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    // Check rank indicators are visible
+    const rankIndicators = page.locator('[data-testid="sort-rank"]');
+    await expect(rankIndicators).toHaveCount(2);
+  });
+
+  test('Shift+click toggles existing column direction (AC #4)', async ({
+    page,
+  }) => {
+    // Primary sort: Symbol asc
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    // Secondary sort: Risk Group asc
+    const riskGroupHeader = page.getByRole('button', { name: 'Risk Group' });
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    // Shift+click Risk Group again → toggle to desc
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([
+      { column: 'symbol', direction: 'asc' },
+      { column: 'risk_group', direction: 'desc' },
+    ]);
+  });
+
+  test('Shift+click removes column when already desc (AC #4)', async ({
+    page,
+  }) => {
+    // Primary sort: Symbol asc
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    // Secondary sort: Risk Group asc
+    const riskGroupHeader = page.getByRole('button', { name: 'Risk Group' });
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    // Shift+click Risk Group → desc
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    // Shift+click Risk Group again → remove
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
+  });
+
+  test('non-shift click clears secondary sort (AC #1 regression)', async ({
+    page,
+  }) => {
+    // Set up multi-column sort: Symbol + Risk Group
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    const riskGroupHeader = page.getByRole('button', { name: 'Risk Group' });
+    await riskGroupHeader.click({ modifiers: ['Shift'] });
+    await page.waitForTimeout(300);
+
+    // Non-shift click on Symbol → should reset to single sort
+    await symbolHeader.click();
+    await page.waitForTimeout(300);
+
+    // MatSort will cycle: was asc → now desc for Symbol
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toHaveLength(1);
+  });
+});

--- a/apps/dms-material-e2e/src/server-side-sorting.spec.ts
+++ b/apps/dms-material-e2e/src/server-side-sorting.spec.ts
@@ -53,6 +53,25 @@ async function getSortState(
 }
 
 /**
+ * Helper: read sortColumns state from localStorage.
+ */
+async function getSortColumnsState(
+  page: Page,
+  table: string
+): Promise<{ column: string; direction: string }[] | null> {
+  return page.evaluate(function readSortColumnsState(t: string) {
+    const raw = localStorage.getItem('dms-sort-filter-state');
+    if (raw === null) {
+      return null;
+    }
+    const state = JSON.parse(raw);
+    return (
+      (state[t]?.sortColumns as { column: string; direction: string }[]) ?? null
+    );
+  }, table);
+}
+
+/**
  * Helper: clear sort state from localStorage.
  */
 async function clearSortState(page: Page): Promise<void> {
@@ -93,11 +112,10 @@ test.describe('Universe Table - Server-Side Sorting', () => {
     await symbolHeader.click();
     await page.waitForTimeout(300);
 
-    // Verify sort state was saved to localStorage
-    const state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('symbol');
-    expect(state!.order).toBe('asc');
+    // Verify sort state was saved to localStorage as sortColumns
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
   });
 
   test('should toggle sort direction on second click', async ({ page }) => {
@@ -106,14 +124,14 @@ test.describe('Universe Table - Server-Side Sorting', () => {
     // First click → asc
     await symbolHeader.click();
     await page.waitForTimeout(300);
-    let state = await getSortState(page, 'universes');
-    expect(state!.order).toBe('asc');
+    let cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
 
     // Second click → desc
     await symbolHeader.click();
     await page.waitForTimeout(300);
-    state = await getSortState(page, 'universes');
-    expect(state!.order).toBe('desc');
+    cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toEqual([{ column: 'symbol', direction: 'desc' }]);
   });
 
   test('should save sort state to localStorage on sort click', async ({
@@ -123,10 +141,9 @@ test.describe('Universe Table - Server-Side Sorting', () => {
     await symbolHeader.click();
     await page.waitForTimeout(500);
 
-    const state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('symbol');
-    expect(state!.order).toBe('asc');
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
   });
 
   test('should send sort params for Risk Group column', async ({ page }) => {
@@ -135,10 +152,9 @@ test.describe('Universe Table - Server-Side Sorting', () => {
     await page.waitForTimeout(300);
 
     // Verify sort state was saved
-    const state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('risk_group');
-    expect(state!.order).toBe('asc');
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols).toEqual([{ column: 'risk_group', direction: 'asc' }]);
   });
 
   test('should update localStorage sort state when column is clicked', async ({
@@ -147,17 +163,17 @@ test.describe('Universe Table - Server-Side Sorting', () => {
     const symbolHeader = page.getByRole('button', { name: 'Symbol' });
 
     // Before sorting, verify no sort state
-    let state = await getSortState(page, 'universes');
-    expect(state).toBeNull();
+    let cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toBeNull();
 
     // Click to sort
     await symbolHeader.click();
     await page.waitForTimeout(300);
 
     // After sorting, verify state changed
-    state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('symbol');
+    cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols![0].column).toBe('symbol');
   });
 });
 
@@ -179,19 +195,18 @@ test.describe('Universe Sort Persistence', () => {
     await page.waitForTimeout(500);
 
     // Confirm state is saved
-    let state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('symbol');
+    let cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols![0].column).toBe('symbol');
 
     // Refresh the page
     await page.reload();
     await page.waitForLoadState('networkidle');
 
     // Verify sort state persisted after refresh
-    state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('symbol');
-    expect(state!.order).toBe('asc');
+    cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols).toEqual([{ column: 'symbol', direction: 'asc' }]);
   });
 
   test('should persist sort state across navigation', async ({ page }) => {
@@ -204,8 +219,8 @@ test.describe('Universe Sort Persistence', () => {
     await page.waitForTimeout(500);
 
     // Confirm state is saved
-    let state = await getSortState(page, 'universes');
-    expect(state!.field).toBe('risk_group');
+    let cols = await getSortColumnsState(page, 'universes');
+    expect(cols![0].column).toBe('risk_group');
 
     // Navigate away to a different page
     await page.goto(`/account/${ACCOUNT_UUID}/open`);
@@ -216,10 +231,9 @@ test.describe('Universe Sort Persistence', () => {
     await page.waitForLoadState('networkidle');
 
     // Verify sort state persisted
-    state = await getSortState(page, 'universes');
-    expect(state).not.toBeNull();
-    expect(state!.field).toBe('risk_group');
-    expect(state!.order).toBe('asc');
+    cols = await getSortColumnsState(page, 'universes');
+    expect(cols).not.toBeNull();
+    expect(cols).toEqual([{ column: 'risk_group', direction: 'asc' }]);
   });
 });
 
@@ -409,7 +423,7 @@ test.describe('Cross-Table Sort Independence', () => {
     await page.waitForTimeout(300);
 
     // Verify sort state was cleared from localStorage
-    const state = await getSortState(page, 'universes');
-    expect(state).toBeNull();
+    const cols = await getSortColumnsState(page, 'universes');
+    expect(cols).toBeNull();
   });
 });

--- a/apps/dms-material/src/app/global/global-universe/build-shift-sort-columns.function.ts
+++ b/apps/dms-material/src/app/global/global-universe/build-shift-sort-columns.function.ts
@@ -1,0 +1,22 @@
+import { SortColumn } from '../../shared/services/sort-column.interface';
+
+export function buildShiftSortColumns(
+  current: SortColumn[],
+  column: string,
+  direction: 'asc' | 'desc'
+): SortColumn[] {
+  const idx = current.findIndex(function matchColumn(sc) {
+    return sc.column === column;
+  });
+  if (idx === -1) {
+    return [...current, { column, direction }];
+  }
+  if (current[idx].direction === 'asc') {
+    const updated = [...current];
+    updated[idx] = { column, direction: 'desc' };
+    return updated;
+  }
+  return current.filter(function excludeColumn(sc) {
+    return sc.column !== column;
+  });
+}

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -91,6 +91,7 @@
     <dms-base-table
       [data]="filteredData$()"
       [columns]="columns"
+      [sortColumns]="sortColumns$()"
       [selectable]="false"
       [rowHeight]="48"
       tableLabel="Universe positions"

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
@@ -2320,25 +2320,27 @@ describe('GlobalUniverseComponent - Ex-Date Editing Enhancements (TDD - Story AN
 
     it('should save sort state to SortFilterStateService when user changes sort', () => {
       const sortFilterStateService = TestBed.inject(SortFilterStateService);
-      const saveSpy = vi.spyOn(sortFilterStateService, 'saveSortState');
+      const saveSpy = vi.spyOn(sortFilterStateService, 'saveSortColumnsState');
       component.onSortChange({ active: 'symbol', direction: 'asc' });
-      expect(saveSpy).toHaveBeenCalledWith('universes', {
-        field: 'symbol',
-        order: 'asc',
-      });
+      expect(saveSpy).toHaveBeenCalledWith('universes', [
+        { column: 'symbol', direction: 'asc' },
+      ]);
     });
 
     it('should persist sort state when sort changes', () => {
       const sortFilterStateService = TestBed.inject(SortFilterStateService);
       component.onSortChange({ active: 'distribution', direction: 'desc' });
-      const state = sortFilterStateService.loadSortState('universes');
-      expect(state).toEqual({ field: 'distribution', order: 'desc' });
+      const state = sortFilterStateService.loadSortColumnsState('universes');
+      expect(state).toEqual([{ column: 'distribution', direction: 'desc' }]);
     });
 
     it('should clear sort state when sort direction is reset', () => {
       // When direction is empty string (sort cleared), clear sort state
       const sortFilterStateService = TestBed.inject(SortFilterStateService);
-      const clearSpy = vi.spyOn(sortFilterStateService, 'clearSortState');
+      const clearSpy = vi.spyOn(
+        sortFilterStateService,
+        'clearSortColumnsState'
+      );
       component.onSortChange({ active: 'symbol', direction: '' });
       expect(clearSpy).toHaveBeenCalledWith('universes');
     });
@@ -2430,15 +2432,14 @@ describe('GlobalUniverseComponent - Client-Side Sorting Removal', () => {
 
     it('should trigger HTTP call on sort change instead of local sorting', () => {
       const sortFilterStateService = TestBed.inject(SortFilterStateService);
-      const saveSpy = vi.spyOn(sortFilterStateService, 'saveSortState');
+      const saveSpy = vi.spyOn(sortFilterStateService, 'saveSortColumnsState');
 
       component.onSortChange({ active: 'symbol', direction: 'asc' });
 
       // Sort change should delegate to SortFilterStateService (which triggers HTTP via interceptor)
-      expect(saveSpy).toHaveBeenCalledWith('universes', {
-        field: 'symbol',
-        order: 'asc',
-      });
+      expect(saveSpy).toHaveBeenCalledWith('universes', [
+        { column: 'symbol', direction: 'asc' },
+      ]);
 
       // Component should NOT have any local sort logic that reorders filteredData$
       expect(

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -7,6 +7,7 @@ import {
   OnDestroy,
   output,
   signal,
+  viewChild,
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
@@ -28,17 +29,18 @@ import { EditableDateCellComponent } from '../../shared/components/editable-date
 import { ErrorHandlingService } from '../../shared/services/error-handling.service';
 import { GlobalLoadingService } from '../../shared/services/global-loading.service';
 import { NotificationService } from '../../shared/services/notification.service';
+import { SortColumn } from '../../shared/services/sort-column.interface';
 import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { UniverseSyncService } from '../../shared/services/universe-sync.service';
 import { UpdateUniverseFieldsService } from '../../shared/services/update-universe-fields.service';
 import { selectAccounts } from '../../store/accounts/selectors/select-accounts.function';
 import { selectRiskGroup } from '../../store/risk-group/selectors/select-risk-group.function';
-import { selectUniverses } from '../../store/universe/selectors/select-universes.function';
 import { Universe } from '../../store/universe/universe.interface';
 import { AddSymbolDialogComponent } from '../../universe-settings/add-symbol-dialog/add-symbol-dialog';
 import { ScreenerService } from '../global-screener/services/screener.service';
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component';
 import { ImportDialogResult } from '../import-dialog/import-dialog-result.interface';
+import { buildShiftSortColumns } from './build-shift-sort-columns.function';
 import { calculateYieldPercent } from './calculate-yield-percent.function';
 import { CellEditEvent } from './cell-edit-event.interface';
 import { enrichUniverseWithRiskGroups } from './enrich-universe-with-risk-groups.function';
@@ -46,6 +48,7 @@ import { filterUniverses } from './filter-universes.function';
 import { formatPosition } from './format-position.function';
 import { UNIVERSE_COLUMNS } from './global-universe.columns';
 import { EXPIRED_OPTIONS } from './global-universe.expired-options';
+import { handleCellEdit } from './handle-cell-edit.function';
 import { parseYieldValue } from './parse-yield-value.function';
 import { saveUniverseFiltersAndNotify } from './save-universe-filters-and-notify.function';
 import { UniverseService } from './services/universe.service';
@@ -93,8 +96,13 @@ export class GlobalUniverseComponent implements OnDestroy {
   readonly expiredFilter$ = signal<boolean | null>(null);
   readonly selectedAccountId$ = signal<string>('all');
   readonly minYieldFilter$ = signal<number | null>(null);
+  readonly sortColumns$ = signal<SortColumn[]>(
+    this.sortFilterStateService.loadSortColumnsState('universes') ?? []
+  );
+
   private readonly localSyncInProgress$ = signal<boolean>(false);
   private textFilterTimer?: ReturnType<typeof setTimeout>;
+  private readonly baseTable = viewChild(BaseTableComponent);
 
   ngOnDestroy(): void {
     clearTimeout(this.textFilterTimer);
@@ -163,14 +171,19 @@ export class GlobalUniverseComponent implements OnDestroy {
   });
 
   onSortChange(sort: Sort): void {
-    if (sort.direction === '') {
-      this.sortFilterStateService.clearSortState('universes');
-    } else {
-      this.sortFilterStateService.saveSortState('universes', {
-        field: sort.active,
-        order: sort.direction,
-      });
+    const shiftKey = this.baseTable()?.getLastShiftKey() ?? false;
+    if (sort.direction === '' && !shiftKey) {
+      this.sortColumns$.set([]);
+      this.sortFilterStateService.clearSortColumnsState('universes');
+      handleSocketNotification('top', 'update', ['1']);
+      return;
     }
+    const direction = sort.direction as 'asc' | 'desc';
+    const newColumns = shiftKey
+      ? buildShiftSortColumns(this.sortColumns$(), sort.active, direction)
+      : [{ column: sort.active, direction }];
+    this.sortColumns$.set(newColumns);
+    this.sortFilterStateService.saveSortColumnsState('universes', newColumns);
     handleSocketNotification('top', 'update', ['1']);
   }
 
@@ -226,16 +239,10 @@ export class GlobalUniverseComponent implements OnDestroy {
   }
 
   showAddSymbolDialog(): void {
-    const dialogRef = this.dialog.open(AddSymbolDialogComponent, {
+    this.dialog.open(AddSymbolDialogComponent, {
       width: '400px',
       disableClose: false,
       autoFocus: 'dialog',
-    });
-
-    dialogRef.afterClosed().subscribe({
-      next: function onDialogClosed() {
-        // Table will automatically update via signals
-      },
     });
   }
 
@@ -272,30 +279,10 @@ export class GlobalUniverseComponent implements OnDestroy {
   }
 
   onCellEdit(row: Universe, field: keyof Universe, value: unknown): void {
-    // Transform value based on field type before validation
-    let transformedValue = value;
-    if (field === 'ex_date') {
-      transformedValue = this.validationService.transformExDateValue(value);
-    }
-
-    if (!this.validationService.validateFieldValue(field, transformedValue)) {
-      return;
-    }
-
-    // Find the actual universe object in the SmartNgRX store and update it
-    // This triggers SmartNgRX to automatically save the changes
-    const universes = selectUniverses();
-    for (let i = 0; i < universes.length; i++) {
-      if (universes[i].id === row.id) {
-        // Update the field directly on the SmartNgRX managed object
-        (universes[i] as unknown as Record<string, unknown>)[field] =
-          transformedValue;
-        break;
-      }
-    }
-
-    // Emit event for any listeners (optional, for compatibility)
-    this.cellEdit.emit({ row, field, value: transformedValue });
+    handleCellEdit(row, field, value, {
+      validationService: this.validationService,
+      emitCellEdit: this.cellEdit.emit.bind(this.cellEdit),
+    });
   }
 
   onSymbolFilterChange(value: string): void {

--- a/apps/dms-material/src/app/global/global-universe/handle-cell-edit.function.ts
+++ b/apps/dms-material/src/app/global/global-universe/handle-cell-edit.function.ts
@@ -1,0 +1,36 @@
+import { selectUniverses } from '../../store/universe/selectors/select-universes.function';
+import { Universe } from '../../store/universe/universe.interface';
+import { CellEditEvent } from './cell-edit-event.interface';
+import { UniverseValidationService } from './services/universe-validation.service';
+
+interface CellEditDeps {
+  validationService: UniverseValidationService;
+  emitCellEdit(event: CellEditEvent): void;
+}
+
+export function handleCellEdit(
+  row: Universe,
+  field: keyof Universe,
+  value: unknown,
+  deps: CellEditDeps
+): void {
+  let transformedValue = value;
+  if (field === 'ex_date') {
+    transformedValue = deps.validationService.transformExDateValue(value);
+  }
+
+  if (!deps.validationService.validateFieldValue(field, transformedValue)) {
+    return;
+  }
+
+  const universes = selectUniverses();
+  for (let i = 0; i < universes.length; i++) {
+    if (universes[i].id === row.id) {
+      (universes[i] as unknown as Record<string, unknown>)[field] =
+        transformedValue;
+      break;
+    }
+  }
+
+  deps.emitCellEdit({ row, field, value: transformedValue });
+}

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.html
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.html
@@ -59,6 +59,11 @@
           [style.width]="column.width"
         >
           {{ column.header }}
+          @if (sortRankMap()[column.field]) {
+          <span class="sort-rank-indicator" data-testid="sort-rank">{{
+            sortRankMap()[column.field]
+          }}</span>
+          }
         </th>
         <td mat-cell *matCellDef="let row; let i = index">
           <ng-container

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
@@ -100,6 +100,12 @@ th.mat-mdc-header-cell {
   // a border-bottom on a sticky th disappears during scroll; box-shadow persists
   box-shadow: 0 1px 0 0
     color-mix(in srgb, var(--dms-text-primary) 12%, transparent);
+
+  .sort-rank-indicator {
+    font-size: 0.75em;
+    margin-left: 2px;
+    opacity: 0.8;
+  }
 }
 
 tr.filter-row th.mat-mdc-header-cell {

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.ts
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.ts
@@ -13,6 +13,7 @@ import {
   ContentChild,
   DestroyRef,
   effect,
+  ElementRef,
   inject,
   input,
   output,
@@ -27,6 +28,7 @@ import { MatSortModule, Sort } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { debounceTime } from 'rxjs';
 
+import { SortColumn } from '../../services/sort-column.interface';
 import { ColumnDef } from './column-def.interface';
 
 @Component({
@@ -46,6 +48,19 @@ import { ColumnDef } from './column-def.interface';
 export class BaseTableComponent<T extends { id: string }>
   implements AfterViewInit
 {
+  private static readonly superscripts = [
+    '',
+    '\u00B9',
+    '\u00B2',
+    '\u00B3',
+    '\u2074',
+    '\u2075',
+    '\u2076',
+    '\u2077',
+    '\u2078',
+    '\u2079',
+  ];
+
   // Inputs
   data = input.required<T[]>(); // Signal-based data input
   columns = input.required<ColumnDef[]>();
@@ -55,6 +70,7 @@ export class BaseTableComponent<T extends { id: string }>
   selectable = input<boolean>(false);
   multiSelect = input<boolean>(false);
   loading = input<boolean>(false);
+  sortColumns = input<SortColumn[]>([]);
 
   // Outputs
   readonly sortChange = output<Sort>();
@@ -70,8 +86,37 @@ export class BaseTableComponent<T extends { id: string }>
   private sortState = signal<Sort | null>(null);
   private cdr = inject(ChangeDetectorRef);
   private destroyRef = inject(DestroyRef);
+  private lastShiftKey = false;
+
+  // eslint-disable-next-line @smarttools/no-anonymous-functions -- Required for computed signal
+  readonly sortRankMap = computed(() => {
+    const columns = this.sortColumns();
+    const map: Record<string, string> = {};
+    for (let i = 0; i < columns.length; i++) {
+      const rank = i + 1;
+      const sup =
+        rank < BaseTableComponent.superscripts.length
+          ? BaseTableComponent.superscripts[rank]
+          : String(rank);
+      const arrow = columns[i].direction === 'asc' ? '\u2191' : '\u2193';
+      map[columns[i].column] = sup + arrow;
+    }
+    return map;
+  });
 
   constructor() {
+    const el = inject(ElementRef).nativeElement as HTMLElement;
+    const self = this;
+
+    function captureShiftKey(event: MouseEvent): void {
+      self.lastShiftKey = event.shiftKey;
+    }
+
+    el.addEventListener('click', captureShiftKey, true);
+    this.destroyRef.onDestroy(function removeShiftListener() {
+      el.removeEventListener('click', captureShiftKey, true);
+    });
+
     // Force change detection when dataSource changes
     // This ensures MatTable and virtual scroll viewport update properly
     effect(
@@ -172,6 +217,12 @@ export class BaseTableComponent<T extends { id: string }>
 
   @ContentChild('cellTemplate') cellTemplate?: TemplateRef<unknown>;
   @ContentChild('filterRowTemplate') filterRowTemplate?: TemplateRef<unknown>;
+
+  getLastShiftKey(): boolean {
+    const value = this.lastShiftKey;
+    this.lastShiftKey = false;
+    return value;
+  }
 
   onSort(sort: Sort): void {
     this.sortState.set(sort);

--- a/apps/dms-material/src/app/shared/services/sort-filter-state.service.spec.ts
+++ b/apps/dms-material/src/app/shared/services/sort-filter-state.service.spec.ts
@@ -247,6 +247,114 @@ describe('SortFilterStateService', () => {
     });
   });
 
+  describe('saveSortColumnsState', () => {
+    it('should save sortColumns and remove legacy sort', () => {
+      mockGetItem.mockReturnValue(
+        JSON.stringify({
+          universes: { sort: { field: 'symbol', order: 'asc' } },
+        })
+      );
+
+      service.saveSortColumnsState('universes', [
+        { column: 'symbol', direction: 'asc' },
+      ]);
+
+      const saved = JSON.parse(mockSetItem.mock.calls[0][1]);
+      expect(saved.universes.sortColumns).toEqual([
+        { column: 'symbol', direction: 'asc' },
+      ]);
+      expect(saved.universes.sort).toBeUndefined();
+    });
+
+    it('should create table entry if none exists', () => {
+      mockGetItem.mockReturnValue(null);
+
+      service.saveSortColumnsState('universes', [
+        { column: 'price', direction: 'desc' },
+      ]);
+
+      const saved = JSON.parse(mockSetItem.mock.calls[0][1]);
+      expect(saved.universes.sortColumns).toEqual([
+        { column: 'price', direction: 'desc' },
+      ]);
+    });
+  });
+
+  describe('loadSortColumnsState', () => {
+    it('should return sortColumns when present', () => {
+      mockGetItem.mockReturnValue(
+        JSON.stringify({
+          universes: {
+            sortColumns: [{ column: 'symbol', direction: 'asc' }],
+          },
+        })
+      );
+
+      const result = service.loadSortColumnsState('universes');
+      expect(result).toEqual([{ column: 'symbol', direction: 'asc' }]);
+    });
+
+    it('should return null when no sortColumns exist', () => {
+      mockGetItem.mockReturnValue(JSON.stringify({ universes: {} }));
+
+      const result = service.loadSortColumnsState('universes');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when table has no entry', () => {
+      mockGetItem.mockReturnValue(null);
+
+      const result = service.loadSortColumnsState('universes');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('clearSortColumnsState', () => {
+    it('should remove sortColumns and sort, delete table entry when no filters', () => {
+      mockGetItem.mockReturnValue(
+        JSON.stringify({
+          universes: {
+            sortColumns: [{ column: 'symbol', direction: 'asc' }],
+            sort: { field: 'symbol', order: 'asc' },
+          },
+        })
+      );
+
+      service.clearSortColumnsState('universes');
+
+      expect(mockRemoveItem).toHaveBeenCalledWith(STORAGE_KEY);
+    });
+
+    it('should preserve filters when clearing sort columns', () => {
+      mockGetItem.mockReturnValue(
+        JSON.stringify({
+          universes: {
+            sortColumns: [{ column: 'symbol', direction: 'asc' }],
+            filters: { symbol: 'AAPL' },
+          },
+        })
+      );
+
+      service.clearSortColumnsState('universes');
+
+      const saved = JSON.parse(mockSetItem.mock.calls[0][1]);
+      expect(saved.universes.filters).toEqual({ symbol: 'AAPL' });
+      expect(saved.universes.sortColumns).toBeUndefined();
+      expect(saved.universes.sort).toBeUndefined();
+    });
+
+    it('should save state unchanged when table has no entry', () => {
+      mockGetItem.mockReturnValue(
+        JSON.stringify({ other: { sort: { field: 'a', order: 'asc' } } })
+      );
+
+      service.clearSortColumnsState('nonexistent');
+
+      const saved = JSON.parse(mockSetItem.mock.calls[0][1]);
+      expect(saved.nonexistent).toBeUndefined();
+    });
+  });
+
   describe('filter state', () => {
     it('should save filter state to localStorage', () => {
       mockGetItem.mockReturnValue(null);

--- a/apps/dms-material/src/app/shared/services/sort-filter-state.service.ts
+++ b/apps/dms-material/src/app/shared/services/sort-filter-state.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 
 import { FilterConfig } from './filter-config.interface';
+import { SortColumn } from './sort-column.interface';
 import { SortConfig } from './sort-config.interface';
 import { TableState } from './table-state.interface';
 
@@ -17,15 +18,43 @@ export class SortFilterStateService {
     localStorage.setItem(this.storageKey, JSON.stringify(state));
   }
 
+  saveSortColumnsState(table: string, columns: SortColumn[]): void {
+    const state = this.loadAllState();
+    if (state[table] === undefined) {
+      state[table] = {};
+    }
+    state[table].sortColumns = columns;
+    delete state[table].sort;
+    localStorage.setItem(this.storageKey, JSON.stringify(state));
+  }
+
   loadSortState(table: string): SortConfig | null {
     const state = this.loadAllState();
     return state[table]?.sort ?? null;
+  }
+
+  loadSortColumnsState(table: string): SortColumn[] | null {
+    const state = this.loadAllState();
+    return state[table]?.sortColumns ?? null;
   }
 
   clearSortState(table: string): void {
     const state = this.loadAllState();
     if (state[table] !== undefined) {
       state[table] = { filters: state[table].filters };
+      if (state[table].filters === undefined) {
+        this.saveState(this.removeTableEntry(state, table));
+        return;
+      }
+    }
+    this.saveState(state);
+  }
+
+  clearSortColumnsState(table: string): void {
+    const state = this.loadAllState();
+    if (state[table] !== undefined) {
+      delete state[table].sortColumns;
+      delete state[table].sort;
       if (state[table].filters === undefined) {
         this.saveState(this.removeTableEntry(state, table));
         return;


### PR DESCRIPTION
## Story 24.3: Implement Multi-Column Sort UI on Universe Screen

Closes #810

### Changes

**BaseTableComponent:**
- Added `sortColumns` input and `sortRankMap` computed signal for rank indicators (¹↑, ²↓, etc.)
- Added shift-key detection via capturing-phase click listener on host element
- Added `getLastShiftKey()` method for parent components to read shift state
- Added sort rank indicator markup and styles in template

**GlobalUniverseComponent:**
- Rewrote `onSortChange()` to support multi-column sort via Shift+click
- Normal click replaces sort state (single column) — existing behavior preserved
- Shift+click appends, toggles, or removes sort columns
- State persisted via `saveSortColumnsState`/`clearSortColumnsState`
- Extracted `buildShiftSortColumns` function for sort accumulation logic
- Extracted `handleCellEdit` function to reduce file size below 300 lines

**SortFilterStateService:**
- Added `saveSortColumnsState()`, `loadSortColumnsState()`, `clearSortColumnsState()`
- New methods use `sortColumns` array format; `saveSortColumnsState` also cleans up legacy `sort`

**E2E Tests:**
- Updated existing Universe sort tests to use `sortColumns` format
- Added `multi-column-sort.spec.ts` covering all acceptance criteria

### Quality Gates
- ✅ `pnpm all` (lint + build + test with 100% coverage)
- ✅ `pnpm dupcheck` (0.08%)
- ✅ `pnpm format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-column sorting now available: Single-click sets primary sort; shift+click adds or modifies secondary sort columns
  * Sort rank indicators display in column headers, showing the priority order of multi-column sorts

* **Tests**
  * Added end-to-end tests for multi-column sorting behavior, including shift-click interactions and sort state persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->