### PR TITLE
feat(base-table): fix virtual-scroll header jumping (contain: strict → contain: paint)

### DIFF
--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
@@ -11,7 +11,7 @@
   overflow-y: auto;
   overflow-x: hidden;
   will-change: transform;
-  contain: strict;
+  contain: paint; // was: strict — strict breaks position:sticky on header cells
 }
 
 mat-progress-bar {


### PR DESCRIPTION
## Summary

Fixes the virtual-scroll table header jumping bug where `position: sticky` on header cells was completely non-functional, causing the header to scroll with the content row-by-row instead of staying fixed.

## Root Cause (from Story 31.1 investigation)

`contain: strict` on `.virtual-scroll-viewport` was the culprit. CSS `contain: strict` implies `layout`, `style`, `paint`, and `size` containment. The `layout` containment creates an independent formatting context that breaks `position: sticky` — sticky positioning requires ancestors to not establish an independent containing block, but `contain: layout` does exactly that.

Evidence captured in Story 31.1: header `getBoundingClientRect().top` changed by exactly −50 px per 50 px scroll step (1:1 ratio), confirming `position: sticky` was completely non-functional.

## Fix

Changed `.virtual-scroll-viewport` from:
```scss
contain: strict;
```
to:
```scss
contain: paint; // was: strict — strict breaks position:sticky on header cells
```

`contain: paint` provides paint containment (overflow clipping, stacking context, GPU layer hints) without the layout/size containment that was breaking sticky positioning. Scroll performance is maintained.

## Testing

- **Unit tests**: all passed (`pnpm nx run dms-material:test`)
- **Build**: clean (`pnpm nx run dms-material:build`)  
- **Lint**: clean (`pnpm nx run dms-material:lint`)
- **E2E Chromium**: 595 tests passed (22.5 min)
- **E2E Firefox**: 595 tests passed (27.5 min)
- **Dupcheck**: passed
- **Format**: clean

Closes #839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed table header cells not remaining visible when scrolling through large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->