### PR TITLE
feat(universe): apply panelWidth="" to Accounts filter dropdown mat-select

### DIFF
--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -7,6 +7,7 @@
     <mat-form-field appearance="outline" class="account-select">
       <mat-label>Account</mat-label>
       <mat-select
+        panelWidth=""
         [value]="selectedAccountId$()"
         (selectionChange)="onAccountChange($event.value)"
       >


### PR DESCRIPTION
Applies `panelWidth=""` to the Accounts filter dropdown's `mat-select` element on the Universe screen toolbar, allowing the dropdown panel to auto-size to fit account names.

## Changes
- Added `panelWidth=""` as the first attribute on `mat-select` inside `mat-form-field.account-select` in the Universe toolbar

## Related
- Follows the identical fix applied to the Risk Group dropdown in Story 51.1 (#948)
- Story 52.2 will add e2e tests to verify the behavior

Closes #949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the Account filter dropdown panel display properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->