### PR TITLE
test(e2e): Story 51.2 — update Risk Group dropdown width tests for panelWidth=""

### DIFF
--- a/apps/dms-material-e2e/src/universe-riskgroup-dropdown-width.spec.ts
+++ b/apps/dms-material-e2e/src/universe-riskgroup-dropdown-width.spec.ts
@@ -89,12 +89,10 @@ test.describe('Universe Risk Group Filter Dropdown Width', () => {
     expect(panelBox).not.toBeNull();
 
     // Measure the widest option label's rendered width
-    const widestOptionLabelWidth = await page.evaluate(() => {
-      const options = document.querySelectorAll(
-        '.mat-mdc-select-panel mat-option'
-      );
+    const widestOptionLabelWidth = await panel.evaluate((panelEl) => {
+      const labels = panelEl.querySelectorAll('.mdc-list-item__primary-text');
       let maxWidth = 0;
-      options.forEach((el) => {
+      labels.forEach((el) => {
         const w = (el as HTMLElement).scrollWidth;
         if (w > maxWidth) {
           maxWidth = w;
@@ -102,6 +100,7 @@ test.describe('Universe Risk Group Filter Dropdown Width', () => {
       });
       return maxWidth;
     });
+    expect(widestOptionLabelWidth).toBeGreaterThan(0);
 
     // Panel must be at least as wide as the widest option label
     expect(panelBox!.width).toBeGreaterThanOrEqual(widestOptionLabelWidth - 1);


### PR DESCRIPTION
## Summary

Updates the Playwright E2E tests for the Risk Group filter dropdown to reflect the `panelWidth=""` change made in Story 51.1 (PR #946).

## Changes

- **File**: `apps/dms-material-e2e/src/universe-riskgroup-dropdown-width.spec.ts`
  - Change locator in both tests from `mat-select[panelwidth="auto"]` to `mat-select[panelwidth=""]`
  - Update file-header comment to reflect `panelWidth=""` applied in Story 51.1
  - Update both in-test comments to describe content-width behavior
  - Rename second test: 'at least as wide as its trigger' → 'at least as wide as its widest option label'
  - Replace trigger-width assertion with widest-option-label assertion using `page.evaluate()`

## Why

Story 51.1 changed `panelWidth="auto"` to `panelWidth=""` in the Angular template. The DOM attribute changed from `panelwidth="auto"` to `panelwidth=""`, breaking the CSS attribute selector used by the existing tests. The width assertion also needed updating since `panelWidth=""` enables content-width sizing (not trigger-constrained sizing).

## Test Results

- ✅ Chromium: 2/2 passed
- ✅ Firefox: 2/2 passed  
- ✅ `pnpm all` no regressions

Closes #947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated dropdown panel-width tests to match component configuration and improve measurement accuracy.
  * Refined assertions to compare panel width against the widest option label rather than the trigger.
  * Improved measurement technique by computing rendered label widths and adjusted selectors for the overflow scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->