### PR TITLE
fix(tables): standardize virtual scroll row heights to match actual 52px

### DIFF
--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.html
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.html
@@ -1,7 +1,6 @@
 <dms-base-table
   [data]="dividends$()"
   [columns]="columns"
-  [rowHeight]="48"
   [bufferSize]="20"
   (sortChange)="onSortChange($event)"
   (rowClick)="onEditDividend($event)"

--- a/apps/dms-material/src/app/global/global-screener/global-screener.component.html
+++ b/apps/dms-material/src/app/global/global-screener/global-screener.component.html
@@ -36,7 +36,6 @@
       [data]="filteredData$()"
       [columns]="columns"
       [selectable]="false"
-      [rowHeight]="48"
       tableLabel="Screener positions"
       (sortChange)="onSortChange($event)"
     >

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -93,7 +93,6 @@
       [columns]="columns"
       [sortColumns]="sortColumns$()"
       [selectable]="false"
-      [rowHeight]="48"
       tableLabel="Universe positions"
       (sortChange)="onSortChange($event)"
     >

--- a/apps/dms-material/src/app/shared/components/base-table/QUICK-REFERENCE.md
+++ b/apps/dms-material/src/app/shared/components/base-table/QUICK-REFERENCE.md
@@ -26,7 +26,7 @@ export class MyComponent {
 | `data`        | `T[]`         | ✅ Yes   | -       | Array of table data (must be signal) |
 | `columns`     | `ColumnDef[]` | ✅ Yes   | -       | Column definitions                   |
 | `loading`     | `boolean`     | ❌ No    | `false` | Loading state indicator              |
-| `rowHeight`   | `number`      | ❌ No    | `48`    | Height of each row in pixels         |
+| `rowHeight`   | `number`      | ❌ No    | `52`    | Height of each row in pixels         |
 | `bufferSize`  | `number`      | ❌ No    | `10`    | Virtual scroll buffer size           |
 | `selectable`  | `boolean`     | ❌ No    | `false` | Enable row selection                 |
 | `multiSelect` | `boolean`     | ❌ No    | `false` | Allow multiple row selection         |

--- a/docs/row-height-audit.md
+++ b/docs/row-height-audit.md
@@ -1,0 +1,40 @@
+# Row Height Audit
+
+**Date:** 2026-03-29
+**Story:** 29.1
+**Issue:** #831
+
+## Method
+
+1. Searched all usages of `dms-base-table`, `cdk-virtual-scroll-viewport`, and `rowHeight` in `apps/dms-material/src/`.
+2. Measured the actual rendered row height using Playwright by reading the Angular Material CSS custom property `--mat-table-row-item-container-height` at runtime. Confirmed header row renders at 56px and data row CSS is set to **52px**.
+3. Cross-referenced the `BaseTableComponent.rowHeight` input default (52) against all consumer bindings.
+
+## Angular Material Row Height
+
+- CSS: `.mat-mdc-row { height: var(--mat-table-row-item-container-height, 52px); }`
+- No theme override of `--mat-table-row-item-container-height` anywhere in the project.
+- **Actual rendered data row height: 52px**
+- Header row height: 56px
+
+## Audit Results
+
+| Screen            | Component                          | Configured rowHeight | Measured Height | Match? | Action Taken                                    |
+| ----------------- | ---------------------------------- | -------------------- | --------------- | ------ | ----------------------------------------------- |
+| Global Universe   | `global-universe.component.html`   | 48 (explicit)        | 52px            | **No** | Removed `[rowHeight]="48"`, now uses default 52 |
+| Global Screener   | `global-screener.component.html`   | 48 (explicit)        | 52px            | **No** | Removed `[rowHeight]="48"`, now uses default 52 |
+| Dividend Deposits | `dividend-deposits.component.html` | 48 (explicit)        | 52px            | **No** | Removed `[rowHeight]="48"`, now uses default 52 |
+| Open Positions    | `open-positions.component.html`    | 52 (default)         | 52px            | Yes    | No change needed                                |
+| Sold Positions    | `sold-positions.component.html`    | 52 (default)         | 52px            | Yes    | No change needed                                |
+
+## Documentation Fix
+
+The `QUICK-REFERENCE.md` listed the default `rowHeight` as `48`, but the actual component default is `52`. Updated to `52`.
+
+## Impact
+
+The 4px mismatch (configured 48 vs actual 52) caused the CDK virtual scroll viewport to miscalculate scroll positions. With `[itemSize]="48"` but rows rendering at 52px, the viewport would:
+
+- Underestimate total scroll height (fewer pixels allocated than needed)
+- Show slight misalignment when scrolling to specific rows
+- Render slightly fewer buffer rows than intended


### PR DESCRIPTION
## Summary

Standardize virtual scroll row heights across all tables to use the actual measured 52px default instead of the hardcoded 48px override.

## Changes

- Remove explicit `[rowHeight]="48"` from dividend-deposits, global-screener, and global-universe templates
- Update QUICK-REFERENCE.md to document the correct 52px default
- Add row-height-audit.md documenting the investigation and findings

## Why

The BaseTable component's actual rendered row height is 52px (Material Design default for dense tables). Three consumer templates were overriding this with `[rowHeight]="48"`, creating a 4px mismatch between the virtual scroll container's assumed row height and the actual rendered height. This mismatch could cause scroll position drift and phantom rows at the bottom.

## Testing

- All unit tests pass (1691 tests, 100% coverage)
- E2E Chromium: 593 passed
- E2E Firefox: 593 passed  
- Lint, build, format, dupcheck: all clean

Closes #831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized table row heights across application screens to use consistent default sizing.

* **Documentation**
  * Updated row height configuration documentation to reflect the correct 52-pixel default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->