### PR TITLE
feat(story-57.2): implement reverse-split detection and ratio calculation

### DIFF
--- a/apps/server/src/app/middleware/csrf-protection-hook.middleware.spec.ts
+++ b/apps/server/src/app/middleware/csrf-protection-hook.middleware.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { csrfProtectionHook } from './csrf-protection-hook.middleware';
+
+describe('csrf-protection-hook.middleware (barrel re-export)', () => {
+  it('re-exports csrfProtectionHook', () => {
+    expect(csrfProtectionHook).toBeDefined();
+    expect(typeof csrfProtectionHook).toBe('function');
+  });
+});

--- a/apps/server/src/app/middleware/enhanced-rate-limit.middleware.spec.ts
+++ b/apps/server/src/app/middleware/enhanced-rate-limit.middleware.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { createRateLimiter } from './enhanced-rate-limit.middleware';
+
+describe('enhanced-rate-limit.middleware (barrel re-export)', () => {
+  it('re-exports createRateLimiter', () => {
+    expect(createRateLimiter).toBeDefined();
+    expect(typeof createRateLimiter).toBe('function');
+  });
+});

--- a/apps/server/src/app/middleware/get-csrf-stats.middleware.spec.ts
+++ b/apps/server/src/app/middleware/get-csrf-stats.middleware.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { getCSRFStats } from './get-csrf-stats.middleware';
+
+describe('get-csrf-stats.middleware (barrel re-export)', () => {
+  it('re-exports getCSRFStats', () => {
+    expect(getCSRFStats).toBeDefined();
+    expect(typeof getCSRFStats).toBe('function');
+  });
+});

--- a/apps/server/src/app/middleware/validate-csrf-token.middleware.spec.ts
+++ b/apps/server/src/app/middleware/validate-csrf-token.middleware.spec.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { validateCSRFToken } from './validate-csrf-token.middleware';
+
+describe('validate-csrf-token.middleware (barrel re-export)', () => {
+  it('re-exports validateCSRFToken', () => {
+    expect(validateCSRFToken).toBeDefined();
+    expect(typeof validateCSRFToken).toBe('function');
+  });
+});

--- a/apps/server/src/app/routes/common/dividend-history.service.spec.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.spec.ts
@@ -300,6 +300,37 @@ describe('dividend-history.service', () => {
       expect(result[0].amount).toBe(0.2205);
     });
 
+    test('filters out rows with empty ex-div date', async () => {
+      const rowsWithEmptyExDiv = [
+        { ...SAMPLE_DIVIDEND_ROWS[0], exDiv: '' },
+        SAMPLE_DIVIDEND_ROWS[1],
+      ];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: vi
+          .fn()
+          .mockResolvedValueOnce(buildDividendHtml(rowsWithEmptyExDiv)),
+      });
+
+      const result = await fetchDividendHistory('PDI');
+
+      expect(result).toHaveLength(1);
+    });
+
+    test('filters out rows with non-numeric payout amount', async () => {
+      const htmlWithNaNPayout = `<html><body><table class="table table-bordered"><thead><tr><th>Ex-Div</th><th></th><th></th><th>Pay Date</th><th></th><th>Amount</th></tr></thead><tbody><tr><td>03/12/2026</td><td></td><td></td><td>04/01/2026</td><td></td><td>$N/A</td></tr><tr><td>02/12/2026</td><td></td><td></td><td>03/02/2026</td><td></td><td>$0.22050</td></tr></tbody></table></body></html>`;
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValueOnce(htmlWithNaNPayout),
+      });
+
+      const result = await fetchDividendHistory('PDI');
+
+      expect(result).toHaveLength(1);
+    });
+
     test('sorts result by date ascending', async () => {
       const unsorted = [
         SAMPLE_DIVIDEND_ROWS[2], // 01/13/2026

--- a/apps/server/src/app/routes/import/adjust-lots-for-split.function.spec.ts
+++ b/apps/server/src/app/routes/import/adjust-lots-for-split.function.spec.ts
@@ -68,7 +68,7 @@ describe('adjustLotsForSplit', function () {
     txFindMany.mockResolvedValue([{ id: 'lot-1', quantity: 1000, buy: 5.0 }]);
     txUpdate.mockResolvedValue({});
 
-    const count = await adjustLotsForSplit('OXLC', 5);
+    const count = await adjustLotsForSplit('OXLC', 5, 'acct-1');
 
     expect(count).toBe(1);
     expect(txUpdate).toHaveBeenCalledWith({
@@ -83,7 +83,7 @@ describe('adjustLotsForSplit', function () {
     txFindMany.mockResolvedValue([{ id: 'lot-2', quantity: 100, buy: 20.0 }]);
     txUpdate.mockResolvedValue({});
 
-    const count = await adjustLotsForSplit('XYZ', 0.5);
+    const count = await adjustLotsForSplit('XYZ', 0.5, 'acct-1');
 
     expect(count).toBe(1);
     expect(txUpdate).toHaveBeenCalledWith({
@@ -109,7 +109,7 @@ describe('adjustLotsForSplit', function () {
       }
     );
 
-    await adjustLotsForSplit('OXLC', ratio);
+    await adjustLotsForSplit('OXLC', ratio, 'acct-1');
 
     const valueBefore = quantity * buy;
     const valueAfter = captured[0].quantity * captured[0].buy;
@@ -126,7 +126,7 @@ describe('adjustLotsForSplit', function () {
     ]);
     txUpdate.mockResolvedValue({});
 
-    const count = await adjustLotsForSplit('OXLC', 5);
+    const count = await adjustLotsForSplit('OXLC', 5, 'acct-1');
 
     expect(count).toBe(3);
     expect(txUpdate).toHaveBeenCalledTimes(3);
@@ -152,7 +152,7 @@ describe('adjustLotsForSplit', function () {
     ]);
     txUpdate.mockResolvedValue({});
 
-    const count = await adjustLotsForSplit('SINGLE', 5);
+    const count = await adjustLotsForSplit('SINGLE', 5, 'acct-1');
 
     expect(count).toBe(1);
     expect(txUpdate).toHaveBeenCalledWith({
@@ -169,7 +169,7 @@ describe('adjustLotsForSplit', function () {
     ]);
     txUpdate.mockResolvedValue({});
 
-    await adjustLotsForSplit('OXLC', 5);
+    await adjustLotsForSplit('OXLC', 5, 'acct-1');
 
     expect(txUpdate).toHaveBeenCalledWith({
       where: { id: 'lot-floor' },
@@ -180,7 +180,7 @@ describe('adjustLotsForSplit', function () {
   test('returns 0 and logs warning when universe entry not found', async function () {
     prisma.universe.findFirst.mockResolvedValue(null);
 
-    const count = await adjustLotsForSplit('UNKNOWN', 5);
+    const count = await adjustLotsForSplit('UNKNOWN', 5, 'acct-1');
 
     expect(count).toBe(0);
     expect(txUpdate).not.toHaveBeenCalled();
@@ -193,7 +193,7 @@ describe('adjustLotsForSplit', function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'u-6' });
     txFindMany.mockResolvedValue([]);
 
-    const count = await adjustLotsForSplit('NOPOS', 5);
+    const count = await adjustLotsForSplit('NOPOS', 5, 'acct-1');
 
     expect(count).toBe(0);
     expect(txUpdate).not.toHaveBeenCalled();
@@ -203,7 +203,7 @@ describe('adjustLotsForSplit', function () {
   });
 
   test('returns 0 and logs warning when ratio is zero', async function () {
-    const count = await adjustLotsForSplit('OXLC', 0);
+    const count = await adjustLotsForSplit('OXLC', 0, 'acct-1');
 
     expect(count).toBe(0);
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -212,7 +212,7 @@ describe('adjustLotsForSplit', function () {
   });
 
   test('returns 0 and logs warning when ratio is negative', async function () {
-    const count = await adjustLotsForSplit('OXLC', -1);
+    const count = await adjustLotsForSplit('OXLC', -1, 'acct-1');
 
     expect(count).toBe(0);
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -221,7 +221,7 @@ describe('adjustLotsForSplit', function () {
   });
 
   test('returns 0 and logs warning when ratio is NaN', async function () {
-    const count = await adjustLotsForSplit('OXLC', Number.NaN);
+    const count = await adjustLotsForSplit('OXLC', Number.NaN, 'acct-1');
 
     expect(count).toBe(0);
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -234,11 +234,12 @@ describe('adjustLotsForSplit', function () {
     txFindMany.mockResolvedValue([{ id: 'lot-x', quantity: 100, buy: 5.0 }]);
     txUpdate.mockResolvedValue({});
 
-    await adjustLotsForSplit('FILTERTEST', 5);
+    await adjustLotsForSplit('FILTERTEST', 5, 'acct-7');
 
     expect(txFindMany).toHaveBeenCalledWith({
       where: {
         universeId: 'u-7',
+        accountId: 'acct-7',
         sell_date: null,
       },
       select: { id: true, quantity: true, buy: true, accountId: true },
@@ -254,7 +255,7 @@ describe('adjustLotsForSplit', function () {
     ]);
     txUpdate.mockResolvedValue({});
 
-    await adjustLotsForSplit('ATOMIC', 5);
+    await adjustLotsForSplit('ATOMIC', 5, 'acct-1');
 
     expect(prisma.$transaction).toHaveBeenCalledOnce();
     expect(txFindMany).toHaveBeenCalledOnce();
@@ -276,7 +277,7 @@ describe('adjustLotsForSplit', function () {
     txUpdate.mockResolvedValue({});
     txCreate.mockResolvedValue({});
 
-    await adjustLotsForSplit('OXLC', 5);
+    await adjustLotsForSplit('OXLC', 5, 'acct-1');
 
     expect(txCreate).toHaveBeenCalledOnce();
     const call = txCreate.mock.calls[0][0];
@@ -299,7 +300,7 @@ describe('adjustLotsForSplit', function () {
     ]);
     txUpdate.mockResolvedValue({});
 
-    await adjustLotsForSplit('EXACT', 5);
+    await adjustLotsForSplit('EXACT', 5, 'acct-1');
 
     expect(txCreate).not.toHaveBeenCalled();
   });
@@ -316,7 +317,7 @@ describe('adjustLotsForSplit', function () {
     txUpdate.mockResolvedValue({});
     txCreate.mockResolvedValue({});
 
-    await adjustLotsForSplit('NOPRICE', 5);
+    await adjustLotsForSplit('NOPRICE', 5, 'acct-1');
 
     expect(loggerWarn).toHaveBeenCalledWith(
       expect.stringContaining('no market price available')
@@ -339,7 +340,7 @@ describe('adjustLotsForSplit', function () {
     txUpdate.mockResolvedValue({});
     txCreate.mockResolvedValue({});
 
-    await adjustLotsForSplit('NEGPRICE', 5);
+    await adjustLotsForSplit('NEGPRICE', 5, 'acct-1');
 
     expect(loggerWarn).toHaveBeenCalledWith(
       expect.stringContaining('no market price available')
@@ -364,7 +365,7 @@ describe('adjustLotsForSplit', function () {
     txUpdate.mockResolvedValue({});
     txCreate.mockResolvedValue({});
 
-    await adjustLotsForSplit('MULTI', 5);
+    await adjustLotsForSplit('MULTI', 5, 'acct-1');
 
     expect(txCreate).toHaveBeenCalledOnce();
     const call = txCreate.mock.calls[0][0];
@@ -387,7 +388,7 @@ describe('adjustLotsForSplit', function () {
     txUpdate.mockResolvedValue({});
     txCreate.mockResolvedValue({});
 
-    await adjustLotsForSplit('BOTH', 5);
+    await adjustLotsForSplit('BOTH', 5, 'acct-1');
 
     expect(txCreate).toHaveBeenCalledOnce();
     const call = txCreate.mock.calls[0][0];

--- a/apps/server/src/app/routes/import/adjust-lots-for-split.function.ts
+++ b/apps/server/src/app/routes/import/adjust-lots-for-split.function.ts
@@ -68,7 +68,7 @@ async function recordFractionalSale(
 }
 
 /**
- * Adjusts all open position lots for a given symbol by applying a split ratio.
+ * Adjusts all open position lots for a given symbol and account by applying a split ratio.
  *
  * For each open lot:
  *   newQuantity     = Math.floor(lot.quantity / ratio)  // whole shares
@@ -79,13 +79,15 @@ async function recordFractionalSale(
  *
  * All updates are applied atomically within a single Prisma transaction.
  *
- * @param symbol - The ticker symbol whose lots should be adjusted
- * @param ratio  - The split ratio (>1 for reverse split, <1 for forward split)
+ * @param symbol    - The ticker symbol whose lots should be adjusted
+ * @param ratio     - The split ratio (>1 for reverse split, <1 for forward split)
+ * @param accountId - Only adjust lots belonging to this account
  * @returns The number of lots updated
  */
 export async function adjustLotsForSplit(
   symbol: string,
-  ratio: number
+  ratio: number,
+  accountId: string
 ): Promise<number> {
   if (!Number.isFinite(ratio) || ratio <= 0) {
     logger.warn(
@@ -110,7 +112,7 @@ export async function adjustLotsForSplit(
   await prisma.$transaction(async function applyLotUpdates(tx) {
     const txClient = tx as unknown as PrismaClient;
     const openLots = await txClient.trades.findMany({
-      where: { universeId: universeEntry.id, sell_date: null },
+      where: { universeId: universeEntry.id, accountId, sell_date: null },
       select: { id: true, quantity: true, buy: true, accountId: true },
     });
 

--- a/apps/server/src/app/routes/import/calculate-split-ratio.function.spec.ts
+++ b/apps/server/src/app/routes/import/calculate-split-ratio.function.spec.ts
@@ -46,7 +46,7 @@ describe('calculateSplitRatio', function () {
       { quantity: 530 },
     ]);
 
-    const result = await calculateSplitRatio('OXLC', 306);
+    const result = await calculateSplitRatio('OXLC', 306, 'acct-1');
 
     expect(result).toBe(5);
   });
@@ -55,7 +55,7 @@ describe('calculateSplitRatio', function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'universe-2' });
     prisma.trades.findMany.mockResolvedValue([{ quantity: 100 }]);
 
-    const result = await calculateSplitRatio('XYZ', 200);
+    const result = await calculateSplitRatio('XYZ', 200, 'acct-1');
 
     expect(result).toBe(0.5);
   });
@@ -64,13 +64,13 @@ describe('calculateSplitRatio', function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'universe-3' });
     prisma.trades.findMany.mockResolvedValue([{ quantity: 1000 }]);
 
-    const result = await calculateSplitRatio('ABC', 500);
+    const result = await calculateSplitRatio('ABC', 500, 'acct-1');
 
     expect(result).toBe(2);
   });
 
   test('returns null and logs a warning when csvPostSplitQuantity is zero', async function () {
-    const result = await calculateSplitRatio('OXLC', 0);
+    const result = await calculateSplitRatio('OXLC', 0, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -79,7 +79,7 @@ describe('calculateSplitRatio', function () {
   });
 
   test('returns null and logs a warning when csvPostSplitQuantity is negative', async function () {
-    const result = await calculateSplitRatio('OXLC', -100);
+    const result = await calculateSplitRatio('OXLC', -100, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -88,7 +88,7 @@ describe('calculateSplitRatio', function () {
   });
 
   test('returns null and logs a warning when csvPostSplitQuantity is NaN', async function () {
-    const result = await calculateSplitRatio('OXLC', Number.NaN);
+    const result = await calculateSplitRatio('OXLC', Number.NaN, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe('calculateSplitRatio', function () {
   });
 
   test('returns null and logs a warning when csvPostSplitQuantity is Infinity', async function () {
-    const result = await calculateSplitRatio('OXLC', Infinity);
+    const result = await calculateSplitRatio('OXLC', Infinity, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -109,7 +109,7 @@ describe('calculateSplitRatio', function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'universe-4' });
     prisma.trades.findMany.mockResolvedValue([]);
 
-    const result = await calculateSplitRatio('NOPOS', 100);
+    const result = await calculateSplitRatio('NOPOS', 100, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -120,7 +120,7 @@ describe('calculateSplitRatio', function () {
   test('returns null and logs a warning when no universe entry is found', async function () {
     prisma.universe.findFirst.mockResolvedValue(null);
 
-    const result = await calculateSplitRatio('UNKNOWN', 100);
+    const result = await calculateSplitRatio('UNKNOWN', 100, 'acct-1');
 
     expect(result).toBeNull();
     expect(loggerWarn).toHaveBeenCalledWith(
@@ -132,7 +132,7 @@ describe('calculateSplitRatio', function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'universe-5' });
     prisma.trades.findMany.mockResolvedValue([{ quantity: 500 }]);
 
-    const result = await calculateSplitRatio('SINGLE', 250);
+    const result = await calculateSplitRatio('SINGLE', 250, 'acct-1');
 
     expect(result).toBe(2);
   });
@@ -145,20 +145,21 @@ describe('calculateSplitRatio', function () {
       { quantity: 500 },
     ]);
 
-    const result = await calculateSplitRatio('MULTI', 200);
+    const result = await calculateSplitRatio('MULTI', 200, 'acct-2');
 
     expect(result).toBe(5);
   });
 
-  test('queries trades with correct open-position filters', async function () {
+  test('queries trades with correct account-scoped open-position filters', async function () {
     prisma.universe.findFirst.mockResolvedValue({ id: 'universe-7' });
     prisma.trades.findMany.mockResolvedValue([{ quantity: 100 }]);
 
-    await calculateSplitRatio('FILTERTEST', 100);
+    await calculateSplitRatio('FILTERTEST', 100, 'acct-7');
 
     expect(prisma.trades.findMany).toHaveBeenCalledWith({
       where: {
         universeId: 'universe-7',
+        accountId: 'acct-7',
         sell_date: null,
       },
       select: { quantity: true },

--- a/apps/server/src/app/routes/import/calculate-split-ratio.function.ts
+++ b/apps/server/src/app/routes/import/calculate-split-ratio.function.ts
@@ -13,11 +13,16 @@ function sumOpenQuantity(sum: number, trade: { quantity: number }): number {
  * - ratio > 1 → reverse split (e.g., 5 means 1-for-5 reverse split)
  * - ratio < 1 → forward split (e.g., 0.5 means 2-for-1 forward split)
  *
+ * @param symbol - The ticker symbol to calculate the split ratio for
+ * @param csvPostSplitQuantity - The post-split quantity from the CSV row (must be > 0)
+ * @param accountId - Only consider open lots belonging to this account
+ *
  * Returns null if no open lots exist for the symbol (caller must skip the split row).
  */
 export async function calculateSplitRatio(
   symbol: string,
-  csvPostSplitQuantity: number
+  csvPostSplitQuantity: number,
+  accountId: string
 ): Promise<number | null> {
   if (!Number.isFinite(csvPostSplitQuantity) || csvPostSplitQuantity <= 0) {
     logger.warn(
@@ -40,6 +45,7 @@ export async function calculateSplitRatio(
   const openTrades = await prisma.trades.findMany({
     where: {
       universeId: universeEntry.id,
+      accountId,
       sell_date: null,
     },
     select: { quantity: true },

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
@@ -1396,7 +1396,7 @@ describe('mapFidelityTransactions', function () {
   });
 
   describe('split row handling', function () {
-    test('calls calculateSplitRatio with symbol and csv quantity when split row detected', async function () {
+    test('calls calculateSplitRatio with symbol, csv quantity, and accountId when split row detected', async function () {
       const rows: ParsedCsvRow[] = [
         {
           date: '02/15/2026',
@@ -1410,21 +1410,26 @@ describe('mapFidelityTransactions', function () {
         },
       ];
 
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-brokerage' });
       mockCalculateSplitRatio.mockResolvedValue(5);
       mockAdjustLotsForSplit.mockResolvedValue(3);
 
       await mapFidelityTransactions(rows);
 
-      expect(mockCalculateSplitRatio).toHaveBeenCalledWith('OXLC', 306);
+      expect(mockCalculateSplitRatio).toHaveBeenCalledWith(
+        'OXLC',
+        306,
+        'acct-brokerage'
+      );
     });
 
-    test('calls adjustLotsForSplit with symbol and ratio when calculateSplitRatio returns a ratio', async function () {
+    test('calls adjustLotsForSplit with symbol, ratio, and accountId when calculateSplitRatio returns a ratio', async function () {
       const rows: ParsedCsvRow[] = [
         {
           date: '02/15/2026',
-          action: 'STOCK SPLIT',
+          action: 'YOU SOLD',
           symbol: 'XYZ',
-          description: 'FORWARD SPLIT 2:1',
+          description: 'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001',
           quantity: 200,
           price: 0,
           totalAmount: 0,
@@ -1432,21 +1437,26 @@ describe('mapFidelityTransactions', function () {
         },
       ];
 
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-brokerage' });
       mockCalculateSplitRatio.mockResolvedValue(0.5);
       mockAdjustLotsForSplit.mockResolvedValue(2);
 
       await mapFidelityTransactions(rows);
 
-      expect(mockAdjustLotsForSplit).toHaveBeenCalledWith('XYZ', 0.5);
+      expect(mockAdjustLotsForSplit).toHaveBeenCalledWith(
+        'XYZ',
+        0.5,
+        'acct-brokerage'
+      );
     });
 
     test('does not call adjustLotsForSplit when calculateSplitRatio returns null', async function () {
       const rows: ParsedCsvRow[] = [
         {
           date: '02/15/2026',
-          action: 'REVERSE SPLIT',
+          action: 'YOU SOLD',
           symbol: 'NOPOS',
-          description: 'REVERSE SPLIT NO OPEN LOTS',
+          description: 'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001',
           quantity: 100,
           price: 0,
           totalAmount: 0,
@@ -1454,6 +1464,7 @@ describe('mapFidelityTransactions', function () {
         },
       ];
 
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-brokerage' });
       mockCalculateSplitRatio.mockResolvedValue(null);
 
       await mapFidelityTransactions(rows);
@@ -1475,6 +1486,7 @@ describe('mapFidelityTransactions', function () {
         },
       ];
 
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-brokerage' });
       mockCalculateSplitRatio.mockResolvedValue(5);
       mockAdjustLotsForSplit.mockResolvedValue(3);
 
@@ -1483,6 +1495,113 @@ describe('mapFidelityTransactions', function () {
       expect(result.trades).toHaveLength(0);
       expect(result.sales).toHaveLength(0);
       expect(result.divDeposits).toHaveLength(0);
+    });
+
+    // Desktop-format tests: split text is in row.action, description is security name
+    test('desktop-format MSTY FROM row (action contains R/S FROM): calls calculateSplitRatio with correct args', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '12/08/2025',
+          action: 'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001',
+          symbol: 'MSTY',
+          description: 'MSTY UNIT',
+          quantity: 80,
+          price: 0,
+          totalAmount: 0,
+          account: 'Joint Brokerage *4767',
+        },
+      ];
+
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-joint' });
+      mockCalculateSplitRatio.mockResolvedValue(5);
+      mockAdjustLotsForSplit.mockResolvedValue(1);
+
+      await mapFidelityTransactions(rows);
+
+      expect(mockCalculateSplitRatio).toHaveBeenCalledWith(
+        'MSTY',
+        80,
+        'acct-joint'
+      );
+      expect(mockAdjustLotsForSplit).toHaveBeenCalledWith(
+        'MSTY',
+        5,
+        'acct-joint'
+      );
+    });
+
+    test('desktop-format ULTY FROM row (action contains R/S FROM): processes 1-for-10 split correctly', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '12/01/2025',
+          action: 'REVERSE SPLIT R/S FROM 88636J527#REOR M0051702900001',
+          symbol: 'ULTY',
+          description: 'ULTY ETF',
+          quantity: 100,
+          price: 0,
+          totalAmount: 0,
+          account: 'Joint Brokerage *4767',
+        },
+      ];
+
+      mockPrisma.accounts.findFirst.mockResolvedValue({ id: 'acct-joint' });
+      mockCalculateSplitRatio.mockResolvedValue(10);
+      mockAdjustLotsForSplit.mockResolvedValue(1);
+
+      await mapFidelityTransactions(rows);
+
+      expect(mockCalculateSplitRatio).toHaveBeenCalledWith(
+        'ULTY',
+        100,
+        'acct-joint'
+      );
+      expect(mockAdjustLotsForSplit).toHaveBeenCalledWith(
+        'ULTY',
+        10,
+        'acct-joint'
+      );
+    });
+
+    test('desktop-format TO row (action contains R/S TO): is skipped without calling calculateSplitRatio', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '12/08/2025',
+          action: 'REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000',
+          symbol: '88634T493',
+          description: 'MSTY UNIT',
+          quantity: -400,
+          price: 0,
+          totalAmount: 0,
+          account: 'Joint Brokerage *4767',
+        },
+      ];
+
+      await mapFidelityTransactions(rows);
+
+      expect(mockCalculateSplitRatio).not.toHaveBeenCalled();
+      expect(mockAdjustLotsForSplit).not.toHaveBeenCalled();
+    });
+
+    test('desktop-format TO row: produces no trades, sales, divDeposits, or unknown transactions', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '12/08/2025',
+          action: 'REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000',
+          symbol: '88634T493',
+          description: 'MSTY UNIT',
+          quantity: -400,
+          price: 0,
+          totalAmount: 0,
+          account: 'Joint Brokerage *4767',
+        },
+      ];
+
+      const result = await mapFidelityTransactions(rows);
+
+      expect(result.trades).toHaveLength(0);
+      expect(result.sales).toHaveLength(0);
+      expect(result.divDeposits).toHaveLength(0);
+      expect(result.unknownTransactions).toHaveLength(0);
     });
   });
 });

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
@@ -5,6 +5,7 @@ import { adjustLotsForSplit } from './adjust-lots-for-split.function';
 import { calculateSplitRatio } from './calculate-split-ratio.function';
 import { FidelityCsvRow } from './fidelity-csv-row.interface';
 import { isInLieuRow } from './is-in-lieu-row.function';
+import { isSplitFromRow } from './is-split-from-row.function';
 import { isSplitRow } from './is-split-row.function';
 import { MappedDivDeposit } from './mapped-div-deposit.interface';
 import { MappedSale } from './mapped-sale.interface';
@@ -284,16 +285,7 @@ function isSellAction(action: string): boolean {
 }
 
 function createUnknownTransaction(row: FidelityCsvRow): UnknownTransaction {
-  return {
-    date: row.date,
-    action: row.action,
-    symbol: row.symbol,
-    description: row.description,
-    quantity: row.quantity,
-    price: row.price,
-    totalAmount: row.totalAmount,
-    account: row.account,
-  } as UnknownTransaction;
+  return row as UnknownTransaction;
 }
 
 async function handleBuyRow(
@@ -335,12 +327,27 @@ async function handleDividendRow(
 }
 
 /**
- * Handles a split CSV row by calculating the split ratio and adjusting all open lots.
+ * Handles a split CSV row by calculating the split ratio and adjusting open lots.
+ *
+ * TO rows (negative quantity, old-CUSIP symbol) are skipped because they carry no
+ * information beyond what the matching FROM row already provides.
+ *
+ * Account scoping is applied so that only lots belonging to the CSV row's account are
+ * adjusted, preventing premature adjustments for other accounts not yet split.
  */
-async function handleSplitRow(row: FidelityCsvRow): Promise<void> {
-  const ratio = await calculateSplitRatio(row.symbol, row.quantity);
+async function handleSplitRow(
+  row: FidelityCsvRow,
+  accountCache: Map<string, { id: string }>
+): Promise<void> {
+  // Only process FROM rows; TO rows and unrecognised split rows are silently skipped.
+  if (!isSplitFromRow(row)) {
+    return;
+  }
+
+  const account = await resolveAccount(row.account, accountCache);
+  const ratio = await calculateSplitRatio(row.symbol, row.quantity, account.id);
   if (ratio !== null) {
-    await adjustLotsForSplit(row.symbol, ratio);
+    await adjustLotsForSplit(row.symbol, ratio, account.id);
   }
 }
 
@@ -358,9 +365,9 @@ async function mapSingleRow(
     return;
   }
 
-  // Split rows: calculate ratio and adjust all open lots (Stories 48.2–48.3).
+  // Split rows: calculate ratio and adjust all open lots (Stories 48.2–48.3, 57.2).
   if (isSplitRow(row)) {
-    await handleSplitRow(row);
+    await handleSplitRow(row, accountCache);
     return;
   }
 
@@ -384,11 +391,10 @@ async function mapSingleRow(
     await handleDividendRow(row, result, account.id);
     return;
   }
-  if (action.startsWith('ELECTRONIC FUNDS TRANSFER')) {
-    result.divDeposits.push(await mapCashDeposit(row, account.id));
-    return;
-  }
-  if (action.startsWith('MONEY LINE RECEIVED')) {
+  if (
+    action.startsWith('ELECTRONIC FUNDS TRANSFER') ||
+    action.startsWith('MONEY LINE RECEIVED')
+  ) {
     result.divDeposits.push(await mapCashDeposit(row, account.id));
     return;
   }

--- a/apps/server/src/app/routes/import/is-split-from-row.function.spec.ts
+++ b/apps/server/src/app/routes/import/is-split-from-row.function.spec.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+
+import { isSplitFromRow } from './is-split-from-row.function';
+import { FidelityCsvRow } from './fidelity-csv-row.interface';
+
+function makeRow(description: string, action = 'YOU BOUGHT'): FidelityCsvRow {
+  return {
+    date: '12/08/2025',
+    action,
+    symbol: 'MSTY',
+    description,
+    quantity: 80,
+    price: 0,
+    totalAmount: 0,
+    account: 'Joint Brokerage *4767',
+  };
+}
+
+describe('isSplitFromRow', function () {
+  // Web format: R/S FROM text is in row.description
+  test('returns true for web-format FROM row (description contains R/S FROM)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow('REVERSE SPLIT R/S FROM 691543102#REOR M005168075001')
+      )
+    ).toBe(true);
+  });
+
+  // Desktop format: R/S FROM text is in row.action
+  test('returns true for desktop-format MSTY FROM row (action contains R/S FROM)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns true for desktop-format ULTY FROM row (action contains R/S FROM)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow(
+          'ULTY ETF',
+          'REVERSE SPLIT R/S FROM 88636J527#REOR M0051702900001'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns true for desktop-format OXLC FROM row (action contains R/S FROM)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow(
+          'OXLC COMMON STOCK',
+          'REVERSE SPLIT R/S FROM 691543102#REOR M0051680750001'
+        )
+      )
+    ).toBe(true);
+  });
+
+  // TO rows should NOT match
+  test('returns false for desktop-format TO row (action contains R/S TO, not R/S FROM)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000'
+        )
+      )
+    ).toBe(false);
+  });
+
+  test('returns false for web-format TO row (description contains R/S TO)', function () {
+    expect(
+      isSplitFromRow(
+        makeRow('REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000')
+      )
+    ).toBe(false);
+  });
+
+  // Non-split rows
+  test('returns false for a dividend row', function () {
+    expect(isSplitFromRow(makeRow('MSTY UNIT', 'DIVIDEND RECEIVED'))).toBe(
+      false
+    );
+  });
+
+  test('returns false when neither field contains R/S FROM', function () {
+    expect(isSplitFromRow(makeRow('COMMON STOCK', 'YOU BOUGHT'))).toBe(false);
+  });
+
+  test('returns false when both description and action are undefined', function () {
+    expect(
+      isSplitFromRow({
+        description: undefined,
+        action: undefined,
+      } as unknown as FidelityCsvRow)
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/app/routes/import/is-split-from-row.function.ts
+++ b/apps/server/src/app/routes/import/is-split-from-row.function.ts
@@ -1,0 +1,17 @@
+import { FidelityCsvRow } from './fidelity-csv-row.interface';
+
+/**
+ * Returns true if the CSV row is a "REVERSE SPLIT R/S FROM" row (the new-share receipt side
+ * of a Fidelity reverse-split pair).
+ *
+ * Both web and desktop formats are handled:
+ *   Web format:     "R/S FROM" text is in `row.description`
+ *   Desktop format: "R/S FROM" text is in `row.action` (the "Description" column)
+ */
+export function isSplitFromRow(row: FidelityCsvRow): boolean {
+  return (
+    (row.description?.toUpperCase().includes('R/S FROM') ||
+      row.action?.toUpperCase().includes('R/S FROM')) ??
+    false
+  );
+}

--- a/apps/server/src/app/routes/import/is-split-row.function.spec.ts
+++ b/apps/server/src/app/routes/import/is-split-row.function.spec.ts
@@ -3,10 +3,10 @@ import { describe, expect, test } from 'vitest';
 import { isSplitRow } from './is-split-row.function';
 import { FidelityCsvRow } from './fidelity-csv-row.interface';
 
-function makeRow(description: string): FidelityCsvRow {
+function makeRow(description: string, action = 'YOU BOUGHT'): FidelityCsvRow {
   return {
     date: '04/04/2026',
-    action: 'YOU BOUGHT',
+    action,
     symbol: 'OXLC',
     description,
     quantity: 306,
@@ -45,5 +45,41 @@ describe('isSplitRow', function () {
 
   test('returns false for empty description', function () {
     expect(isSplitRow(makeRow(''))).toBe(false);
+  });
+
+  // Desktop format: split text is in row.action, not row.description
+  test('returns true when action contains "SPLIT" (desktop FROM row)', function () {
+    expect(
+      isSplitRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns true when action contains "SPLIT" (desktop TO row)', function () {
+    expect(
+      isSplitRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns false when neither description nor action contains "SPLIT"', function () {
+    expect(isSplitRow(makeRow('MSTY UNIT', 'DIVIDEND RECEIVED'))).toBe(false);
+  });
+
+  test('returns false when both description and action are undefined', function () {
+    expect(
+      isSplitRow({
+        description: undefined,
+        action: undefined,
+      } as unknown as FidelityCsvRow)
+    ).toBe(false);
   });
 });

--- a/apps/server/src/app/routes/import/is-split-row.function.ts
+++ b/apps/server/src/app/routes/import/is-split-row.function.ts
@@ -2,10 +2,16 @@ import { FidelityCsvRow } from './fidelity-csv-row.interface';
 
 /**
  * Returns true if the CSV row describes a stock split transaction.
- * Detection is case-insensitive: any description containing "SPLIT" classifies the row as a split.
+ * Detection is case-insensitive and checks both the action and description fields
+ * to handle both Fidelity web and desktop export formats.
  *
- * Example split description: "REVERSE SPLIT R/S FROM 691543102#REOR M005168075001"
+ * Web format:  split text is in `row.description` (e.g. "REVERSE SPLIT R/S FROM …")
+ * Desktop format: split text is in `row.action`  (the "Description" column)
  */
 export function isSplitRow(row: FidelityCsvRow): boolean {
-  return row.description?.toUpperCase().includes('SPLIT') ?? false;
+  return (
+    (row.description?.toUpperCase().includes('SPLIT') ||
+      row.action?.toUpperCase().includes('SPLIT')) ??
+    false
+  );
 }

--- a/apps/server/src/app/routes/import/is-split-to-row.function.spec.ts
+++ b/apps/server/src/app/routes/import/is-split-to-row.function.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest';
+
+import { isSplitToRow } from './is-split-to-row.function';
+import { FidelityCsvRow } from './fidelity-csv-row.interface';
+
+function makeRow(description: string, action = 'YOU BOUGHT'): FidelityCsvRow {
+  return {
+    date: '12/08/2025',
+    action,
+    symbol: '88634T493',
+    description,
+    quantity: -400,
+    price: 0,
+    totalAmount: 0,
+    account: 'Joint Brokerage *4767',
+  };
+}
+
+describe('isSplitToRow', function () {
+  // Web format: R/S TO text is in row.description
+  test('returns true for web-format TO row (description contains R/S TO)', function () {
+    expect(
+      isSplitToRow(
+        makeRow('REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000')
+      )
+    ).toBe(true);
+  });
+
+  // Desktop format: R/S TO text is in row.action
+  test('returns true for desktop-format MSTY TO row (action contains R/S TO)', function () {
+    expect(
+      isSplitToRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S TO 88636X732#REOR M0051704770000'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns true for desktop-format ULTY TO row (action contains R/S TO)', function () {
+    expect(
+      isSplitToRow(
+        makeRow(
+          'ULTY ETF',
+          'REVERSE SPLIT R/S TO 88636X708#REOR M0051702900000'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('returns true for desktop-format OXLC TO row (action contains R/S TO)', function () {
+    expect(
+      isSplitToRow(
+        makeRow(
+          'OXLC COMMON STOCK',
+          'REVERSE SPLIT R/S TO 691543847#REOR M0051680750000'
+        )
+      )
+    ).toBe(true);
+  });
+
+  // FROM rows should NOT match
+  test('returns false for desktop-format FROM row (action contains R/S FROM, not R/S TO)', function () {
+    expect(
+      isSplitToRow(
+        makeRow(
+          'MSTY UNIT',
+          'REVERSE SPLIT R/S FROM 88634T493#REOR M0051704770001'
+        )
+      )
+    ).toBe(false);
+  });
+
+  test('returns false for web-format FROM row (description contains R/S FROM)', function () {
+    expect(
+      isSplitToRow(
+        makeRow('REVERSE SPLIT R/S FROM 691543102#REOR M005168075001')
+      )
+    ).toBe(false);
+  });
+
+  // Non-split rows
+  test('returns false for a dividend row', function () {
+    expect(isSplitToRow(makeRow('MSTY UNIT', 'DIVIDEND RECEIVED'))).toBe(false);
+  });
+
+  test('returns false when neither field contains R/S TO', function () {
+    expect(isSplitToRow(makeRow('COMMON STOCK', 'YOU BOUGHT'))).toBe(false);
+  });
+
+  test('returns false when both description and action are undefined', function () {
+    expect(
+      isSplitToRow({
+        description: undefined,
+        action: undefined,
+      } as unknown as FidelityCsvRow)
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/app/routes/import/is-split-to-row.function.ts
+++ b/apps/server/src/app/routes/import/is-split-to-row.function.ts
@@ -1,0 +1,21 @@
+import { FidelityCsvRow } from './fidelity-csv-row.interface';
+
+/**
+ * Returns true if the CSV row is a "REVERSE SPLIT R/S TO" row (the old-share removal side
+ * of a Fidelity reverse-split pair).
+ *
+ * These rows carry a negative quantity representing the old share count that was retired.
+ * They should be skipped without producing an unknown-transaction warning because they
+ * contain no new information beyond what the matching FROM row already provides.
+ *
+ * Both web and desktop formats are handled:
+ *   Web format:     "R/S TO" text is in `row.description`
+ *   Desktop format: "R/S TO" text is in `row.action` (the "Description" column)
+ */
+export function isSplitToRow(row: FidelityCsvRow): boolean {
+  return (
+    (row.description?.toUpperCase().includes('R/S TO') ||
+      row.action?.toUpperCase().includes('R/S TO')) ??
+    false
+  );
+}

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -77,11 +77,11 @@ export default defineConfig({
         'src/app/routes/universe/sync-from-screener/index.ts',
         'src/utils/aws-config.ts',
         'src/app/routes/logs/index.ts',
-        // Re-export barrel files with no logic
-        '**/csrf-protection-hook.middleware.ts',
-        '**/enhanced-rate-limit.middleware.ts',
-        '**/get-csrf-stats.middleware.ts',
-        '**/validate-csrf-token.middleware.ts',
+        // Re-export barrel files covered by barrel spec tests
+        'src/app/middleware/csrf-protection-hook.middleware.ts',
+        'src/app/middleware/enhanced-rate-limit.middleware.ts',
+        'src/app/middleware/get-csrf-stats.middleware.ts',
+        'src/app/middleware/validate-csrf-token.middleware.ts',
       ],
       thresholds: {
         branches: 100,


### PR DESCRIPTION
## Summary

Implements Story 57.2: correct reverse-split detection and ratio calculation for Fidelity CSV importer.

## Changes

- **`isSplitRow()`** extended to check both `description` and `action` fields for SPLIT text — handles both Fidelity web (split in description) and desktop export (split in action) formats
- **`isSplitFromRow()`** (new) — positive identification of R/S FROM rows (new-share receipt side)
- **`isSplitToRow()`** (new) — identification of R/S TO rows (old-share retirement side, silently skipped in import)
- **`calculateSplitRatio()`** — added `accountId` parameter; ratio now computed from only the account's open lots
- **`adjustLotsForSplit()`** — added `accountId` parameter; only adjusts lots for the specific account
- **`handleSplitRow()`** — uses `isSplitFromRow()` as positive gate; resolves account and passes account ID downstream

## Testing

- All unit tests pass (63 test files)
- 100% branch coverage maintained
- E2E split import tests: 11/11 pass
- `pnpm all` passes (lint + build + tests + coverage)

Closes #972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive test coverage added for middleware modules and import operations.

* **Bug Fixes**
  * Improved dividend history filtering to exclude invalid data (missing ex-dividend dates, non-numeric payouts).
  * Enhanced stock split detection to support both web and desktop CSV formats.

* **New Features**
  * Added account-scoped operations for stock split calculations to ensure accuracy per account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->