### PR TITLE
feat(filters): restore filter UI state from saved localStorage on init

### DIFF
--- a/apps/dms-material-e2e/src/filter-persistence.spec.ts
+++ b/apps/dms-material-e2e/src/filter-persistence.spec.ts
@@ -1,0 +1,68 @@
+import { expect, Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+
+const ACCOUNT_UUID = '1677e04f-ef9b-4372-adb3-b740443088dc';
+
+/**
+ * Helper: read filter state from localStorage.
+ */
+async function getFilterState(
+  page: Page,
+  table: string
+): Promise<Record<string, unknown> | null> {
+  return page.evaluate(function readFilterState(t: string) {
+    const raw = localStorage.getItem('dms-sort-filter-state');
+    if (raw === null) {
+      return null;
+    }
+    const state = JSON.parse(raw);
+    return (state[t]?.filters as Record<string, unknown>) ?? null;
+  }, table);
+}
+
+/**
+ * Helper: clear all sort/filter state from localStorage.
+ */
+async function clearState(page: Page): Promise<void> {
+  await page.evaluate(function removeState(): void {
+    localStorage.removeItem('dms-sort-filter-state');
+  });
+}
+
+test.describe('Universe Filter Persistence', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await clearState(page);
+  });
+
+  test('should restore symbol filter input on page load from saved state', async ({
+    page,
+  }) => {
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+
+    // Type in the Symbol filter input
+    const symbolInput = page.getByPlaceholder('Search Symbol');
+    await symbolInput.fill('XYZ');
+    // Wait for debounced save (300ms) plus a buffer
+    await page.waitForTimeout(600);
+
+    // Verify filter was saved to localStorage
+    const filters = await getFilterState(page, 'universes');
+    expect(filters).not.toBeNull();
+    expect(filters!['symbol']).toBe('XYZ');
+
+    // Navigate away
+    await page.goto(`/account/${ACCOUNT_UUID}/open`);
+    await page.waitForLoadState('networkidle');
+
+    // Navigate back to universe
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+
+    // Verify filter input is restored
+    const restoredInput = page.getByPlaceholder('Search Symbol');
+    await expect(restoredInput).toHaveValue('XYZ');
+  });
+});

--- a/apps/dms-material/src/app/global/global-screener/global-screener.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-screener/global-screener.component.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 
 import { NotificationService } from '../../shared/services/notification.service';
 import { GlobalLoadingService } from '../../shared/services/global-loading.service';
+import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { Screen } from '../../store/screen/screen.interface';
 import { GlobalScreenerComponent } from './global-screener.component';
 import { ScreenerService } from './services/screener.service';
@@ -575,5 +576,66 @@ describe('GlobalScreenerComponent', () => {
       filtered = component.filteredData$();
       expect(filtered.length).toBe(2);
     });
+  });
+});
+
+describe('GlobalScreenerComponent - Filter State Restoration', () => {
+  let mockLoadFilterState: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    mockLoadFilterState = vi.fn().mockReturnValue(null);
+
+    await TestBed.configureTestingModule({
+      imports: [GlobalScreenerComponent],
+      providers: [
+        {
+          provide: SortFilterStateService,
+          useValue: {
+            loadFilterState: mockLoadFilterState,
+            saveFilterState: vi.fn(),
+            clearFilterState: vi.fn(),
+            saveSortState: vi.fn(),
+            clearSortState: vi.fn(),
+          },
+        },
+        {
+          provide: ScreenerService,
+          useValue: {
+            refresh: vi.fn().mockReturnValue(of(null)),
+            error: vi.fn().mockReturnValue(null),
+            screens: vi.fn().mockReturnValue([]),
+            updateScreener: vi.fn(),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: { show: vi.fn() },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should restore risk group filter from saved state', () => {
+    mockLoadFilterState.mockReturnValue({ risk_group: 'Income' });
+    const fixture = TestBed.createComponent(GlobalScreenerComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.riskGroupFilter$()).toBe('Income');
+  });
+
+  it('should default to null when no saved filter state exists', () => {
+    mockLoadFilterState.mockReturnValue(null);
+    const fixture = TestBed.createComponent(GlobalScreenerComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.riskGroupFilter$()).toBeNull();
+  });
+
+  it('should silently ignore unknown filter keys', () => {
+    mockLoadFilterState.mockReturnValue({ unknown_key: 'test' });
+    const fixture = TestBed.createComponent(GlobalScreenerComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.riskGroupFilter$()).toBeNull();
   });
 });

--- a/apps/dms-material/src/app/global/global-screener/global-screener.component.ts
+++ b/apps/dms-material/src/app/global/global-screener/global-screener.component.ts
@@ -67,7 +67,14 @@ export class GlobalScreenerComponent {
   readonly cellEdit = output<ScreenCellEditEvent>();
   readonly error = this.screenerService.error;
 
-  readonly riskGroupFilter$ = signal<string | null>(null);
+  private readonly savedFilters =
+    this.sortFilterStateService.loadFilterState('screens');
+
+  readonly riskGroupFilter$ = signal<string | null>(
+    typeof this.savedFilters?.['risk_group'] === 'string'
+      ? this.savedFilters['risk_group']
+      : null
+  );
 
   readonly columns: ColumnDef[] = [
     { field: 'symbol', header: 'Symbol', sortable: true, width: '100px' },

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
@@ -1071,6 +1071,7 @@ describe('GlobalUniverseComponent - SmartNgRX Integration', () => {
   };
 
   beforeEach(async () => {
+    localStorage.clear();
     // Get reference to the mocked selector
     const { selectUniverses } = await import(
       '../../store/universe/selectors/select-universes.function'
@@ -1323,6 +1324,7 @@ describe('Universe Selectors', () => {
   };
 
   beforeEach(async () => {
+    localStorage.clear();
     // Get reference to the mocked selector
     const { selectUniverses } = await import(
       '../../store/universe/selectors/select-universes.function'
@@ -2535,5 +2537,88 @@ describe('GlobalUniverseComponent - Sort State Restoration on Init', () => {
     const component = fixture.componentInstance;
 
     expect(component.sortColumns$()).toEqual([]);
+  });
+});
+
+describe('GlobalUniverseComponent - Filter State Restoration', () => {
+  let mockLoadFilterState: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    mockLoadFilterState = vi.fn().mockReturnValue(null);
+
+    await TestBed.configureTestingModule({
+      imports: [GlobalUniverseComponent],
+      providers: [
+        provideSmartNgRX(),
+        {
+          provide: SortFilterStateService,
+          useValue: {
+            loadFilterState: mockLoadFilterState,
+            loadSortColumnsState: vi.fn().mockReturnValue(null),
+            saveFilterState: vi.fn(),
+            clearFilterState: vi.fn(),
+            saveSortColumnsState: vi.fn(),
+            clearSortColumnsState: vi.fn(),
+          },
+        },
+        {
+          provide: UniverseSyncService,
+          useValue: {
+            syncFromScreener: vi.fn().mockReturnValue(of({})),
+            isSyncing: vi.fn().mockReturnValue(false),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: { success: vi.fn(), showPersistent: vi.fn() },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('should restore all filter values from saved state', () => {
+    mockLoadFilterState.mockReturnValue({
+      symbol: 'AAPL',
+      risk_group: 'Equities',
+      expired: true,
+      min_yield: 5.5,
+      account_id: 'acc-1',
+    });
+    const fixture = TestBed.createComponent(GlobalUniverseComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.symbolFilter$()).toBe('AAPL');
+    expect(component.riskGroupFilter$()).toBe('Equities');
+    expect(component.expiredFilter$()).toBe(true);
+    expect(component.minYieldFilter$()).toBe(5.5);
+    expect(component.selectedAccountId$()).toBe('acc-1');
+  });
+
+  it('should use defaults when no saved filter state exists', () => {
+    mockLoadFilterState.mockReturnValue(null);
+    const fixture = TestBed.createComponent(GlobalUniverseComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.symbolFilter$()).toBe('');
+    expect(component.riskGroupFilter$()).toBeNull();
+    expect(component.expiredFilter$()).toBeNull();
+    expect(component.selectedAccountId$()).toBe('all');
+    expect(component.minYieldFilter$()).toBeNull();
+  });
+
+  it('should silently ignore unknown filter keys', () => {
+    mockLoadFilterState.mockReturnValue({
+      symbol: 'AAPL',
+      unknown_key: 'test',
+      another_unknown: 42,
+    });
+    const fixture = TestBed.createComponent(GlobalUniverseComponent);
+    const component = fixture.componentInstance;
+
+    expect(component.symbolFilter$()).toBe('AAPL');
+    expect(component.riskGroupFilter$()).toBeNull();
+    expect(component.expiredFilter$()).toBeNull();
+    expect(component.minYieldFilter$()).toBeNull();
+    expect(component.selectedAccountId$()).toBe('all');
   });
 });

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -50,6 +50,7 @@ import { UNIVERSE_COLUMNS } from './global-universe.columns';
 import { EXPIRED_OPTIONS } from './global-universe.expired-options';
 import { handleCellEdit } from './handle-cell-edit.function';
 import { parseYieldValue } from './parse-yield-value.function';
+import { restoreUniverseFilters } from './restore-universe-filters.function';
 import { saveUniverseFiltersAndNotify } from './save-universe-filters-and-notify.function';
 import { UniverseService } from './services/universe.service';
 import { UniverseValidationService } from './services/universe-validation.service';
@@ -91,11 +92,15 @@ export class GlobalUniverseComponent implements OnDestroy {
   readonly cellEdit = output<CellEditEvent>();
   readonly symbolDeleted = output<Universe>();
   readonly today = new Date();
-  readonly symbolFilter$ = signal<string>('');
-  readonly riskGroupFilter$ = signal<string | null>(null);
-  readonly expiredFilter$ = signal<boolean | null>(null);
-  readonly selectedAccountId$ = signal<string>('all');
-  readonly minYieldFilter$ = signal<number | null>(null);
+  private readonly rf = restoreUniverseFilters(
+    this.sortFilterStateService.loadFilterState('universes')
+  );
+
+  readonly symbolFilter$ = signal<string>(this.rf.symbol);
+  readonly riskGroupFilter$ = signal<string | null>(this.rf.riskGroup);
+  readonly expiredFilter$ = signal<boolean | null>(this.rf.expired);
+  readonly selectedAccountId$ = signal<string>(this.rf.accountId);
+  readonly minYieldFilter$ = signal<number | null>(this.rf.minYield);
   readonly sortColumns$ = signal<SortColumn[]>(
     this.sortFilterStateService.loadSortColumnsState('universes') ?? []
   );

--- a/apps/dms-material/src/app/global/global-universe/restore-universe-filters.function.spec.ts
+++ b/apps/dms-material/src/app/global/global-universe/restore-universe-filters.function.spec.ts
@@ -1,0 +1,51 @@
+import { restoreUniverseFilters } from './restore-universe-filters.function';
+
+describe('restoreUniverseFilters', () => {
+  it('should return defaults when filters is null', () => {
+    const result = restoreUniverseFilters(null);
+
+    expect(result).toEqual({
+      symbol: '',
+      riskGroup: null,
+      expired: null,
+      accountId: 'all',
+      minYield: null,
+    });
+  });
+
+  it('should restore all filter values from saved state', () => {
+    const result = restoreUniverseFilters({
+      symbol: 'AAPL',
+      risk_group: 'Equities',
+      expired: true,
+      min_yield: 5.5,
+      account_id: 'acc-1',
+    });
+
+    expect(result.symbol).toBe('AAPL');
+    expect(result.riskGroup).toBe('Equities');
+    expect(result.expired).toBe(true);
+    expect(result.minYield).toBe(5.5);
+    expect(result.accountId).toBe('acc-1');
+  });
+
+  it('should silently ignore unknown filter keys', () => {
+    const result = restoreUniverseFilters({
+      symbol: 'MSFT',
+      unknown_key: 'ignored',
+    });
+
+    expect(result.symbol).toBe('MSFT');
+    expect(result.riskGroup).toBeNull();
+    expect(result.expired).toBeNull();
+    expect(result.accountId).toBe('all');
+    expect(result.minYield).toBeNull();
+  });
+
+  it('should handle empty filter config', () => {
+    const result = restoreUniverseFilters({});
+
+    expect(result.symbol).toBe('');
+    expect(result.riskGroup).toBeNull();
+  });
+});

--- a/apps/dms-material/src/app/global/global-universe/restore-universe-filters.function.ts
+++ b/apps/dms-material/src/app/global/global-universe/restore-universe-filters.function.ts
@@ -1,0 +1,30 @@
+import { FilterConfig } from '../../shared/services/filter-config.interface';
+
+interface RestoredUniverseFilters {
+  symbol: string;
+  riskGroup: string | null;
+  expired: boolean | null;
+  accountId: string;
+  minYield: number | null;
+}
+
+export function restoreUniverseFilters(
+  filters: FilterConfig | null
+): RestoredUniverseFilters {
+  if (filters === null) {
+    return {
+      symbol: '',
+      riskGroup: null,
+      expired: null,
+      accountId: 'all',
+      minYield: null,
+    };
+  }
+  return {
+    symbol: (filters['symbol'] as string) ?? '',
+    riskGroup: (filters['risk_group'] as string) ?? null,
+    expired: (filters['expired'] as boolean) ?? null,
+    accountId: (filters['account_id'] as string) ?? 'all',
+    minYield: (filters['min_yield'] as number) ?? null,
+  };
+}


### PR DESCRIPTION
## Story 25.2: Restore Filter UI State from Saved State

Closes #814

### Changes

**Universe Component (`global-universe.component.ts`):**
- Load saved filter state from `SortFilterStateService.loadFilterState('universes')` once during field initialization
- Initialize `symbolFilter$`, `riskGroupFilter$`, `expiredFilter$`, `selectedAccountId$`, and `minYieldFilter$` signals from the saved FilterConfig
- Unknown filter keys are silently ignored (AC #4)

**Screener Component (`global-screener.component.ts`):**
- Load saved filter state from `SortFilterStateService.loadFilterState('screens')`
- Initialize `riskGroupFilter$` signal from saved `risk_group` value

**Unit Tests:**
- Universe: 3 new tests — full filters restored, empty/null state defaults, unknown keys silently ignored
- Screener: 3 new tests — risk group restored, null default, unknown keys ignored
- Fixed test isolation by adding `localStorage.clear()` to 2 existing describe blocks that were affected by cross-test contamination

**E2E Test:**
- `filter-persistence.spec.ts`: Verifies filter round-trip — type "XYZ" in symbol filter, navigate away, navigate back, assert input value restored

### Quality Gates
- [x] `pnpm lint` — clean
- [x] `CI=1 pnpm all` — lint, build, test (100% coverage) pass
- [x] `pnpm dupcheck` — 0.08% (under 0.1% threshold)
- [x] `pnpm format` — applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filter settings (search term, risk group, expiration, min yield, account) persist across navigation and are restored when returning to filtered pages.

* **Tests**
  * Added end-to-end and unit tests covering filter persistence, restoration logic, and behavior with saved, missing, or unknown saved keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->