### PR TITLE
Story 50.1: Switch fetchDividendHistory to dividendhistory.net with Browser Headers

### DIFF
--- a/apps/server/src/app/routes/common/distribution-api.function.ts
+++ b/apps/server/src/app/routes/common/distribution-api.function.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @smarttools/one-exported-item-per-file -- Utility file with related distribution API functions */
 
 // Yahoo Finance dividend retrieval has been removed (Story 45.1).
-// Dividend data is now sourced exclusively from dividendhistory.org.
+// Dividend data is now sourced exclusively from dividendhistory.net.
 // This stub is retained for structural compatibility with callers and tests.
 
 export interface ProcessedRow {

--- a/apps/server/src/app/routes/common/dividend-history.service.spec.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.spec.ts
@@ -111,7 +111,19 @@ describe('dividend-history.service', () => {
         date: new Date('2026-03-12'),
       });
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://dividendhistory.org/payout/PDI/'
+        'https://dividendhistory.net/payout/PDI/',
+        {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+              '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            Accept:
+              'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,' +
+              'image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            Referer: 'https://dividendhistory.net/',
+          },
+        }
       );
     });
 
@@ -127,7 +139,19 @@ describe('dividend-history.service', () => {
       await fetchDividendHistory('pdi');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://dividendhistory.org/payout/PDI/'
+        'https://dividendhistory.net/payout/PDI/',
+        {
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+              '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+            Accept:
+              'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,' +
+              'image/webp,*/*;q=0.8',
+            'Accept-Language': 'en-US,en;q=0.9',
+            Referer: 'https://dividendhistory.net/',
+          },
+        }
       );
     });
 
@@ -161,7 +185,7 @@ describe('dividend-history.service', () => {
 
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'dividendhistory.org returned 404 for ticker UNKNOWN',
+        'dividendhistory.net returned 404 for ticker UNKNOWN',
         { ticker: 'UNKNOWN', status: 404 }
       );
     });
@@ -177,7 +201,7 @@ describe('dividend-history.service', () => {
 
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'No dividend data found on dividendhistory.org for ticker NODATA',
+        'No dividend data found on dividendhistory.net for ticker NODATA',
         { ticker: 'NODATA' }
       );
     });
@@ -193,7 +217,7 @@ describe('dividend-history.service', () => {
 
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'No dividend data found on dividendhistory.org for ticker BAD',
+        'No dividend data found on dividendhistory.net for ticker BAD',
         { ticker: 'BAD' }
       );
     });
@@ -223,7 +247,7 @@ describe('dividend-history.service', () => {
 
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'No dividend data found on dividendhistory.org for ticker EMPTY',
+        'No dividend data found on dividendhistory.net for ticker EMPTY',
         { ticker: 'EMPTY' }
       );
     });
@@ -235,7 +259,7 @@ describe('dividend-history.service', () => {
 
       expect(result).toEqual([]);
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        'Error fetching dividend history for NET from dividendhistory.org',
+        'Error fetching dividend history for NET from dividendhistory.net',
         { ticker: 'NET', error: 'Error: Network failure' }
       );
     });

--- a/apps/server/src/app/routes/common/dividend-history.service.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.ts
@@ -5,9 +5,22 @@ import type { ProcessedRow } from './distribution-api.function';
 
 // Global rate limiting - track last API call time
 let lastDividendHistoryCallTime = 0;
-const DIVIDEND_HISTORY_RATE_LIMIT_DELAY = 10 * 1000; // 10 seconds in milliseconds
+// 10-second minimum gap between requests — intentionally human-paced to respect
+// dividendhistory.net fair-use expectations and avoid automated-access detection.
+const DIVIDEND_HISTORY_RATE_LIMIT_DELAY = 10 * 1000;
 
-const BASE_URL = 'https://dividendhistory.org/payout';
+const BASE_URL = 'https://dividendhistory.net/payout';
+
+const BROWSER_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+    '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept:
+    'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,' +
+    'image/webp,*/*;q=0.8',
+  'Accept-Language': 'en-US,en;q=0.9',
+  Referer: 'https://dividendhistory.net/',
+} as const;
 
 interface DividendHistoryRow {
   ex_div: string;
@@ -39,10 +52,10 @@ async function fetchAndParseHtml(
   url: string,
   upperTicker: string
 ): Promise<DividendHistoryRow[] | null> {
-  const response = await fetch(url);
+  const response = await fetch(url, { headers: BROWSER_HEADERS });
   if (!response.ok) {
     logger.warn(
-      `dividendhistory.org returned ${String(
+      `dividendhistory.net returned ${String(
         response.status
       )} for ticker ${upperTicker}`,
       { ticker: upperTicker, status: response.status }
@@ -90,7 +103,7 @@ export async function fetchDividendHistory(
 
   try {
     logger.debug(
-      `Fetching dividend history for ${upperTicker} from dividendhistory.org`,
+      `Fetching dividend history for ${upperTicker} from dividendhistory.net`,
       {
         ticker: upperTicker,
         url,
@@ -101,7 +114,7 @@ export async function fetchDividendHistory(
 
     if (!rawRows || rawRows.length === 0) {
       logger.warn(
-        `No dividend data found on dividendhistory.org for ticker ${upperTicker}`,
+        `No dividend data found on dividendhistory.net for ticker ${upperTicker}`,
         { ticker: upperTicker }
       );
       return [];
@@ -118,14 +131,14 @@ export async function fetchDividendHistory(
       });
 
     logger.debug(
-      `Found ${processed.length.toString()} dividend entries for ${upperTicker} from dividendhistory.org`,
+      `Found ${processed.length.toString()} dividend entries for ${upperTicker} from dividendhistory.net`,
       { ticker: upperTicker, count: processed.length }
     );
 
     return processed;
   } catch (error) {
     logger.warn(
-      `Error fetching dividend history for ${upperTicker} from dividendhistory.org`,
+      `Error fetching dividend history for ${upperTicker} from dividendhistory.net`,
       { ticker: upperTicker, error: String(error) }
     );
     return [];

--- a/apps/server/src/app/routes/screener/get-consistent-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/screener/get-consistent-distributions.function.spec.ts
@@ -413,7 +413,7 @@ describe('getConsistentDistributions', () => {
       expect(result).toBe(true);
       expect(mockFetchDistributionData).toHaveBeenCalledWith('NOLISTING');
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-        'fetchDividendHistory returned no data for NOLISTING, falling back to Yahoo Finance',
+        'fetchDividendHistory returned no data for NOLISTING',
         { symbol: 'NOLISTING' }
       );
     });

--- a/apps/server/src/app/routes/screener/get-consistent-distributions.function.ts
+++ b/apps/server/src/app/routes/screener/get-consistent-distributions.function.ts
@@ -66,10 +66,9 @@ export async function getConsistentDistributions(
   let rows = await fetchDividendHistory(symbol);
 
   if (rows.length === 0) {
-    logger.warn(
-      `fetchDividendHistory returned no data for ${symbol}, falling back to Yahoo Finance`,
-      { symbol }
-    );
+    logger.warn(`fetchDividendHistory returned no data for ${symbol}`, {
+      symbol,
+    });
     rows = await fetchDistributionData(symbol);
   }
 


### PR DESCRIPTION
## Summary

Switches dividend data source from dividendhistory.org to dividendhistory.net and adds browser-like request headers to avoid being blocked.

## Changes
- Updated BASE_URL to dividendhistory.net
- Added BROWSER_HEADERS constant with User-Agent, Accept, Accept-Language, Referer
- Updated fetchAndParseHtml to pass headers to fetch()
- Added explanatory comment on rate limit constant
- Updated all log messages from dividendhistory.org → dividendhistory.net
- Removed stale 'falling back to Yahoo Finance' log message in get-consistent-distributions.function.ts
- Updated corresponding test assertions to match new log message and headers

## Testing
- pnpm all passes
- e2e tests pass

Closes #941