### PR TITLE
feat(e2e): add Universe Accounts filter dropdown width tests (Story 52.2)

### DIFF
--- a/apps/dms-material-e2e/src/universe-accounts-dropdown-width.spec.ts
+++ b/apps/dms-material-e2e/src/universe-accounts-dropdown-width.spec.ts
@@ -87,7 +87,9 @@ test.describe('Universe Accounts Filter Dropdown Width', () => {
       let maxWidth = 0;
       options.forEach((el) => {
         const w = (el as HTMLElement).scrollWidth;
-        if (w > maxWidth) maxWidth = w;
+        if (w > maxWidth) {
+          maxWidth = w;
+        }
       });
       return maxWidth;
     });


### PR DESCRIPTION
## Summary

Adds E2E tests for the Accounts filter dropdown width on the Universe screen, verifying the Story 52.1 fix (panelWidth="" applied to mat-select).

## Tests Added

- **Overflow check**: Asserts no mat-option element has horizontal text overflow
- **Panel width check**: Asserts panel is at least as wide as the widest option label

## Closes

Closes #951

## Test Results

All tests pass on chromium and firefox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying the Universe accounts dropdown renders correctly, ensuring no horizontal overflow of options and that the dropdown panel is wide enough to display option labels without clipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->