### PR TITLE
fix(story-53.2): Fix dividendhistory.net Integration - HTML Table Parsing

### DIFF
--- a/apps/server/src/app/routes/common/dividend-history.service.spec.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.spec.ts
@@ -19,53 +19,48 @@ import {
 const mockLogger = vi.mocked(logger);
 
 const SAMPLE_DIVIDEND_ROWS = [
-  {
-    ex_div: '2026-03-12',
-    payday: '2026-04-01',
-    payout: 0.2205,
-    type: '',
-    currency: 'USD',
-    pctChange: '',
-  },
-  {
-    ex_div: '2026-02-12',
-    payday: '2026-03-02',
-    payout: 0.2205,
-    type: '',
-    currency: 'USD',
-    pctChange: '',
-  },
-  {
-    ex_div: '2026-01-13',
-    payday: '2026-02-02',
-    payout: 0.2205,
-    type: '',
-    currency: 'USD',
-    pctChange: '',
-  },
+  { exDiv: '03/12/2026', payDay: '04/01/2026', payout: 0.2205 },
+  { exDiv: '02/12/2026', payDay: '03/02/2026', payout: 0.2205 },
+  { exDiv: '01/13/2026', payDay: '02/02/2026', payout: 0.2205 },
 ];
 
-const UNCONFIRMED_ROW = {
-  ex_div: '2026-04-10',
-  payday: '2026-05-01',
-  payout: 0.2205,
-  type: 'u',
-  currency: 'USD',
-  pctChange: '',
-};
-
-function buildDividendHtml(rows: unknown[]): string {
-  return `<html><body><script type="application/json" data-dividend-chart-json>${JSON.stringify(
-    rows
-  )}</script></body></html>`;
+function buildDividendHtml(
+  rows: Array<{ exDiv: string; payDay: string; payout: number }>
+): string {
+  const tableRows = rows
+    .map(
+      (r) =>
+        `<tr><td>${r.exDiv}</td><td></td><td></td><td>${
+          r.payDay
+        }</td><td></td><td>$${r.payout.toFixed(5)}</td></tr>`
+    )
+    .join('\n');
+  return `<html><body><table class="table table-bordered"><thead><tr><th>Ex-Div</th><th></th><th></th><th>Pay Date</th><th></th><th>Amount</th></tr></thead><tbody>${tableRows}</tbody></table></body></html>`;
 }
 
 function buildHtmlWithoutScript(): string {
   return '<html><body><p>No dividend data found.</p></body></html>';
 }
 
-function buildHtmlWithInvalidJson(): string {
-  return '<html><body><script type="application/json" data-dividend-chart-json>not valid json</script></body></html>';
+function buildHtmlWithMalformedTable(): string {
+  return '<html><body><table class="table table-bordered"><tbody><tr><td>03/12/2026</td><td>only two</td></tr></tbody></table></body></html>';
+}
+
+function buildMultiTableDividendHtml(
+  rows: Array<{ exDiv: string; payDay: string; payout: number }>
+): string {
+  const dummyTable =
+    '<table class="table table-bordered"><tbody><tr><td>Symbol</td><td>Info</td></tr></tbody></table>';
+  const tableRows = rows
+    .map(
+      (r) =>
+        `<tr><td>${r.exDiv}</td><td></td><td></td><td>${
+          r.payDay
+        }</td><td></td><td>$${r.payout.toFixed(5)}</td></tr>`
+    )
+    .join('\n');
+  const dividendTable = `<table class="table table-bordered"><thead><tr><th>Ex-Div</th><th></th><th></th><th>Pay Date</th><th></th><th>Amount</th></tr></thead><tbody>${tableRows}</tbody></table>`;
+  return `<html><body>${dummyTable}${dividendTable}</body></html>`;
 }
 
 describe('dividend-history.service', () => {
@@ -100,18 +95,18 @@ describe('dividend-history.service', () => {
       expect(result).toHaveLength(3);
       expect(result[0]).toEqual({
         amount: 0.2205,
-        date: new Date('2026-01-13'),
+        date: new Date(2026, 0, 13),
       });
       expect(result[1]).toEqual({
         amount: 0.2205,
-        date: new Date('2026-02-12'),
+        date: new Date(2026, 1, 12),
       });
       expect(result[2]).toEqual({
         amount: 0.2205,
-        date: new Date('2026-03-12'),
+        date: new Date(2026, 2, 12),
       });
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://dividendhistory.net/payout/PDI/',
+        'https://dividendhistory.net/pdi-dividend-yield',
         {
           headers: {
             'User-Agent':
@@ -127,7 +122,7 @@ describe('dividend-history.service', () => {
       );
     });
 
-    test('uppercases ticker in URL', async () => {
+    test('lowercases ticker in URL', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -139,7 +134,7 @@ describe('dividend-history.service', () => {
       await fetchDividendHistory('pdi');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://dividendhistory.net/payout/PDI/',
+        'https://dividendhistory.net/pdi-dividend-yield',
         {
           headers: {
             'User-Agent':
@@ -155,22 +150,43 @@ describe('dividend-history.service', () => {
       );
     });
 
-    test('filters out unconfirmed rows (type === u)', async () => {
-      const rowsWithUnconfirmed = [...SAMPLE_DIVIDEND_ROWS, UNCONFIRMED_ROW];
+    test('parses dividend rows from multiple table.table-bordered tables', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
         text: vi
           .fn()
-          .mockResolvedValueOnce(buildDividendHtml(rowsWithUnconfirmed)),
+          .mockResolvedValueOnce(
+            buildMultiTableDividendHtml(SAMPLE_DIVIDEND_ROWS)
+          ),
+      });
+
+      const result = await fetchDividendHistory('PDI');
+
+      expect(result).toHaveLength(3);
+      expect(result[0].date).toEqual(new Date(2026, 0, 13));
+      expect(result[2].date).toEqual(new Date(2026, 2, 12));
+    });
+
+    test('filters out future ex-div rows', async () => {
+      const futureRow = {
+        exDiv: '12/31/2099',
+        payDay: '01/31/2100',
+        payout: 0.2205,
+      };
+      const rowsWithFuture = [...SAMPLE_DIVIDEND_ROWS, futureRow];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValueOnce(buildDividendHtml(rowsWithFuture)),
       });
 
       const result = await fetchDividendHistory('PDI');
 
       expect(result).toHaveLength(3);
       expect(
-        result.every(function checkNoFutureDate(row) {
-          return row.date < new Date('2026-04-10');
+        result.every(function checkNoPastDate(row) {
+          return row.date < new Date('12/31/2099');
         })
       ).toBe(true);
     });
@@ -190,7 +206,7 @@ describe('dividend-history.service', () => {
       );
     });
 
-    test('returns empty array and logs warning when script tag is missing', async () => {
+    test('returns empty array and logs warning when no dividend table found', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -206,11 +222,11 @@ describe('dividend-history.service', () => {
       );
     });
 
-    test('returns empty array and logs warning when JSON is invalid', async () => {
+    test('returns empty array and logs warning when table has insufficient columns', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        text: vi.fn().mockResolvedValueOnce(buildHtmlWithInvalidJson()),
+        text: vi.fn().mockResolvedValueOnce(buildHtmlWithMalformedTable()),
       });
 
       const result = await fetchDividendHistory('BAD');
@@ -222,13 +238,13 @@ describe('dividend-history.service', () => {
       );
     });
 
-    test('returns empty array when JSON is non-array (object)', async () => {
-      const htmlWithObjectJson =
-        '<html><body><script type="application/json" data-dividend-chart-json>{"key":"value"}</script></body></html>';
+    test('returns empty array when table has no data rows', async () => {
+      const htmlWithOnlyHeader =
+        '<html><body><table class="table table-bordered"><thead><tr><th>Ex-Div</th></tr></thead><tbody></tbody></table></body></html>';
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
-        text: vi.fn().mockResolvedValueOnce(htmlWithObjectJson),
+        text: vi.fn().mockResolvedValueOnce(htmlWithOnlyHeader),
       });
 
       const result = await fetchDividendHistory('OBJ');
@@ -236,7 +252,7 @@ describe('dividend-history.service', () => {
       expect(result).toEqual([]);
     });
 
-    test('returns empty array and logs warning when JSON array is empty', async () => {
+    test('returns empty array and logs warning when table is empty', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -286,9 +302,9 @@ describe('dividend-history.service', () => {
 
     test('sorts result by date ascending', async () => {
       const unsorted = [
-        SAMPLE_DIVIDEND_ROWS[2], // 2026-01-13
-        SAMPLE_DIVIDEND_ROWS[0], // 2026-03-12
-        SAMPLE_DIVIDEND_ROWS[1], // 2026-02-12
+        SAMPLE_DIVIDEND_ROWS[2], // 01/13/2026
+        SAMPLE_DIVIDEND_ROWS[0], // 03/12/2026
+        SAMPLE_DIVIDEND_ROWS[1], // 02/12/2026
       ];
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -298,9 +314,9 @@ describe('dividend-history.service', () => {
 
       const result = await fetchDividendHistory('PDI');
 
-      expect(result[0].date).toEqual(new Date('2026-01-13'));
-      expect(result[1].date).toEqual(new Date('2026-02-12'));
-      expect(result[2].date).toEqual(new Date('2026-03-12'));
+      expect(result[0].date).toEqual(new Date(2026, 0, 13));
+      expect(result[1].date).toEqual(new Date(2026, 1, 12));
+      expect(result[2].date).toEqual(new Date(2026, 2, 12));
     });
 
     test('logs debug on successful fetch', async () => {

--- a/apps/server/src/app/routes/common/dividend-history.service.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.ts
@@ -9,7 +9,7 @@ let lastDividendHistoryCallTime = 0;
 // dividendhistory.net fair-use expectations and avoid automated-access detection.
 const DIVIDEND_HISTORY_RATE_LIMIT_DELAY = 10 * 1000;
 
-const BASE_URL = 'https://dividendhistory.net/payout';
+const BASE_URL = 'https://dividendhistory.net';
 
 const BROWSER_HEADERS = {
   'User-Agent':
@@ -22,13 +22,10 @@ const BROWSER_HEADERS = {
   Referer: 'https://dividendhistory.net/',
 } as const;
 
-interface DividendHistoryRow {
-  ex_div: string;
-  payday: string;
-  payout: number;
-  type: string;
-  currency: string;
-  pctChange: number | string;
+interface ParsedDividendRow {
+  exDiv: string; // column 0: MM/DD/YYYY format
+  payDay: string; // column 3: payout date
+  payout: number; // column 5: dollar amount like "$0.05000"
 }
 
 export async function enforceDividendHistoryRateLimit(): Promise<void> {
@@ -51,7 +48,7 @@ export function updateDividendHistoryCallTime(): void {
 async function fetchAndParseHtml(
   url: string,
   upperTicker: string
-): Promise<DividendHistoryRow[] | null> {
+): Promise<ParsedDividendRow[] | null> {
   const response = await fetch(url, { headers: BROWSER_HEADERS });
   if (!response.ok) {
     logger.warn(
@@ -63,28 +60,70 @@ async function fetchAndParseHtml(
     return null;
   }
   const html = await response.text();
-  return extractDividendJson(html);
+  return parseDividendTable(html);
 }
 
-function extractDividendJson(html: string): DividendHistoryRow[] | null {
-  const scriptRegex =
-    /<script[^>]+data-dividend-chart-json[^>]*>([\s\S]*?)<\/script>/;
-  const match = scriptRegex.exec(html);
-  if (!match) {
-    return null;
+function parseCellValues(cells: string): string[] {
+  const cellValues: string[] = [];
+  const cellRegex = /<td[^>]*>([\s\S]*?)<\/td>/gi;
+  let cellMatch: RegExpExecArray | null;
+  while ((cellMatch = cellRegex.exec(cells)) !== null) {
+    // eslint-disable-next-line sonarjs/slow-regex -- safe: [^>]+ is bounded by > and cannot catastrophically backtrack
+    const text = cellMatch[1].replace(/<[^>]+>/g, '').trim();
+    cellValues.push(text);
   }
-  try {
-    const parsed: unknown = JSON.parse(match[1]);
-    return Array.isArray(parsed) ? (parsed as DividendHistoryRow[]) : null;
-  } catch {
-    return null;
-  }
+  return cellValues;
 }
 
-function mapToProcessedRow(row: DividendHistoryRow): ProcessedRow {
+function parseTableRows(tableContent: string): ParsedDividendRow[] {
+  const rows: ParsedDividendRow[] = [];
+  const rowRegex = /<tr[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch: RegExpExecArray | null;
+
+  while ((rowMatch = rowRegex.exec(tableContent)) !== null) {
+    const cells = rowMatch[1];
+    if (/<th/i.test(cells)) {
+      continue;
+    }
+
+    const cellValues = parseCellValues(cells);
+    if (cellValues.length < 6) {
+      continue;
+    }
+
+    const exDiv = cellValues[0];
+    const payDay = cellValues[3];
+    const payoutStr = cellValues[5].replace(/[$,]/g, '');
+    const payout = parseFloat(payoutStr);
+
+    if (!exDiv || isNaN(payout)) {
+      continue;
+    }
+
+    rows.push({ exDiv, payDay, payout });
+  }
+
+  return rows;
+}
+
+function parseDividendTable(html: string): ParsedDividendRow[] | null {
+  const tableRegex =
+    /<table[^>]*class="[^"]*table[^"]*table-bordered[^"]*"[^>]*>([\s\S]*?)<\/table>/gi;
+  const rows: ParsedDividendRow[] = [];
+  let tableMatch: RegExpExecArray | null;
+
+  while ((tableMatch = tableRegex.exec(html)) !== null) {
+    rows.push(...parseTableRows(tableMatch[1]));
+  }
+
+  return rows.length > 0 ? rows : null;
+}
+
+function mapToProcessedRow(row: ParsedDividendRow): ProcessedRow {
+  const [month, day, year] = row.exDiv.split('/').map(Number);
   return {
     amount: row.payout,
-    date: new Date(row.ex_div),
+    date: new Date(year, month - 1, day),
   };
 }
 
@@ -99,7 +138,9 @@ export async function fetchDividendHistory(
   updateDividendHistoryCallTime();
 
   const upperTicker = ticker.toUpperCase();
-  const url = `${BASE_URL}/${encodeURIComponent(upperTicker)}/`;
+  const url = `${BASE_URL}/${encodeURIComponent(
+    upperTicker.toLowerCase()
+  )}-dividend-yield`;
 
   try {
     logger.debug(
@@ -120,12 +161,13 @@ export async function fetchDividendHistory(
       return [];
     }
 
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
     const processed = rawRows
-      .filter(function filterConfirmedRows(row: DividendHistoryRow): boolean {
-        return row.type !== 'u';
-      })
       .map(mapToProcessedRow)
-      .filter(isValidProcessedRow)
+      .filter(function filterPastRows(row: ProcessedRow): boolean {
+        return isValidProcessedRow(row) && row.date <= today;
+      })
       .sort(function sortByDate(a: ProcessedRow, b: ProcessedRow): number {
         return a.date.valueOf() - b.date.valueOf();
       });


### PR DESCRIPTION
## Summary

Fixes the dividendhistory.net integration based on Story 53.1 investigation findings.

## Changes

- **URL fix**: Change `BASE_URL` from `https://dividendhistory.net/payout` to `https://dividendhistory.net` and update URL pattern from `/payout/{TICKER}/` to `/{ticker}-dividend-yield` (lowercase)
- **Parser fix**: Replace `DividendHistoryRow` interface + `extractDividendJson` (which searched for non-existent `<script data-dividend-chart-json>`) with `ParsedDividendRow` interface + `parseDividendTable` (parses HTML `table.table-bordered`)
- **Table column mapping**: col 0=ex_div (MM/DD/YYYY), col 3=payday, col 5=amount ($0.05000 format)
- **Filter fix**: Replace `row.type !== 'u'` filter (no type field exists) with date-based guard excluding rows where ex-div date > today
- **Tests**: Updated all test fixtures to use HTML table format, corrected URL assertions, replaced type-filter test with future-date-filter test

## Test Coverage

All 15 unit tests pass with 100% branch coverage.

Closes #955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dividend history data retrieval to improve data accuracy and reliability.
  * Refined filtering logic to exclude future ex-dividend dates from historical dividend records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->