### PR TITLE
feat: Story 34.3 - Wire Dividend Fetch Service into Update Process

### DIFF
--- a/_bmad-output/implementation-artifacts/34-3-wire-new-service-into-dividend-update-process.md
+++ b/_bmad-output/implementation-artifacts/34-3-wire-new-service-into-dividend-update-process.md
@@ -1,6 +1,6 @@
 # Story 34.3: Wire New Service into Dividend Update Process
 
-Status: Approved
+Status: Done
 
 ## Story
 
@@ -17,25 +17,25 @@ so that dividend data is stored with full precision (≥ 4 decimal places).
 
 ## Definition of Done
 
-- [ ] Yahoo Finance dividend call replaced by new service in the update route/function
-- [ ] Fallback to Yahoo Finance implemented and logged
-- [ ] Integration test or updated unit test covering the fallback path
-- [ ] `pnpm all` passes
-- [ ] `pnpm format` passes
+- [x] Yahoo Finance dividend call replaced by new service in the update route/function
+- [x] Fallback to Yahoo Finance implemented and logged
+- [x] Integration test or updated unit test covering the fallback path
+- [x] `pnpm all` passes
+- [x] `pnpm format` passes
 
 ## Tasks / Subtasks
 
-- [ ] Locate the server update route/function that currently calls Yahoo Finance for dividends (AC: #1)
-  - [ ] Identify the exact call site in `distribution-api.function.ts` or related route handler
-- [ ] Replace the Yahoo Finance dividend call with `fetchDividendHistory` from Story 34.2 (AC: #1)
-  - [ ] Ensure the response is passed to the same database write logic
-- [ ] Implement fallback to Yahoo Finance when `fetchDividendHistory` returns an empty array (AC: #2)
-  - [ ] Log a structured warning with the ticker symbol that triggered the fallback
-- [ ] Verify no precision truncation occurs in the database write path (AC: #3)
-  - [ ] Check Prisma schema field types for dividend amount
-- [ ] Update or add unit/integration tests covering: primary source success, fallback path (AC: #4)
-- [ ] Run `pnpm all` and fix any failures
-- [ ] Run `pnpm format`
+- [x] Locate the server update route/function that currently calls Yahoo Finance for dividends (AC: #1)
+  - [x] Identify the exact call site in `distribution-api.function.ts` or related route handler
+- [x] Replace the Yahoo Finance dividend call with `fetchDividendHistory` from Story 34.2 (AC: #1)
+  - [x] Ensure the response is passed to the same database write logic
+- [x] Implement fallback to Yahoo Finance when `fetchDividendHistory` returns an empty array (AC: #2)
+  - [x] Log a structured warning with the ticker symbol that triggered the fallback
+- [x] Verify no precision truncation occurs in the database write path (AC: #3)
+  - [x] Check Prisma schema field types for dividend amount
+- [x] Update or add unit/integration tests covering: primary source success, fallback path (AC: #4)
+- [x] Run `pnpm all` and fix any failures
+- [x] Run `pnpm format`
 
 ## Dev Notes
 
@@ -52,7 +52,17 @@ This story is a targeted surgical replacement of one call site. Do not restructu
 ## Dev Agent Record
 
 ### Agent Model Used
+Claude Sonnet 4.6 (GitHub Copilot)
 
 ### Completion Notes
+- Replaced `fetchDistributionData` with `fetchDividendHistory` as primary source in 2 files
+- Fallback to Yahoo Finance when primary returns empty array, with structured warning log
+- Prisma `Float` type preserves full IEEE 754 double precision (no truncation)
+- Added 4 new tests (2 per file): primary path and fallback path
+- 43 total tests passing across both spec files
 
 ## File List
+- `apps/server/src/app/routes/settings/common/get-distributions.function.ts` (modified)
+- `apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts` (modified)
+- `apps/server/src/app/routes/screener/get-consistent-distributions.function.ts` (modified)
+- `apps/server/src/app/routes/screener/get-consistent-distributions.function.spec.ts` (modified)

--- a/apps/server/src/app/routes/screener/get-consistent-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/screener/get-consistent-distributions.function.spec.ts
@@ -1,13 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ProcessedRow } from '../../common/distribution-api.function';
+import { logger } from '../../../utils/structured-logger';
 import { getConsistentDistributions } from './get-consistent-distributions.function';
 
-// Hoisted mock
+// Hoisted mocks
 const mockFetchDistributionData = vi.hoisted(() => vi.fn());
+const mockFetchDividendHistory = vi.hoisted(() => vi.fn());
 
 vi.mock('../common/distribution-api.function', () => ({
   fetchDistributionData: mockFetchDistributionData,
+}));
+
+vi.mock('../common/dividend-history.service', () => ({
+  fetchDividendHistory: mockFetchDividendHistory,
+}));
+
+vi.mock('../../../utils/structured-logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 describe('getConsistentDistributions', () => {
@@ -15,6 +30,8 @@ describe('getConsistentDistributions', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-11-09T10:00:00Z'));
+    // Default: new service returns no data, triggering fallback to Yahoo Finance
+    mockFetchDividendHistory.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -364,4 +381,42 @@ describe('getConsistentDistributions', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('primary and fallback data source', () => {
+    test('uses primary dividend service when it returns data (no fallback)', async () => {
+      const primaryRows: ProcessedRow[] = [
+        { amount: 0.2205, date: new Date('2025-08-15') },
+        { amount: 0.2205, date: new Date('2025-09-15') },
+        { amount: 0.2205, date: new Date('2025-10-15') },
+      ];
+
+      mockFetchDividendHistory.mockResolvedValueOnce(primaryRows);
+
+      const result = await getConsistentDistributions('PDI');
+
+      expect(result).toBe(true);
+      expect(mockFetchDistributionData).not.toHaveBeenCalled();
+    });
+
+    test('falls back to Yahoo Finance and logs warning when primary returns empty', async () => {
+      const fallbackRows: ProcessedRow[] = [
+        { amount: 0.2205, date: new Date('2025-08-15') },
+        { amount: 0.2205, date: new Date('2025-09-15') },
+        { amount: 0.2205, date: new Date('2025-10-15') },
+      ];
+
+      mockFetchDividendHistory.mockResolvedValueOnce([]);
+      mockFetchDistributionData.mockResolvedValueOnce(fallbackRows);
+
+      const result = await getConsistentDistributions('NOLISTING');
+
+      expect(result).toBe(true);
+      expect(mockFetchDistributionData).toHaveBeenCalledWith('NOLISTING');
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        'fetchDividendHistory returned no data for NOLISTING, falling back to Yahoo Finance',
+        { symbol: 'NOLISTING' }
+      );
+    });
+  });
 });
+

--- a/apps/server/src/app/routes/screener/get-consistent-distributions.function.ts
+++ b/apps/server/src/app/routes/screener/get-consistent-distributions.function.ts
@@ -1,7 +1,9 @@
+import { logger } from '../../../utils/structured-logger';
 import {
   fetchDistributionData,
   type ProcessedRow,
 } from '../common/distribution-api.function';
+import { fetchDividendHistory } from '../common/dividend-history.service';
 
 function filterPastDistributions(rows: ProcessedRow[]): ProcessedRow[] {
   const today = new Date();
@@ -61,7 +63,15 @@ function hasDecliningTrend(recentExDates: ProcessedRow[]): boolean {
 export async function getConsistentDistributions(
   symbol: string
 ): Promise<boolean> {
-  const rows = await fetchDistributionData(symbol);
+  let rows = await fetchDividendHistory(symbol);
+
+  if (rows.length === 0) {
+    logger.warn(
+      `fetchDividendHistory returned no data for ${symbol}, falling back to Yahoo Finance`,
+      { symbol }
+    );
+    rows = await fetchDistributionData(symbol);
+  }
 
   if (rows.length === 0) {
     return false;

--- a/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
@@ -1,13 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import type { ProcessedRow } from '../../common/distribution-api.function';
+import { logger } from '../../../../utils/structured-logger';
 import { getDistributions } from './get-distributions.function';
 
-// Hoisted mock
+// Hoisted mocks
 const mockFetchDistributionData = vi.hoisted(() => vi.fn());
+const mockFetchDividendHistory = vi.hoisted(() => vi.fn());
 
 vi.mock('../../common/distribution-api.function', () => ({
   fetchDistributionData: mockFetchDistributionData,
+}));
+
+vi.mock('../../common/dividend-history.service', () => ({
+  fetchDividendHistory: mockFetchDividendHistory,
+}));
+
+vi.mock('../../../../utils/structured-logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 describe('getDistributions', () => {
@@ -20,6 +35,8 @@ describe('getDistributions', () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2025-08-21T10:00:00Z'));
+    // Default: new service returns no data, triggering fallback to Yahoo Finance
+    mockFetchDividendHistory.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -288,5 +305,40 @@ describe('getDistributions', () => {
     const result = await getDistributions('MONTHLY_BOUNDARY');
 
     expect(result?.distributions_per_year).toBe(12);
+  });
+
+  test('uses primary dividend service when it returns data (no fallback)', async () => {
+    const primaryRows: ProcessedRow[] = [
+      { amount: 0.2205, date: new Date('2025-05-15') },
+      { amount: 0.2205, date: new Date('2025-06-15') },
+      { amount: 0.2205, date: new Date('2025-07-15') },
+    ];
+
+    mockFetchDividendHistory.mockResolvedValueOnce(primaryRows);
+
+    const result = await getDistributions('PDI');
+
+    expect(result).toBeDefined();
+    expect(result?.distribution).toBe(0.2205);
+    expect(mockFetchDistributionData).not.toHaveBeenCalled();
+  });
+
+  test('falls back to Yahoo Finance and logs warning when primary returns empty', async () => {
+    const fallbackRows: ProcessedRow[] = [
+      { amount: 0.22, date: new Date('2025-06-13') },
+      { amount: 0.22, date: new Date('2025-07-12') },
+    ];
+
+    mockFetchDividendHistory.mockResolvedValueOnce([]);
+    mockFetchDistributionData.mockResolvedValueOnce(fallbackRows);
+
+    const result = await getDistributions('NOLISTING');
+
+    expect(result).toBeDefined();
+    expect(mockFetchDistributionData).toHaveBeenCalledWith('NOLISTING');
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      'fetchDividendHistory returned no data for NOLISTING, falling back to Yahoo Finance',
+      { symbol: 'NOLISTING' }
+    );
   });
 });

--- a/apps/server/src/app/routes/settings/common/get-distributions.function.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.ts
@@ -1,7 +1,9 @@
+import { logger } from '../../../../utils/structured-logger';
 import {
   fetchDistributionData,
   type ProcessedRow,
 } from '../../common/distribution-api.function';
+import { fetchDividendHistory } from '../../common/dividend-history.service';
 
 interface DistributionResult {
   distribution: number;
@@ -72,7 +74,15 @@ export async function getDistributions(
   symbol: string
 ): Promise<DistributionResult | undefined> {
   try {
-    const rows = await fetchDistributionData(symbol);
+    let rows = await fetchDividendHistory(symbol);
+
+    if (rows.length === 0) {
+      logger.warn(
+        `fetchDividendHistory returned no data for ${symbol}, falling back to Yahoo Finance`,
+        { symbol }
+      );
+      rows = await fetchDistributionData(symbol);
+    }
 
     if (rows.length === 0) {
       return undefined;


### PR DESCRIPTION
## Story 34.3: Wire New Dividend Service into Update Process

Closes #851

### Changes

**`get-distributions.function.ts`** (modified):
- Import `fetchDividendHistory`, `logger`
- Call `fetchDividendHistory(symbol)` first (primary source)
- If result is empty → log fallback warning → call `fetchDistributionData(symbol)` (Yahoo Finance fallback)
- 2 new unit tests: primary path success, fallback path with warning

**`get-consistent-distributions.function.ts`** (modified):
- Same primary → fallback pattern
- 2 new unit tests: primary path success, fallback path with warning

### Acceptance Criteria

- [x] AC1: Yahoo Finance dividend call replaced by `fetchDividendHistory` as primary source
- [x] AC2: Fallback to Yahoo Finance with structured warning when primary returns no data
- [x] AC3: `Float` Prisma type preserves full IEEE 754 double precision (no truncation)
- [x] AC4: 43 unit tests passing across both spec files

### Test Coverage

- `get-distributions.function.spec.ts`: 19 tests (all passing)
- `get-consistent-distributions.function.spec.ts`: 24 tests (all passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated a new primary data source for dividend information with automatic fallback to existing provider for enhanced reliability.

* **Improvements**
  * Added structured logging for fallback scenarios to improve visibility into data source behavior.

* **Tests**
  * Expanded test coverage to validate both primary and fallback data retrieval paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->