### PR TITLE
feat(account): restore sort/filter state on account screens (Story 38.2)

### DIFF
--- a/apps/dms-material-e2e/src/account-sort-filter-persistence.spec.ts
+++ b/apps/dms-material-e2e/src/account-sort-filter-persistence.spec.ts
@@ -118,7 +118,11 @@ test.describe('Account Sort/Filter Persistence (Story 38.1)', () => {
 
       // Reload the page
       await page.reload();
-      await waitForTableRows(page);
+      // Wait for the table component to render (not data rows, since the
+      // restored filter may legitimately exclude all seeded data)
+      await expect(page.locator('dms-base-table')).toBeVisible({
+        timeout: 15000,
+      });
 
       // After reload, filter input should still contain the value
       const restoredInput = page.getByPlaceholder('Search Symbol');
@@ -213,7 +217,11 @@ test.describe('Account Sort/Filter Persistence (Story 38.1)', () => {
 
       // Reload the page
       await page.reload();
-      await waitForTableRows(page);
+      // Wait for the table component to render (not data rows, since the
+      // restored filter may legitimately exclude all seeded data)
+      await expect(page.locator('dms-base-table')).toBeVisible({
+        timeout: 15000,
+      });
 
       // After reload, filter input should still contain the value
       const restoredInput = page.getByPlaceholder('Search Symbol');

--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.html
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.html
@@ -2,6 +2,7 @@
   [data]="dividends$()"
   [columns]="columns"
   [bufferSize]="20"
+  [sortColumns]="sortColumns$()"
   (sortChange)="onSortChange($event)"
   (rowClick)="onEditDividend($event)"
   (renderedRangeChange)="onRangeChange($event)"

--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.ts
@@ -17,6 +17,7 @@ import { BaseTableComponent } from '../../shared/components/base-table/base-tabl
 import { ColumnDef } from '../../shared/components/base-table/column-def.interface';
 import { ConfirmDialogService } from '../../shared/services/confirm-dialog.service';
 import { NotificationService } from '../../shared/services/notification.service';
+import { SortColumn } from '../../shared/services/sort-column.interface';
 import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { getAccountIds } from '../../store/accounts/selectors/get-account-ids.function';
 import { currentAccountSignalStore } from '../../store/current-account/current-account.signal-store';
@@ -49,6 +50,21 @@ export class DividendDepositsComponent {
   private effectsService = inject(divDepositsEffectsServiceToken);
   private readonly sortFilterStateService = inject(SortFilterStateService);
 
+  private readonly restoredSort = this.sortFilterStateService.loadSortState(
+    DividendDepositsComponent.tableKey
+  );
+
+  sortColumns$ = signal<SortColumn[]>(
+    this.restoredSort !== null
+      ? [
+          {
+            column: this.restoredSort.field,
+            direction: this.restoredSort.order,
+          },
+        ]
+      : []
+  );
+
   constructor() {
     const store = this.currentAccountStore;
     const service = this.dividendDepositsService;
@@ -71,15 +87,18 @@ export class DividendDepositsComponent {
 
   onSortChange(sort: Sort): void {
     if (sort.direction === '') {
+      this.sortColumns$.set([]);
       this.sortFilterStateService.clearSortState(
         DividendDepositsComponent.tableKey
       );
     } else {
+      const direction = sort.direction;
+      this.sortColumns$.set([{ column: sort.active, direction }]);
       this.sortFilterStateService.saveSortState(
         DividendDepositsComponent.tableKey,
         {
           field: sort.active,
-          order: sort.direction,
+          order: direction,
         }
       );
     }

--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.html
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.html
@@ -13,6 +13,7 @@
   data-testid="open-positions-table"
   [data]="selectOpenPositions$()"
   [columns]="columns"
+  [sortColumns]="sortColumns$()"
   (sortChange)="onSortChange($event)"
   (renderedRangeChange)="onRangeChange($event)"
 >

--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.ts
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions.component.ts
@@ -21,6 +21,7 @@ import { ColumnDef } from '../../shared/components/base-table/column-def.interfa
 import { EditableCellComponent } from '../../shared/components/editable-cell/editable-cell.component';
 import { EditableDateCellComponent } from '../../shared/components/editable-date-cell/editable-date-cell.component';
 import { FilterConfig } from '../../shared/services/filter-config.interface';
+import { SortColumn } from '../../shared/services/sort-column.interface';
 import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { getAccountIds } from '../../store/accounts/selectors/get-account-ids.function';
 import { OpenPosition } from '../../store/trades/open-position.interface';
@@ -53,7 +54,29 @@ export class OpenPositionsComponent implements OnDestroy {
   // Inject MatDialog for add position dialog
   private dialog = inject(MatDialog);
 
-  searchText = signal<string>('');
+  private readonly restoredFilter = this.sortFilterStateService.loadFilterState(
+    OpenPositionsComponent.tableKey
+  );
+
+  private readonly restoredSort = this.sortFilterStateService.loadSortState(
+    OpenPositionsComponent.tableKey
+  );
+
+  searchText = signal<string>(
+    (this.restoredFilter?.['symbol'] as string) ?? ''
+  );
+
+  sortColumns$ = signal<SortColumn[]>(
+    this.restoredSort !== null
+      ? [
+          {
+            column: this.restoredSort.field,
+            direction: this.restoredSort.order,
+          },
+        ]
+      : []
+  );
+
   errorMessage = signal<string>('');
   successMessage = signal<string>('');
 
@@ -89,15 +112,18 @@ export class OpenPositionsComponent implements OnDestroy {
 
   onSortChange(sort: Sort): void {
     if (sort.direction === '') {
+      this.sortColumns$.set([]);
       this.sortFilterStateService.clearSortState(
         OpenPositionsComponent.tableKey
       );
     } else {
+      const direction = sort.direction;
+      this.sortColumns$.set([{ column: sort.active, direction }]);
       this.sortFilterStateService.saveSortState(
         OpenPositionsComponent.tableKey,
         {
           field: sort.active,
-          order: sort.direction,
+          order: direction,
         }
       );
     }

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html
@@ -2,6 +2,7 @@
 <dms-base-table
   [data]="displayedPositions()"
   [columns]="columns"
+  [sortColumns]="sortColumns$()"
   (sortChange)="onSortChange($event)"
   (renderedRangeChange)="onRangeChange($event)"
 >

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts
@@ -13,6 +13,7 @@ import { handleSocketNotification } from '@smarttools/smart-signals';
 
 import { BaseTableComponent } from '../../shared/components/base-table/base-table.component';
 import { ColumnDef } from '../../shared/components/base-table/column-def.interface';
+import { SortColumn } from '../../shared/services/sort-column.interface';
 import { SortFilterStateService } from '../../shared/services/sort-filter-state.service';
 import { getAccountIds } from '../../store/accounts/selectors/get-account-ids.function';
 import { ClosedPosition } from '../../store/trades/closed-position.interface';
@@ -31,7 +32,28 @@ export class SoldPositionsComponent implements OnDestroy {
   private readonly soldPositionsService = inject(SoldPositionsComponentService);
   private readonly sortFilterStateService = inject(SortFilterStateService);
 
-  searchText = signal<string>('');
+  private readonly restoredFilter = this.sortFilterStateService.loadFilterState(
+    SoldPositionsComponent.tableKey
+  );
+
+  private readonly restoredSort = this.sortFilterStateService.loadSortState(
+    SoldPositionsComponent.tableKey
+  );
+
+  searchText = signal<string>(
+    (this.restoredFilter?.['symbol'] as string) ?? ''
+  );
+
+  sortColumns$ = signal<SortColumn[]>(
+    this.restoredSort !== null
+      ? [
+          {
+            column: this.restoredSort.field,
+            direction: this.restoredSort.order,
+          },
+        ]
+      : []
+  );
 
   visibleRange = signal<{ start: number; end: number }>({
     start: 0,
@@ -70,15 +92,18 @@ export class SoldPositionsComponent implements OnDestroy {
 
   onSortChange(sort: Sort): void {
     if (sort.direction === '') {
+      this.sortColumns$.set([]);
       this.sortFilterStateService.clearSortState(
         SoldPositionsComponent.tableKey
       );
     } else {
+      const direction = sort.direction;
+      this.sortColumns$.set([{ column: sort.active, direction }]);
       this.sortFilterStateService.saveSortState(
         SoldPositionsComponent.tableKey,
         {
           field: sort.active,
-          order: sort.direction,
+          order: direction,
         }
       );
     }


### PR DESCRIPTION
## Story 38.2: Fix Sort/Filter State Persistence for Account Screens

### Problem
The three account table components (Open Positions, Sold Positions, Dividend Deposits) were saving sort/filter state to `SortFilterStateService` but never loading it on initialization. This meant sort indicators and filter values were lost on page reload.

### Solution
Mirror the pattern already used by `GlobalUniverseComponent`:

1. **Open Positions** (`trades-open`): Load saved sort + filter state on init, initialize `searchText` from restored filter, pass `sortColumns` to `BaseTableComponent`
2. **Sold Positions** (`trades-closed`): Same pattern as Open Positions
3. **Dividend Deposits** (`div-deposits`): Load saved sort state on init (no filter input exists), pass `sortColumns` to `BaseTableComponent`

### E2E Test Fix
The two filter persistence tests (`waitForTableRows` after reload) were adjusted to wait for the table component visibility rather than data rows, since the restored filter legitimately excludes all seeded test data (e.g., filtering by 'TEST' when symbols are like 'OPAAA-...').

### Files Changed
- `apps/dms-material/src/app/account-panel/open-positions/open-positions.component.ts` — added state restoration
- `apps/dms-material/src/app/account-panel/open-positions/open-positions.component.html` — added `[sortColumns]` binding
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.ts` — added state restoration
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions.component.html` — added `[sortColumns]` binding
- `apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.ts` — added sort state restoration
- `apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits.component.html` — added `[sortColumns]` binding
- `apps/dms-material-e2e/src/account-sort-filter-persistence.spec.ts` — fixed filter test wait strategy

### Testing
- ✅ 1718 unit tests pass
- ✅ 742 server tests pass
- ✅ All 5 account sort/filter persistence e2e tests pass
- ✅ `pnpm format` clean
- ✅ `pnpm dupcheck` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Table sort preferences are now persisted, restored on return, and reflected in table headers.
  * Previously-entered filters (e.g., symbol search) are restored on component load.

* **Bug Fixes**
  * Improved test reliability for filter persistence after page reload, including cases that yield zero results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->