### PR TITLE
test: Story 36.1 - Write failing e2e tests for multi-column sort universe screen

### DIFF
--- a/apps/dms-material-e2e/src/helpers/seed-universe-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-universe-e2e-data.helper.ts
@@ -1,6 +1,5 @@
 import type { PrismaClient } from '@prisma/client';
 
-import { createTestDates } from './create-test-dates.helper';
 import { generateUniqueId } from './generate-unique-id.helper';
 import type { RiskGroups } from './risk-groups.types';
 import { fetchUniverseIds } from './shared-fetch-universe-ids.helper';
@@ -76,8 +75,7 @@ function createFirstBatch(
 
 function createSecondBatch(
   symbols: string[],
-  riskGroups: { eq: string; inc: string },
-  dates: { futureDate: Date; pastDate: Date }
+  riskGroups: { eq: string; inc: string }
 ): UniverseRecord[] {
   return [
     createRecord({
@@ -86,7 +84,9 @@ function createSecondBatch(
       distribution: 1.5,
       distPerYear: 4,
       lastPrice: 50.0,
-      exDate: dates.futureDate,
+      // Fixed date clearly before symbols[0]'s 2026-06-15, so secondary-sort
+      // assertions remain valid regardless of when the tests are run.
+      exDate: new Date('2026-04-15'),
       expired: true,
     }),
     createRecord({
@@ -95,7 +95,7 @@ function createSecondBatch(
       distribution: 0.3,
       distPerYear: 12,
       lastPrice: 15.0,
-      exDate: dates.pastDate,
+      exDate: new Date('2026-01-15'),
       expired: false,
     }),
   ];
@@ -105,14 +105,13 @@ function createUniverseRecords(
   symbols: string[],
   riskGroups: RiskGroups
 ): UniverseRecord[] {
-  const dates = createTestDates();
   const eq = riskGroups.equitiesRiskGroup.id;
   const inc = riskGroups.incomeRiskGroup.id;
   const tf = riskGroups.taxFreeIncomeRiskGroup.id;
 
   return [
     ...createFirstBatch(symbols, eq, inc, tf),
-    ...createSecondBatch(symbols, { eq, inc }, dates),
+    ...createSecondBatch(symbols, { eq, inc }),
   ];
 }
 

--- a/apps/dms-material-e2e/src/universe-multi-column-sort-rows.spec.ts
+++ b/apps/dms-material-e2e/src/universe-multi-column-sort-rows.spec.ts
@@ -100,16 +100,30 @@ test.describe('Universe Screen - Multi-Column Sort Row Ordering (Story 36.1)', (
     await page.waitForTimeout(800);
     await page.waitForLoadState('networkidle');
 
-    // Collect all visible Symbol values
-    const symbolValues = await getColumnTexts(page, 1);
-    expect(symbolValues.length).toBeGreaterThanOrEqual(5);
+    // Collect Symbol values after ascending sort
+    const ascValues = await getColumnTexts(page, 1);
+    expect(ascValues.length).toBe(5);
 
-    // Every consecutive pair should be in ascending lexicographic order
-    for (let i = 1; i < symbolValues.length; i++) {
-      expect(
-        symbolValues[i - 1].localeCompare(symbolValues[i])
-      ).toBeLessThanOrEqual(0);
-    }
+    // UAAA (symbols[0]) must appear before UEEE (symbols[4]) in ascending order
+    const ascIdxUAAA = ascValues.indexOf(symbols[0]);
+    const ascIdxUEEE = ascValues.indexOf(symbols[4]);
+    expect(ascIdxUAAA).toBeGreaterThan(-1);
+    expect(ascIdxUEEE).toBeGreaterThan(-1);
+    expect(ascIdxUAAA).toBeLessThan(ascIdxUEEE);
+
+    // Click Symbol header again to sort descending, proving the sort is live
+    // (not just natural DB insertion order)
+    await symbolHeader.click();
+    await page.waitForTimeout(800);
+    await page.waitForLoadState('networkidle');
+
+    const descValues = await getColumnTexts(page, 1);
+    expect(descValues.length).toBe(5);
+
+    // In descending order UEEE must appear before UAAA — opposite of ascending
+    const descIdxUAAA = descValues.indexOf(symbols[0]);
+    const descIdxUEEE = descValues.indexOf(symbols[4]);
+    expect(descIdxUEEE).toBeLessThan(descIdxUAAA);
   });
 
   // ─── AC #2: Secondary sort reorders rows within the same primary group ────
@@ -139,8 +153,8 @@ test.describe('Universe Screen - Multi-Column Sort Row Ordering (Story 36.1)', (
 
     // Secondary sort: Ex-Date ascending (Shift+click)
     // After this, within the Equities group:
-    //   UDDD (ex_date ≈ today+30, May)  should appear before
-    //   UAAA (ex_date = 2026-06-15, June)
+    //   UDDD (ex_date 2026-04-15, April)  should appear before
+    //   UAAA (ex_date 2026-06-15, June)
     const exDateHeader = page.getByRole('button', { name: 'Ex-Date' });
     await exDateHeader.click({ modifiers: ['Shift'] });
     await page.waitForTimeout(800);
@@ -148,11 +162,11 @@ test.describe('Universe Screen - Multi-Column Sort Row Ordering (Story 36.1)', (
 
     // Collect all displayed symbol values in DOM order
     const symbolValues = await getColumnTexts(page, 1);
-    expect(symbolValues.length).toBeGreaterThanOrEqual(5);
+    expect(symbolValues.length).toBe(5);
 
     // Identify positions of the two Equities rows
-    const idxUAAA = symbolValues.indexOf(symbols[0]); // June 15 — later date
-    const idxUDDD = symbolValues.indexOf(symbols[3]); // today+30 — earlier date
+    const idxUAAA = symbolValues.indexOf(symbols[0]); // ex_date 2026-06-15 — later date
+    const idxUDDD = symbolValues.indexOf(symbols[3]); // ex_date 2026-04-15 — earlier date
 
     expect(idxUAAA).toBeGreaterThan(-1);
     expect(idxUDDD).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary
Writes Playwright e2e tests capturing the expected behaviour of multi-column sorting on the Universe Screen. The secondary-sort test intentionally fails against the current buggy implementation.

- AC #1: Primary sort by Symbol ascending — test **passes** against current code
- AC #2: Secondary sort by Ex-Date within same Risk Group — test **fails** (by design) revealing the bug, fixed in Story 36.2

Closes #861

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating multi-column sorting in the Universe table. Verifies primary and secondary sort behavior (including modifier-key sorting) and confirms table rows reorder in DOM to reflect expected sort/order rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->