### PR TITLE
fix: change Risk Group panelWidth from "auto" to "" to allow natural panel width

### DIFF
--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -121,7 +121,7 @@
           class="header-filter w-full"
         >
           <mat-select
-            panelWidth="auto"
+            panelWidth=""
             [value]="riskGroupFilter$()"
             (selectionChange)="onRiskGroupFilterChange($event.value)"
             placeholder="Select One"


### PR DESCRIPTION
## Story 51.1

Closes #945

## Change Log

Changed `panelWidth="auto"` to `panelWidth=""` on the `mat-select` in the `@case ('risk_group')` block of `global-universe.component.html`.

### Why

`panelWidth="auto"` sizes the dropdown panel overlay to match the trigger field width. Since `mat-form-field` has `class="header-filter w-full"` constraining it to the column width, the panel was too narrow for option labels like "Tax-Free Income" or "Preferreds / Income" — causing text truncation or wrapping.

`panelWidth=""` (empty string) removes the min-width constraint on the CDK overlay panel, allowing it to grow to the natural width of its longest option label. The collapsed trigger width is governed by `w-full` and is unaffected.

### File Changed

- `apps/dms-material/src/app/global/global-universe/global-universe.component.html` — 1 line changed

### Verification

- Playwright MCP confirmed the dropdown panel min-width is `auto` (unconstrained) with the fix applied, vs constrained to trigger width previously
- 1747 unit tests pass (`CI=1 pnpm all`)
- E2E tests pass on Chromium and Firefox
- No duplicate code introduced
- Formatting verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the width property of the risk group filter dropdown panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->