### PR TITLE
feat(storybook): add fixed-size host wrapper to BaseTable Storybook stories

### DIFF
--- a/apps/dms-material/src/app/shared/components/base-table/base-table.stories.ts
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.stories.ts
@@ -1,4 +1,8 @@
-import type { Decorator, Meta, StoryObj } from '@storybook/angular';
+import {
+  componentWrapperDecorator,
+  type Meta,
+  type StoryObj,
+} from '@storybook/angular';
 
 import { BaseTableComponent } from './base-table.component';
 import { ColumnDef } from './column-def.interface';
@@ -139,21 +143,14 @@ const universeData: UniverseRow[] = [
   },
 ];
 
-const baseTableContainerDecorator: Decorator =
-  function baseTableContainerDecorator(storyFn, context) {
-    const story = storyFn({ args: context.args });
-    return {
-      ...story,
-      template: `<div style="height: 500px; width: 100%; display: block;">${
-        story.template ?? ''
-      }</div>`,
-    };
-  };
+function wrapInFixedContainer(story: string): string {
+  return `<div style="height: 500px; width: 100%; display: block;">${story}</div>`;
+}
 
 const meta: Meta<BaseTableComponent<SampleRow>> = {
   component: BaseTableComponent,
   title: 'Shared/BaseTable',
-  decorators: [baseTableContainerDecorator],
+  decorators: [componentWrapperDecorator(wrapInFixedContainer)],
   argTypes: {
     sortChange: { action: 'sortChange' },
     rowClick: { action: 'rowClick' },


### PR DESCRIPTION
## Summary

Adds a fixed-size container wrapper to all `base-table.stories.ts` Storybook stories using `componentWrapperDecorator` from `@storybook/angular`. The wrapper provides an explicit `height: 500px; width: 100%; display: block;` container div.

This provides a bounded container for the `cdk-virtual-scroll-viewport` inside `BaseTableComponent`, which requires a parent with a defined height to render rows. Without this wrapper, the viewport calculates zero height and renders no rows, making all three stories invisible in Storybook.

## Changes

- `apps/dms-material/src/app/shared/components/base-table/base-table.stories.ts`
  - Replaced `import type { Decorator, Meta, StoryObj }` with `import { componentWrapperDecorator, type Meta, type StoryObj }` from `@storybook/angular`
  - Added named function `wrapInFixedContainer` that returns the story wrapped in a fixed-size `<div>`
  - Added `decorators: [componentWrapperDecorator(wrapInFixedContainer)]` to the `meta` object so all three stories (`Default`, `EmptyState`, `UniverseTableVariation`) receive the wrapper automatically

## Testing

- `pnpm nx run dms-material:lint` — passes
- `pnpm nx run dms-material:build` — passes
- `pnpm nx run dms-material:test` — 1697 tests passed
- `pnpm nx run dms-material:build-storybook` — Storybook builds successfully
- `pnpm dupcheck` — 0 clones found
- `pnpm format` — applied (import expanded to multi-line by Prettier)

Closes #845