### PR TITLE
test(e2e): add Universe sort stickiness spec (Story 54.1)

### DIFF
--- a/apps/dms-material-e2e/src/universe-sort-stickiness.spec.ts
+++ b/apps/dms-material-e2e/src/universe-sort-stickiness.spec.ts
@@ -62,17 +62,13 @@ test.describe('Universe Sort State Stickiness (Story 54.1)', () => {
     // Step 1: Click the Symbol column header twice to apply Symbol descending sort
     const symbolHeader = page.locator('[data-sort-header="symbol"]');
     await symbolHeader.click();
-    await page.waitForTimeout(500);
+    await expect(symbolHeader).toHaveAttribute('aria-sort', 'ascending');
     await symbolHeader.click();
-    await page.waitForTimeout(500);
-
-    // Confirm descending sort is active before navigation
     await expect(symbolHeader).toHaveAttribute('aria-sort', 'descending');
 
     // Step 2: Navigate away using Angular SPA routing (click the nav link)
     // This is a client-side navigation — the Universe component is destroyed
     await page.click('[data-testid="global-nav-screener"]');
-    await page.waitForLoadState('networkidle');
     await expect(page).toHaveURL(/screener/, { timeout: 10000 });
 
     // Step 3: Navigate back to Universe using Angular SPA routing (click the nav link)


### PR DESCRIPTION
## Summary

Adds a Playwright e2e test () that verifies the Universe sort state persists across Angular SPA navigation.

## Change Log

### Added
- New e2e spec file 
- Test seeds universe data, applies Symbol descending sort, navigates to Screener via Angular router link (SPA navigation), navigates back, and asserts sort indicator is restored

## Test Coverage

- Chromium: ✓ passes
- Firefox: ✓ passes

## How to Test

```bash
pnpm e2e:dms-material:chromium
pnpm e2e:dms-material:firefox
```

## Notes

The sort state is read from `localStorage` in `GlobalUniverseComponent`'s `sortColumns$` signal on component init. This test exercises the full end-to-end flow: save via `SortFilterStateService.saveSortColumnsState()` on sort change, restore via `loadSortColumnsState()` on component creation after SPA navigation.

Closes #958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test verifying that column sort state in the Universe table persists across in-app navigation and is restored when returning, ensuring consistent sorting behavior for users. The test seeds data, simulates user sorting and navigation, and validates rehydration of the saved sort preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->