### PR TITLE
Story 49.2: E2E tests for Risk Group filter dropdown width

### DIFF
--- a/apps/dms-material-e2e/src/universe-riskgroup-dropdown-width.spec.ts
+++ b/apps/dms-material-e2e/src/universe-riskgroup-dropdown-width.spec.ts
@@ -37,8 +37,11 @@ test.describe('Universe Risk Group Filter Dropdown Width', () => {
   test('Risk Group filter dropdown options do not overflow horizontally', async ({
     page,
   }) => {
-    // The Risk Group mat-select is the first mat-select in the filter row
-    const riskGroupSelect = page.locator('tr.filter-row mat-select').first();
+    // Risk Group is the only filter mat-select with panelWidth="auto"
+    const riskGroupSelect = page.locator(
+      'tr.filter-row mat-select[panelwidth="auto"]'
+    );
+    await expect(riskGroupSelect).toHaveCount(1);
     await expect(riskGroupSelect).toBeVisible({ timeout: 10000 });
 
     // Open the dropdown panel
@@ -67,8 +70,11 @@ test.describe('Universe Risk Group Filter Dropdown Width', () => {
   test('Risk Group filter dropdown panel is at least as wide as its trigger', async ({
     page,
   }) => {
-    // The Risk Group mat-select is the first mat-select in the filter row
-    const riskGroupSelect = page.locator('tr.filter-row mat-select').first();
+    // Risk Group is the only filter mat-select with panelWidth="auto"
+    const riskGroupSelect = page.locator(
+      'tr.filter-row mat-select[panelwidth="auto"]'
+    );
+    await expect(riskGroupSelect).toHaveCount(1);
     await expect(riskGroupSelect).toBeVisible({ timeout: 10000 });
 
     // Capture the trigger bounding box before opening


### PR DESCRIPTION
## Summary

Adds Playwright e2e tests verifying the Risk Group filter dropdown panel displays options without text wrapping (previously fixed by Story 49.1).

## Tests Added
- Asserts all mat-option elements have no horizontal text overflow (`scrollWidth <= clientWidth`)
- Asserts panel width >= trigger width

## Testing
- pnpm e2e:dms-material:chromium passes
- pnpm e2e:dms-material:firefox passes
- pnpm all passes

Closes #939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the Risk Group filter dropdown on the Universe page.
  * Tests verify dropdown options render without horizontal overflow and that the opened dropdown panel is at least as wide as its trigger (with a small tolerance), ensuring consistent layout and improved usability for the filter control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->