### PR TITLE
Story 29.2: Verify Smooth Scrolling on All Tables with Playwright

### DIFF
--- a/apps/dms-material-e2e/src/helpers/seed-scroll-screener-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-scroll-screener-data.helper.ts
@@ -1,0 +1,81 @@
+import { generateUniqueId } from './generate-unique-id.helper';
+import { createRiskGroups } from './shared-risk-groups.helper';
+
+interface SeederResult {
+  cleanup(): Promise<void>;
+  symbols: string[];
+}
+
+const ROW_COUNT = 60;
+
+/* eslint-disable @typescript-eslint/naming-convention -- Property names match database column names */
+interface ScreenerRecord {
+  symbol: string;
+  risk_group_id: string;
+  distribution: number;
+  distributions_per_year: number;
+  last_price: number;
+}
+/* eslint-enable @typescript-eslint/naming-convention -- Re-enable naming convention */
+
+/**
+ * Generate many screener records for scroll testing
+ */
+function createBulkRecords(
+  symbols: string[],
+  riskGroupId: string
+): ScreenerRecord[] {
+  return symbols.map(function mapSymbol(symbol): ScreenerRecord {
+    return {
+      symbol,
+      risk_group_id: riskGroupId,
+      distribution: 1.0,
+      distributions_per_year: 4,
+      last_price: 50.0,
+    };
+  });
+}
+
+/**
+ * Seeds 60 screener rows for scroll testing
+ */
+export async function seedScrollScreenerData(): Promise<SeederResult> {
+  const prismaClientImport = (await import('@prisma/client')).PrismaClient;
+  const { PrismaBetterSqlite3 } = await import(
+    '@prisma/adapter-better-sqlite3'
+  );
+
+  const testDbUrl = 'file:./test-database.db';
+  const adapter = new PrismaBetterSqlite3({ url: testDbUrl });
+  const prisma = new prismaClientImport({ adapter });
+
+  const uniqueId = generateUniqueId();
+  const symbols = Array.from(
+    { length: ROW_COUNT },
+    function generateSymbol(_: unknown, i: number): string {
+      return `SSCRL${String(i).padStart(2, '0')}-${uniqueId}`;
+    }
+  );
+
+  try {
+    const riskGroups = await createRiskGroups(prisma);
+    const records = createBulkRecords(symbols, riskGroups.equitiesRiskGroup.id);
+    await prisma.screener.createMany({ data: records });
+  } catch (error) {
+    await prisma.$disconnect();
+    throw error;
+  }
+
+  return {
+    symbols,
+    cleanup: async function cleanupScrollScreener(): Promise<void> {
+      try {
+        await prisma.screener.deleteMany({
+          where: { symbol: { in: symbols } },
+        });
+      } finally {
+        await prisma.$disconnect();
+      }
+    },
+  };
+}

--- a/apps/dms-material-e2e/src/helpers/seed-scroll-universe-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-scroll-universe-data.helper.ts
@@ -1,0 +1,88 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { generateUniqueId } from './generate-unique-id.helper';
+import { createRiskGroups } from './shared-risk-groups.helper';
+import type { UniverseRecord } from './universe-record.types';
+
+interface SeederResult {
+  cleanup(): Promise<void>;
+  symbols: string[];
+}
+
+const ROW_COUNT = 60;
+
+/**
+ * Generate many universe records for scroll testing
+ */
+function createBulkRecords(
+  symbols: string[],
+  riskGroupId: string
+): UniverseRecord[] {
+  const futureDate = new Date();
+  futureDate.setFullYear(futureDate.getFullYear() + 1);
+
+  return symbols.map(function mapSymbol(symbol): UniverseRecord {
+    return {
+      symbol,
+      risk_group_id: riskGroupId,
+      distribution: 1.0,
+      distributions_per_year: 4,
+      last_price: 50.0,
+      ex_date: futureDate,
+      most_recent_sell_date: null,
+      most_recent_sell_price: null,
+      expired: false,
+      is_closed_end_fund: true,
+    };
+  });
+}
+
+/**
+ * Initialize Prisma client with test database
+ */
+async function initializePrismaClient(): Promise<PrismaClient> {
+  const prismaClientImport = (await import('@prisma/client')).PrismaClient;
+  const { PrismaBetterSqlite3 } = await import(
+    '@prisma/adapter-better-sqlite3'
+  );
+
+  const testDbUrl = 'file:./test-database.db';
+  const adapter = new PrismaBetterSqlite3({ url: testDbUrl });
+  return new prismaClientImport({ adapter });
+}
+
+/**
+ * Seeds 60 universe rows for scroll testing
+ */
+export async function seedScrollUniverseData(): Promise<SeederResult> {
+  const prisma = await initializePrismaClient();
+  const uniqueId = generateUniqueId();
+  const symbols = Array.from(
+    { length: ROW_COUNT },
+    function generateSymbol(_: unknown, i: number): string {
+      return `USCRL${String(i).padStart(2, '0')}-${uniqueId}`;
+    }
+  );
+
+  try {
+    const riskGroups = await createRiskGroups(prisma);
+    const records = createBulkRecords(symbols, riskGroups.equitiesRiskGroup.id);
+    await prisma.universe.createMany({ data: records });
+  } catch (error) {
+    await prisma.$disconnect();
+    throw error;
+  }
+
+  return {
+    symbols,
+    cleanup: async function cleanupScrollUniverse(): Promise<void> {
+      try {
+        await prisma.universe.deleteMany({
+          where: { symbol: { in: symbols } },
+        });
+      } finally {
+        await prisma.$disconnect();
+      }
+    },
+  };
+}

--- a/apps/dms-material-e2e/src/helpers/verify-smooth-scroll.ts
+++ b/apps/dms-material-e2e/src/helpers/verify-smooth-scroll.ts
@@ -1,0 +1,40 @@
+import type { Page } from 'playwright/test';
+
+/**
+ * Verify that scrolling a container produces monotonically
+ * non-decreasing scrollTop values (no jump-backs).
+ */
+export async function verifyMonotonicScroll(
+  page: Page,
+  selector: string,
+  steps = 20,
+  stepPx = 100
+): Promise<number> {
+  const el = page.locator(selector);
+
+  let prev = await el.evaluate(function getScrollTop(node: Element): number {
+    return node.scrollTop;
+  });
+
+  for (let i = 0; i < steps; i++) {
+    await el.evaluate(function scrollDown(node: Element, px: number): void {
+      node.scrollBy(0, px);
+    }, stepPx);
+    await page.waitForTimeout(50);
+
+    const curr = await el.evaluate(function getCurrentScrollTop(
+      node: Element
+    ): number {
+      return node.scrollTop;
+    });
+
+    if (curr < prev) {
+      throw new Error(
+        `Scroll position decreased: ${prev} -> ${curr} (step ${i})`
+      );
+    }
+    prev = curr;
+  }
+
+  return prev;
+}

--- a/apps/dms-material-e2e/src/screener-smooth-scroll.spec.ts
+++ b/apps/dms-material-e2e/src/screener-smooth-scroll.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedScrollScreenerData } from './helpers/seed-scroll-screener-data.helper';
+import { verifyMonotonicScroll } from './helpers/verify-smooth-scroll';
+
+const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
+
+// ─── Screener Smooth Scroll Tests ────────────────────────────────────────────
+
+test.describe('Screener Smooth Scroll', () => {
+  let cleanup: () => Promise<void>;
+
+  test.beforeAll(async () => {
+    const seeder = await seedScrollScreenerData();
+    cleanup = seeder.cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto('/global/screener');
+    await expect(page.locator('[data-testid="screener-table"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForSelector('tr.mat-mdc-row', { timeout: 15000 });
+  });
+
+  test('scrolling screener table should be monotonically non-decreasing', async ({
+    page,
+  }) => {
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    const finalScrollTop = await verifyMonotonicScroll(page, VIEWPORT_SELECTOR);
+
+    expect(finalScrollTop).toBeGreaterThan(0);
+  });
+});

--- a/apps/dms-material-e2e/src/universe-smooth-scroll.spec.ts
+++ b/apps/dms-material-e2e/src/universe-smooth-scroll.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedScrollUniverseData } from './helpers/seed-scroll-universe-data.helper';
+import { verifyMonotonicScroll } from './helpers/verify-smooth-scroll';
+
+const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
+
+// ─── Universe Smooth Scroll Tests ────────────────────────────────────────────
+
+test.describe('Universe Smooth Scroll', () => {
+  let cleanup: () => Promise<void>;
+
+  test.beforeAll(async () => {
+    const seeder = await seedScrollUniverseData();
+    cleanup = seeder.cleanup;
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto('/global/universe');
+    await expect(page.locator('dms-base-table')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForSelector('tr.mat-mdc-row', { timeout: 15000 });
+  });
+
+  test('scrolling universe table should be monotonically non-decreasing', async ({
+    page,
+  }) => {
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    const finalScrollTop = await verifyMonotonicScroll(page, VIEWPORT_SELECTOR);
+
+    expect(finalScrollTop).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Add Playwright E2E tests that verify virtual-scroll tables scroll monotonically (no jump-backs), serving as a regression guard for rowHeight mismatches.

## Changes
- **verify-smooth-scroll.ts** — Reusable helper: scrolls incrementally and asserts `scrollTop` never decreases
- **seed-scroll-universe-data.helper.ts** — Seeds 60 universe rows for scroll testing
- **seed-scroll-screener-data.helper.ts** — Seeds 60 screener rows for scroll testing
- **universe-smooth-scroll.spec.ts** — Universe table monotonic scroll test
- **screener-smooth-scroll.spec.ts** — Screener table monotonic scroll test

## Quality
- `CI=1 pnpm all` ✅ (lint + build + test)
- `pnpm e2e:dms-material:chromium` ✅ (311 passed)
- `pnpm e2e:dms-material:firefox` ✅ (595 passed)
- `pnpm dupcheck` ✅ (0% TS duplication)

Closes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating smooth scrolling behavior on the Screener and Universe pages.
  * Introduced testing helpers for verifying monotonic scroll behavior and seeding test data with sample records for scrolling validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->