### PR TITLE
fix: Story 36.2 - Fix secondary sort on Universe Screen

### DIFF
--- a/apps/server/src/app/routes/top/index.spec.ts
+++ b/apps/server/src/app/routes/top/index.spec.ts
@@ -347,6 +347,33 @@ describe('Top Route Handler', () => {
       ]);
     });
 
+    it('should apply all sortColumns to orderBy for risk_group + ex_date multi-column sort (Story 36.2)', async () => {
+      mockPrismaUniverse.findMany.mockResolvedValue([{ id: 'u1' }]);
+
+      const filterState = JSON.stringify({
+        universes: {
+          sortColumns: [
+            { column: 'risk_group', direction: 'asc' },
+            { column: 'ex_date', direction: 'asc' },
+          ],
+        },
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/top',
+        payload: ['1'],
+        headers: { 'x-sort-filter-state': filterState },
+      });
+
+      expect(response.statusCode).toBe(200);
+      const universeCall = mockPrismaUniverse.findMany.mock.calls[0][0];
+      expect(universeCall.orderBy).toEqual([
+        { risk_group: { name: 'asc' } },
+        { ex_date: 'asc' },
+      ]);
+    });
+
     it('should return null accountId when filters exist without account_id', async () => {
       mockPrismaUniverse.findMany.mockResolvedValue([
         {


### PR DESCRIPTION
## Story 36.2: Fix Secondary Sort on Universe Screen

Closes #863

## Root Cause Analysis

The secondary sort bug was already fixed in Story 24.2 (`feat(story-24.2): implement multi-column sort in backend query`), which implemented `buildUniverseOrderBy` to correctly iterate over the full `sortColumns` array and map every entry to a Prisma `orderBy` clause.

This story:
1. Confirmed the fix is in place (all Story 36.1 e2e tests pass)
2. Added a targeted integration test in `index.spec.ts` for the exact `risk_group + ex_date` multi-column sort scenario verified by the Story 36.1 e2e tests

## Changes

- **`apps/server/src/app/routes/top/index.spec.ts`** — Added integration test `should apply all sortColumns to orderBy for risk_group + ex_date multi-column sort (Story 36.2)` that asserts the route correctly produces `orderBy: [{risk_group: {name: 'asc'}}, {ex_date: 'asc'}]` when the client sends both columns in `sortColumns`

## Testing

- All 18 `index.spec.ts` tests pass
- All 16 `build-universe-order-by.function.spec.ts` tests pass  
- Story 36.1 e2e tests pass:
  - ✅ primary sort by Symbol ascending orders rows alphabetically (AC #1)
  - ✅ secondary sort by Ex-Date orders rows within same Risk Group ascending (AC #2)
- `pnpm format` clean
- `pnpm dupcheck` clean
- `nx affected -t lint build test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for multi-column database sorting behavior in the top API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->