### PR TITLE
chore: update story 37.1 tracking to review status

### DIFF
--- a/_bmad-output/implementation-artifacts/37-1-write-failing-e2e-tests-account-table-sorting.md
+++ b/_bmad-output/implementation-artifacts/37-1-write-failing-e2e-tests-account-table-sorting.md
@@ -1,6 +1,6 @@
 # Story 37.1: Write Failing E2E Tests for Account Table Sorting
 
-Status: Approved
+Status: review
 
 ## Story
 
@@ -17,20 +17,20 @@ so that the tests fail against the current buggy state and can verify the fix.
 
 ## Definition of Done
 
-- [ ] Playwright tests added for all three Account tables
-- [ ] All three sorting tests fail against current code
-- [ ] Tests use data fixtures with deterministic values
-- [ ] `pnpm format` passes
+- [x] Playwright tests added for all three Account tables
+- [x] All three sorting tests fail against current code
+- [x] Tests use data fixtures with deterministic values
+- [x] `pnpm format` passes
 
 ## Tasks / Subtasks
 
-- [ ] Locate the Account panel in the e2e tests and identify how to navigate to an account (AC: #1)
-- [ ] Write a Playwright test for Open Positions table: click a sortable column header, assert rows are ordered — expect this to fail (AC: #1)
-- [ ] Write a Playwright test for Closed Positions table: click a sortable column header, assert sorted order — expect this to fail (AC: #2)
-- [ ] Write a Playwright test for Dividend Deposits table: click a sortable column header, assert sorted order — expect this to fail (AC: #3)
-- [ ] Ensure test data fixtures provide deterministic values with known sort order (AC: #4)
-- [ ] Confirm all three tests fail against current code; confirm existing tests still pass (AC: #4)
-- [ ] Run `pnpm format`
+- [x] Locate the Account panel in the e2e tests and identify how to navigate to an account (AC: #1)
+- [x] Write a Playwright test for Open Positions table: click a sortable column header, assert rows are ordered — expect this to fail (AC: #1)
+- [x] Write a Playwright test for Closed Positions table: click a sortable column header, assert sorted order — expect this to fail (AC: #2)
+- [x] Write a Playwright test for Dividend Deposits table: click a sortable column header, assert sorted order — expect this to fail (AC: #3)
+- [x] Ensure test data fixtures provide deterministic values with known sort order (AC: #4)
+- [x] Confirm all three tests fail against current code; confirm existing tests still pass (AC: #4)
+- [x] Run `pnpm format`
 
 ## Dev Notes
 
@@ -48,6 +48,22 @@ Follow the same pattern as Story 36.1 for the Universe Screen. Use consistent te
 
 ### Agent Model Used
 
+Claude Sonnet 4.6 (GitHub Copilot)
+
 ### Completion Notes
 
+- Created three Playwright e2e tests for Open Positions (Buy Date sort), Closed Positions (Sell Date sort), and Dividend Deposits (Amount sort)
+- Created `seed-div-deposits-e2e-data.helper.ts` with deterministic `SEEDED_AMOUNTS = [50, 200, 100]`; reused existing open/sold positions seeders
+- All three tests purposefully fail against current code because sort icon appears but rows stay in insertion order
+- Fixed CodeRabbit actionable: added nested try/catch in seeder to delete orphaned account if deposit creation fails
+- PR #868 merged to main at commit `a647f22`; issue #867 closed
+
+## Change Log
+
+- Added `apps/dms-material-e2e/src/account-table-sort.spec.ts` — three failing e2e tests
+- Added `apps/dms-material-e2e/src/helpers/seed-div-deposits-e2e-data.helper.ts` — div deposits seeder
+
 ## File List
+
+- apps/dms-material-e2e/src/account-table-sort.spec.ts (new)
+- apps/dms-material-e2e/src/helpers/seed-div-deposits-e2e-data.helper.ts (new)

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -240,7 +240,7 @@ development_status:
 
   # ── Epic 37: Fix Sorting on Account Tables ───────────────────────────────────
   epic-37: backlog
-  37-1-write-failing-e2e-tests-account-table-sorting: backlog
+  37-1-write-failing-e2e-tests-account-table-sorting: review
   37-2-diagnose-and-fix-account-table-sort-bug: backlog
   37-3-unit-tests-account-table-sort-state-wiring: backlog
   epic-37-retrospective: optional


### PR DESCRIPTION
Mark story 37.1 as review in sprint-status.yaml and update story file with dev agent record. Closes tracking for #867.