### PR TITLE
test: Story 37.1 - Write failing e2e tests for account table sorting

### DIFF
--- a/apps/dms-material-e2e/src/account-table-sort.spec.ts
+++ b/apps/dms-material-e2e/src/account-table-sort.spec.ts
@@ -83,10 +83,7 @@ test.describe('Account Tables - Sorting (Story 37.1 - Failing Tests)', () => {
       await login(page);
       await clearSortFilterState(page);
       await page.goto(`/account/${accountIdOpen}/open`);
-      await expect(
-        page.locator('[data-testid="open-positions-table"]')
-      ).toBeVisible({ timeout: 15000 });
-      await page.waitForSelector('tr.mat-mdc-row', { timeout: 15000 });
+      await waitForTableRows(page);
     });
 
     // EXPECTED TO FAIL: buggy implementation does not reorder rows

--- a/apps/dms-material-e2e/src/helpers/seed-div-deposits-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-div-deposits-e2e-data.helper.ts
@@ -79,7 +79,13 @@ export async function seedDivDepositsE2eData(): Promise<DivDepositsSeederResult>
       data: { name: accountName },
     });
     accountId = account.id;
-    await createDivDeposits(prisma, accountId, divDepositTypeId);
+    try {
+      await createDivDeposits(prisma, accountId, divDepositTypeId);
+    } catch (createError) {
+      // Clean up the account if deposit creation fails to avoid orphaned records
+      await prisma.accounts.delete({ where: { id: accountId } });
+      throw createError;
+    }
   } catch (error) {
     await prisma.$disconnect();
     throw error;


### PR DESCRIPTION
Adds Playwright tests that capture the sort behaviour bug on Account tables. Tests intentionally fail against the current buggy implementation (sort icon appears but rows are not reordered).

## Changes

- **New**: `apps/dms-material-e2e/src/account-table-sort.spec.ts` — three failing Playwright tests:
  - Open Positions: click "Buy Date" header → assert rows ordered by buy date ascending (FAILS)
  - Closed Positions: click "Sell Date" header → assert rows ordered by sell date ascending (FAILS)
  - Dividend Deposits: click "Amount" header → assert rows ordered by amount ascending (FAILS)
- **New**: `apps/dms-material-e2e/src/helpers/seed-div-deposits-e2e-data.helper.ts` — deterministic fixture seeder for Dividend Deposits data

## Test Strategy

Each test seeds a fresh account with rows in a deliberate non-sorted insertion order. After clicking a sortable column header, the test asserts the rows are reordered correctly. The assertions fail because the current implementation updates the sort icon but does not re-order the rows from the server.

Closes #867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating account table sorting for Open Positions, Closed Positions, and Dividend Deposits.
  * Added a test data seeding helper for dividend deposit scenarios and cleanup routines.
  * Tests include expected-failure assertions highlighting a known UI sorting issue (icons update but rows do not reorder).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->