### PR TITLE
feat: Story 34.4 - Add E2E test for dividend precision after update

### DIFF
--- a/apps/dms-material-e2e/src/dividend-precision.spec.ts
+++ b/apps/dms-material-e2e/src/dividend-precision.spec.ts
@@ -111,11 +111,14 @@ test.describe('Dividend Precision After Update', () => {
     // API must accept and echo back the high-precision value (not rounded).
     expect(updateResponse.ok()).toBe(true);
     const updatedRows = (await updateResponse.json()) as Array<{
+      id: string;
+      symbol: string;
       distribution: number;
     }>;
-    expect(updatedRows.length).toBeGreaterThanOrEqual(1);
+    const updatedRecord = updatedRows.find((row) => row.id === seededRecord.id);
+    expect(updatedRecord).toBeDefined();
     // Assert the server stored exactly the 4-decimal precision value.
-    expect(updatedRows[0].distribution).toBe(HIGH_PRECISION_DISTRIBUTION);
+    expect(updatedRecord?.distribution).toBe(HIGH_PRECISION_DISTRIBUTION);
 
     // ── Step 2: Load the Universe screen and verify the stored precision is
     // faithfully displayed in the UI (guards against UI-layer rounding).
@@ -133,6 +136,11 @@ test.describe('Dividend Precision After Update', () => {
 
     // Wait for exactly one data row matching the test symbol.
     await page.waitForSelector('tr.mat-mdc-row', { timeout: 10000 });
+
+    // Verify the first visible row actually contains the expected test symbol
+    // before asserting on the distribution cell value.
+    const firstRow = page.locator('tr.mat-mdc-row').first();
+    await expect(firstRow).toContainText(testSymbol, { timeout: 10000 });
 
     // The editable-cell component uses data-testid="distribution-cell-0" for
     // row index 0, formatted with decimalFormat="1.4-4" (exactly 4 decimal places).
@@ -188,6 +196,11 @@ test.describe('Dividend Precision After Update', () => {
       await page.waitForTimeout(500);
 
       await page.waitForSelector('tr.mat-mdc-row', { timeout: 10000 });
+
+      // Verify the first visible row actually contains the expected baseline symbol
+      // before asserting on the distribution cell value.
+      const firstRow = page.locator('tr.mat-mdc-row').first();
+      await expect(firstRow).toContainText(baselineSymbol, { timeout: 10000 });
 
       const distributionCell = page.locator(
         '[data-testid="distribution-cell-0"]'


### PR DESCRIPTION
## Summary

Adds a Playwright end-to-end regression test that verifies dividend distribution values retain ≥4 decimal place precision through the full API/DB/UI pipeline after an update operation.

This guards against accidentally reverting to a lower-precision data source (e.g., Yahoo Finance which returns only 2 decimal places).

## Changes

- Added `apps/dms-material-e2e/src/dividend-precision.spec.ts` with two tests:
  1. **Update path test**: Seeds a symbol with 2-decimal precision, calls `PUT /api/universe` with a 4-decimal value (`0.2245`), then verifies the Universe screen displays it with ≥4 decimal places
  2. **Baseline display test**: Seeds a symbol with 4-decimal precision directly via Prisma and verifies the Universe screen preserves that precision on display

## Testing

- Test uses Prisma to seed and clean up test data
- Assertions use string pattern matching (`/\.\d{3}[1-9]/`) to reliably detect 4-decimal precision without floating-point comparison issues
- E2e tests run via `pnpm e2e:dms-material:chromium` and `pnpm e2e:dms-material:firefox`

Closes #853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end regression tests ensuring high-precision dividend/distribution values (≥4 decimal places) are preserved through storage, API updates, and UI rendering.
  * Added UI tests that verify distribution values display at least four decimal places in the universe table, guarding against truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->