### PR TITLE
fix: add min-width to date editor for consistent width when empty (Story 39.2)

### DIFF
--- a/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.html
+++ b/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.html
@@ -2,6 +2,7 @@
 <mat-form-field appearance="outline" class="edit-field">
   <input
     matInput
+    class="min-w-[10ch]"
     [matDatepicker]="picker"
     [(ngModel)]="editValue"
     (dateChange)="onDateSelected($event)"

--- a/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.scss
+++ b/apps/dms-material/src/app/shared/components/editable-date-cell/editable-date-cell.component.scss
@@ -1,5 +1,7 @@
 .display-value {
   cursor: pointer;
+  display: inline-block;
+  min-width: 10ch;
   padding: 4px 8px;
   border-radius: 4px;
 }


### PR DESCRIPTION
## Summary

Fixes the date editor width consistency issue so empty date cells have the same width as filled ones, making them easy to click.

## Changes

- **`editable-date-cell.component.html`**: Added `min-w-[10ch]` Tailwind class to the `<input>` element in edit mode, ensuring the input maintains consistent width regardless of content
- **`editable-date-cell.component.scss`**: Added `display: inline-block` and `min-width: 10ch` to `.display-value` span, ensuring empty date cells are clickable with the same dimensions as filled ones

## Design Decisions

- Uses `ch` units (character-width relative) instead of hardcoded pixels for font-resilient sizing
- `10ch` matches the width of a typical date string like "2024-01-15" (10 characters)
- No `::ng-deep` used (follows ADR-002 CSS policy)
- CSS-only fix with no component logic changes

## Testing

- Date Editor Width Consistency e2e test (Story 39.1) passes
- `pnpm all` passes (lint, build, unit tests)
- `pnpm format` passes
- `pnpm dupcheck` passes (0 clones)

## Story

Story 39.2: Fix Date Editor Width to Be Consistent When Empty or Filled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual layout of editable date input fields with improved minimum width constraints for consistent and better-aligned display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->