### PR TITLE
test(e2e): add universe screen sort/filter persistence tests (Story 38.3)

### DIFF
--- a/apps/dms-material-e2e/src/universe-sort-filter-persistence.spec.ts
+++ b/apps/dms-material-e2e/src/universe-sort-filter-persistence.spec.ts
@@ -29,10 +29,12 @@ async function waitForTableRows(page: Page): Promise<void> {
 
 test.describe('Universe Sort/Filter Persistence (Story 38.3)', () => {
   let cleanup: () => Promise<void>;
+  let symbols: string[];
 
   test.beforeAll(async () => {
     const seeder = await seedUniverseE2eData();
     cleanup = seeder.cleanup;
+    symbols = seeder.symbols;
   });
 
   test.afterAll(async () => {
@@ -61,19 +63,17 @@ test.describe('Universe Sort/Filter Persistence (Story 38.3)', () => {
       await header.click();
       await page.waitForTimeout(500);
 
-      // Verify sort indicator is active before reload
-      await expect(header).toHaveAttribute('aria-sort', /ascending|descending/);
+      // Capture exact sort direction before reload
+      const sortBefore = await header.getAttribute('aria-sort');
+      expect(sortBefore).toMatch(/ascending|descending/);
 
       // Reload the page
       await page.reload();
       await waitForTableRows(page);
 
-      // After reload, sort indicator should still be visible
+      // After reload, sort indicator should show the same direction
       const restoredHeader = page.locator('[data-sort-header="symbol"]');
-      await expect(restoredHeader).toHaveAttribute(
-        'aria-sort',
-        /ascending|descending/
-      );
+      await expect(restoredHeader).toHaveAttribute('aria-sort', sortBefore!);
     });
 
     test('sort indicator on Ex-Date persists after page reload', async ({
@@ -84,19 +84,17 @@ test.describe('Universe Sort/Filter Persistence (Story 38.3)', () => {
       await header.click();
       await page.waitForTimeout(500);
 
-      // Verify sort indicator is active before reload
-      await expect(header).toHaveAttribute('aria-sort', /ascending|descending/);
+      // Capture exact sort direction before reload
+      const sortBefore = await header.getAttribute('aria-sort');
+      expect(sortBefore).toMatch(/ascending|descending/);
 
       // Reload the page
       await page.reload();
       await waitForTableRows(page);
 
-      // After reload, sort indicator should still be visible
+      // After reload, sort indicator should show the same direction
       const restoredHeader = page.locator('[data-sort-header="ex_date"]');
-      await expect(restoredHeader).toHaveAttribute(
-        'aria-sort',
-        /ascending|descending/
-      );
+      await expect(restoredHeader).toHaveAttribute('aria-sort', sortBefore!);
     });
   });
 
@@ -113,23 +111,28 @@ test.describe('Universe Sort/Filter Persistence (Story 38.3)', () => {
     });
 
     test('symbol filter value persists after page reload', async ({ page }) => {
-      // Type a filter value into the Symbol search input
+      // Use a seeded symbol prefix to verify both input and data persistence
+      const filterValue = symbols[0];
       const symbolInput = page.getByPlaceholder('Search Symbol');
-      await symbolInput.fill('TESTFILTER');
+      await symbolInput.fill(filterValue);
       // Wait for debounced save (300ms) plus buffer
       await page.waitForTimeout(600);
 
+      // Verify filtered data is visible before reload
+      const rowsBefore = page.locator('tr.mat-mdc-row');
+      await expect(rowsBefore.first()).toBeVisible({ timeout: 10000 });
+
       // Reload the page
       await page.reload();
-      // Wait for the table component to render (not data rows, since the
-      // restored filter may legitimately exclude all seeded data)
-      await expect(page.locator('dms-base-table')).toBeVisible({
-        timeout: 15000,
-      });
+      await waitForTableRows(page);
 
       // After reload, filter input should still contain the value
       const restoredInput = page.getByPlaceholder('Search Symbol');
-      await expect(restoredInput).toHaveValue('TESTFILTER');
+      await expect(restoredInput).toHaveValue(filterValue);
+
+      // After reload, filtered data should still be visible
+      const rowsAfter = page.locator('tr.mat-mdc-row');
+      await expect(rowsAfter.first()).toBeVisible({ timeout: 10000 });
     });
   });
 });


### PR DESCRIPTION
## Story 38.3: Verify Universe Screen Sort/Filter Persistence Still Works

### Summary

Adds Playwright e2e tests verifying that the Universe Screen's sort indicator and filter input values persist across page reloads. This is a verification/regression story ensuring Stories 38.1 and 38.2 did not break existing Universe Screen persistence behavior.

### Changes

- **New file**: `apps/dms-material-e2e/src/universe-sort-filter-persistence.spec.ts`
  - Sort persistence: Verifies sort indicator on Symbol and Ex-Date columns survives page reload
  - Filter persistence: Verifies Symbol filter input value survives page reload
  - Uses existing `seedUniverseE2eData` helper for test data setup

### Testing

- All 3 new tests pass on Chromium ✅
- `pnpm all` passes (no affected lint/build/test targets) ✅
- `pnpm format` passes ✅
- `pnpm dupcheck` passes ✅
- Full Chromium e2e: 553 passed, 49 failed (all pre-existing failures) ✅
- Firefox e2e: running

Closes #878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying that sort order and filter input on the Universe screen persist across page reloads, including data seeding/cleanup and checks that table content remains visible after reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->