### PR TITLE
fix(62-2): remove date filter in fetchDividendHistory to enable future-rows fallback

### DIFF
--- a/apps/server/src/app/routes/common/dividend-history.service.spec.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.spec.ts
@@ -168,7 +168,7 @@ describe('dividend-history.service', () => {
       expect(result[2].date).toEqual(new Date(2026, 2, 12));
     });
 
-    test('filters out future ex-div rows', async () => {
+    test('returns all valid rows including future ex-div rows', async () => {
       const futureRow = {
         exDiv: '12/31/2099',
         payDay: '01/31/2100',
@@ -183,11 +183,11 @@ describe('dividend-history.service', () => {
 
       const result = await fetchDividendHistory('PDI');
 
-      expect(result).toHaveLength(3);
+      // Story 62.2: date filter removed — future ex-div rows are now returned
+      // so that calculateDistributionsPerYear can use them for cadence detection.
+      expect(result).toHaveLength(4);
       expect(
-        result.every(function checkNoPastDate(row) {
-          return row.date < new Date('12/31/2099');
-        })
+        result.every((row) => row.amount > 0 && !isNaN(row.date.valueOf()))
       ).toBe(true);
     });
 

--- a/apps/server/src/app/routes/common/dividend-history.service.ts
+++ b/apps/server/src/app/routes/common/dividend-history.service.ts
@@ -161,13 +161,9 @@ export async function fetchDividendHistory(
       return [];
     }
 
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
     const processed = rawRows
       .map(mapToProcessedRow)
-      .filter(function filterPastRows(row: ProcessedRow): boolean {
-        return isValidProcessedRow(row) && row.date <= today;
-      })
+      .filter(isValidProcessedRow)
       .sort(function sortByDate(a: ProcessedRow, b: ProcessedRow): number {
         return a.date.valueOf() - b.date.valueOf();
       });

--- a/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
@@ -458,54 +458,53 @@ describe('getDistributions', () => {
     expect(result?.distributions_per_year).toBe(12);
   });
 
-  // Story 62.1 regression tests — production-accurate scenario.
+  // Story 62.1 / 62.2 regression tests — production-accurate scenario (post-fix).
   //
-  // Root cause: fetchDividendHistory applies filterPastRows (row.date <= today)
-  // before returning, so getDistributions never receives future ex-dates.
+  // Root cause (Story 62.1): fetchDividendHistory applied filterPastRows (row.date <= today)
+  // before returning, so getDistributions never received future ex-dates.
   // For a new symbol with exactly 1 past ex-date:
   //   rows.length === 1  →  calculateDistributionsPerYear Path A  →  return 1
-  // The Story 58.2 futureRows fallback on Path B is never reached in production.
   //
-  // Both tests use test.fails() so pnpm all continues to pass while confirming
-  // the regression is still present before Story 62.2 applies the fix.
+  // Fix (Story 62.2): fetchDividendHistory now returns all valid rows (past + future).
+  // Production-accurate mocks now include 1 past row + several future rows, allowing
+  // calculateDistributionsPerYear to reach Path B (future-rows fallback) and return
+  // the correct cadence.
 
-  test.fails(
-    'BUG(62-1): monthly payer with 1 past row (no futures) — production-accurate — returns 1 instead of 12',
-    async () => {
-      // System time: 2025-08-21T10:00:00Z (set in beforeEach)
-      // Production-accurate: fetchDividendHistory has stripped all future rows
-      // before returning.  Only 1 past ex-date remains for a new monthly payer.
-      const productionAccurateMonthly: ProcessedRow[] = [
-        { amount: 0.25, date: new Date('2025-08-15') }, // only past row — no future rows
-      ];
+  test('OXLC monthly payer: 1 past row + future monthly rows returns distributions_per_year=12', async () => {
+    // System time: 2025-08-21T10:00:00Z (set in beforeEach)
+    // Post-fix production-accurate: fetchDividendHistory returns 1 past ex-date
+    // plus scheduled future ex-dates for a new monthly payer (e.g. OXLC).
+    const productionAccurateMonthly: ProcessedRow[] = [
+      { amount: 0.25, date: new Date('2025-08-15') }, // only past row
+      { amount: 0.25, date: new Date('2025-09-15') }, // future (+31 days)
+      { amount: 0.25, date: new Date('2025-10-15') }, // future (+30 days)
+      { amount: 0.25, date: new Date('2025-11-14') }, // future (+30 days)
+      { amount: 0.25, date: new Date('2025-12-15') }, // future (+31 days)
+    ];
 
-      mockFetchDividendHistory.mockResolvedValueOnce(productionAccurateMonthly);
+    mockFetchDividendHistory.mockResolvedValueOnce(productionAccurateMonthly);
 
-      const result = await getDistributions('OXLC');
+    const result = await getDistributions('OXLC');
 
-      // Correct expectation: a monthly payer should return 12.
-      // Currently fails: rows.length === 1 → Path A → returns 1.
-      expect(result?.distributions_per_year).toBe(12);
-    }
-  );
+    expect(result?.distributions_per_year).toBe(12);
+  });
 
-  test.fails(
-    'BUG(62-1): weekly payer with 1 past row (no futures) — production-accurate — returns 1 instead of 52',
-    async () => {
-      // System time: 2025-08-21T10:00:00Z (set in beforeEach)
-      // Production-accurate: fetchDividendHistory has stripped all future rows
-      // before returning.  Only 1 past ex-date remains for a new weekly payer.
-      const productionAccurateWeekly: ProcessedRow[] = [
-        { amount: 0.05, date: new Date('2025-08-15') }, // only past row — no future rows
-      ];
+  test('MSTY weekly payer: 1 past row + future weekly rows returns distributions_per_year=52', async () => {
+    // System time: 2025-08-21T10:00:00Z (set in beforeEach)
+    // Post-fix production-accurate: fetchDividendHistory returns 1 past ex-date
+    // plus scheduled future ex-dates for a new weekly payer (e.g. MSTY).
+    const productionAccurateWeekly: ProcessedRow[] = [
+      { amount: 0.05, date: new Date('2025-08-15') }, // only past row
+      { amount: 0.05, date: new Date('2025-08-22') }, // future (+7 days)
+      { amount: 0.05, date: new Date('2025-08-29') }, // future (+7 days)
+      { amount: 0.05, date: new Date('2025-09-05') }, // future (+7 days)
+      { amount: 0.05, date: new Date('2025-09-12') }, // future (+7 days)
+    ];
 
-      mockFetchDividendHistory.mockResolvedValueOnce(productionAccurateWeekly);
+    mockFetchDividendHistory.mockResolvedValueOnce(productionAccurateWeekly);
 
-      const result = await getDistributions('MSTY');
+    const result = await getDistributions('MSTY');
 
-      // Correct expectation: a weekly payer should return 52.
-      // Currently fails: rows.length === 1 → Path A → returns 1.
-      expect(result?.distributions_per_year).toBe(52);
-    }
-  );
+    expect(result?.distributions_per_year).toBe(52);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the root cause identified in Story 62.1: `fetchDividendHistory` was applying a date filter (`row.date <= today`) that stripped all future ex-dates before returning. For a newly-added symbol with only 1 past ex-date, `calculateDistributionsPerYear` hit the `rows.length <= 1` early-exit (Path A) and returned 1 — the Story 58.2 future-rows fallback (Path B) was never reachable in production.

## Changes
- **`dividend-history.service.ts`**: Removed `filterPastRows` predicate; service now returns all valid rows (past + future) sorted ascending. The unused `today` variable is also removed.
- **`get-distributions.function.spec.ts`**: Removed `test.fails()` wrappers from Story 62.1 OXLC and MSTY regression tests; updated mock data to include future rows reflecting post-fix production reality.
- **`dividend-history.service.spec.ts`**: Updated `'filters out future ex-div rows'` test to document the new behavior: future rows are now returned (renamed to `'returns all valid rows including future ex-div rows'`, expects 4 rows).

## Testing
- `pnpm vitest run apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts` → 28/28 ✅
- `pnpm vitest run apps/server/src/app/routes/common/dividend-history.service.spec.ts` → 18/18 ✅
- `pnpm vitest run apps/server/src/` → 852/852 ✅

## Acceptance Criteria Satisfied
- ✅ AC1: Monthly payer (OXLC) → `distributions_per_year = 12`
- ✅ AC2: Weekly payer (MSTY) → `distributions_per_year = 52`
- ✅ AC3: Quarterly sparse-history → `distributions_per_year = 4`
- ✅ AC4: Annual sparse-history → `distributions_per_year = 1`
- ✅ AC6: Story 62.1 `test.fails()` tests now pass green
- ✅ AC7: No regressions — all existing 58.1/58.2 tests pass

Closes #1003