### PR TITLE
feat: Story 57.1 – investigate reverse-split import code and identify gaps

### DIFF
--- a/_bmad-output/implementation-artifacts/57-1-investigate-reverse-split-import-code.md
+++ b/_bmad-output/implementation-artifacts/57-1-investigate-reverse-split-import-code.md
@@ -52,21 +52,21 @@ fix code.
 
   Example 1 — MSTY 1-for-5:
 
-  ```
+  ```csv
   Dec-8-2025,REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001,MSTY,80,--,--,"+2,637.48",...,Joint Brokerage *4767
   Dec-8-2025,REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000,88634T493,-400,--,--,"+2,637.48",...,Joint Brokerage *4767
   ```
 
   Example 2 — ULTY 1-for-10:
 
-  ```
+  ```csv
   Dec-1-2025,REVERSE SPLIT R/S FROM 88636J527#REOR M0051702900001,ULTY,100,--,--,"+1,697.07",...,Joint Brokerage *4767
   Dec-1-2025,REVERSE SPLIT R/S TO 88636X708#REOR M0051702900000,88636J527,"-1,000",--,--,"+1,697.07",...,Joint Brokerage *4767
   ```
 
   Example 3 — OXLC 1-for-5:
 
-  ```
+  ```csv
   Sep-8-2025,REVERSE SPLIT R/S FROM 691543102#REOR M0051680750001,OXLC,306,--,--,"+3,672.63",...,Joint Brokerage *4767
   Sep-8-2025,REVERSE SPLIT R/S TO 691543847#REOR M0051680750000,691543102,"-1,530",--,--,"+3,672.63",...,Joint Brokerage *4767
   ```
@@ -139,7 +139,7 @@ The TO rows (negative quantity, CUSIP as symbol) are also not detected as split 
 
 `calculateSplitRatio(symbol, csvPostSplitQuantity)` **does NOT** derive the ratio from the CSV pair. It always queries the database:
 
-```
+```ts
 ratio = totalCurrentOpenQuantity (from DB) / csvPostSplitQuantity (from CSV)
 ```
 


### PR DESCRIPTION
## Summary

Investigation-only story: audited the existing Fidelity CSV reverse-split import code against real desktop-export CSV rows (MSTY 1-for-5, ULTY 1-for-10, OXLC 1-for-5) to identify exactly what works, what is broken, and what must be fixed before writing any production code.

No production code was changed in this story.

Closes #970

## Key Findings

### What Works
- `isSplitRow()` correctly detects split rows in the **web** export format (where description text lands in `row.description`). The existing OXLC e2e test exercises only this path and passes.
- `resolveCusipSymbols()` already runs before mapping and attempts to resolve CUSIP symbols (TO-row symbols) via cache → 13f.info → Yahoo Finance fallback.
- `isInLieuRow()` is correct as-is — the in-lieu cash payout rows are detected reliably in both formats.

### What Is Broken
1. **`isSplitRow()` fails for desktop format** — the split description text is in `row.action` (the "Description" column), not `row.description` (the "Security Description" column). All three story examples go undetected; their rows fall through as unknown transactions.
2. **Account scoping is absent** — `calculateSplitRatio` and `adjustLotsForSplit` query all accounts in the universe. For multi-account users, a split import from one account incorrectly adjusts lots in other accounts.
3. **No explicit skip for TO rows** — TO rows are implicitly dropped by the `csvPostSplitQuantity <= 0` guard in `calculateSplitRatio`, but there is no dedicated early-return guard. This is fragile and causes a warning log.

### What Needs to Change for Story 57.2
In priority order:
1. **`isSplitRow()`** — also check `row.action` for the word "SPLIT".
2. **New `isSplitFromRow()`** — returns TRUE for FROM rows only (checks for "R/S FROM" in action or description); used to route only FROM rows to ratio calculation.
3. **New `isSplitToRow()`** — returns TRUE for TO rows (checks for "R/S TO"); used for explicit early-return skip.
4. **`calculateSplitRatio()`** — add `accountId` parameter for account-scoped lot query.
5. **`adjustLotsForSplit()`** — add `accountId` parameter for account-scoped lot adjustment.
6. **`handleSplitRow()`** — resolve account from `row.account` and pass `accountId` to both functions above.
7. **Unit tests** (`fidelity-data-mapper.spec.ts`) — add desktop-format paired split test cases.
8. **E2E test + fixture** — add a desktop CSV fixture and e2e scenario for paired FROM/TO split rows.

## No Production Code Changed

All changes in this PR are documentation only (investigation findings in `_bmad-output/implementation-artifacts/57-1-investigate-reverse-split-import-code.md`). Story 57.2 will implement the production fixes identified above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Investigation doc updated to "review" with checklist completed; detailed findings recorded and a prioritized list of recommended fixes for reverse-split import handling.
  * Minor formatting adjustments to key-file and row-format sections.

* **Chores**
  * No user-facing changes; artifacts are internal investigation and planning only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->