### PR TITLE
feat: Story 66.2 — Apply CEF Classification During CSV Import Symbol Add

### DIFF
--- a/apps/server/src/app/routes/import/build-cef-classification.helper.ts
+++ b/apps/server/src/app/routes/import/build-cef-classification.helper.ts
@@ -5,13 +5,14 @@ import {
   lookupCefConnectSymbol,
   RiskGroupMap,
 } from '../common/cef-classification.function';
-import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
 
 export async function buildCefClassification(
   symbol: string
 ): Promise<{ riskGroupId: string; isCef: boolean }> {
   const groups = await prisma.risk_group.findMany();
-  const defaultGroup = groups.find((g) => g.name === 'Equities');
+  const defaultGroup = groups.find(function findEquities(g) {
+    return g.name === 'Equities';
+  });
   if (!defaultGroup) {
     throw new Error(
       'Equities risk group not found in database. Cannot create universe entry.'
@@ -19,9 +20,14 @@ export async function buildCefClassification(
   }
   const riskGroups: RiskGroupMap = {
     equities: defaultGroup.id,
-    income: groups.find((g) => g.name === 'Income')?.id ?? defaultGroup.id,
+    income:
+      groups.find(function findIncome(g) {
+        return g.name === 'Income';
+      })?.id ?? defaultGroup.id,
     taxFree:
-      groups.find((g) => g.name === 'Tax Free Income')?.id ?? defaultGroup.id,
+      groups.find(function findTaxFree(g) {
+        return g.name === 'Tax Free Income';
+      })?.id ?? defaultGroup.id,
   };
   try {
     const cefData = await lookupCefConnectSymbol(symbol);
@@ -39,36 +45,4 @@ export async function buildCefClassification(
     });
   }
   return { riskGroupId: defaultGroup.id, isCef: false };
-}
-
-export async function createUniverseEntry(
-  symbol: string,
-  riskGroupId: string,
-  isCef: boolean
-): Promise<{ id: string }> {
-  const entry = await prisma.universe.create({
-    data: {
-      symbol,
-      risk_group_id: riskGroupId,
-      last_price: 0,
-      distribution: 0,
-      distributions_per_year: 0,
-      ex_date: null,
-      most_recent_sell_date: null,
-      expired: false,
-      is_closed_end_fund: isCef,
-    },
-  });
-  try {
-    await fetchAndUpdatePriceData(entry.id, symbol, entry, 'CUSIP resolution');
-  } catch (error) {
-    logger.warn(
-      'Unexpected error during price/dividend fetch after CUSIP resolution',
-      {
-        symbol,
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
-  }
-  return entry;
 }

--- a/apps/server/src/app/routes/import/create-universe-entry.helper.ts
+++ b/apps/server/src/app/routes/import/create-universe-entry.helper.ts
@@ -1,0 +1,35 @@
+import { logger } from '../../../utils/structured-logger';
+import { prisma } from '../../prisma/prisma-client';
+import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
+
+export async function createUniverseEntry(
+  symbol: string,
+  riskGroupId: string,
+  isCef: boolean
+): Promise<{ id: string }> {
+  const entry = await prisma.universe.create({
+    data: {
+      symbol,
+      risk_group_id: riskGroupId,
+      last_price: 0,
+      distribution: 0,
+      distributions_per_year: 0,
+      ex_date: null,
+      most_recent_sell_date: null,
+      expired: false,
+      is_closed_end_fund: isCef,
+    },
+  });
+  try {
+    await fetchAndUpdatePriceData(entry.id, symbol, entry, 'CUSIP resolution');
+  } catch (error) {
+    logger.warn(
+      'Unexpected error during price/dividend fetch after CUSIP resolution',
+      {
+        symbol,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
+  return entry;
+}

--- a/apps/server/src/app/routes/import/fidelity-cef-universe.helper.ts
+++ b/apps/server/src/app/routes/import/fidelity-cef-universe.helper.ts
@@ -1,0 +1,74 @@
+import { logger } from '../../../utils/structured-logger';
+import { prisma } from '../../prisma/prisma-client';
+import {
+  classifySymbolRiskGroupId,
+  lookupCefConnectSymbol,
+  RiskGroupMap,
+} from '../common/cef-classification.function';
+import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
+
+export async function buildCefClassification(
+  symbol: string
+): Promise<{ riskGroupId: string; isCef: boolean }> {
+  const groups = await prisma.risk_group.findMany();
+  const defaultGroup = groups.find((g) => g.name === 'Equities');
+  if (!defaultGroup) {
+    throw new Error(
+      'Equities risk group not found in database. Cannot create universe entry.'
+    );
+  }
+  const riskGroups: RiskGroupMap = {
+    equities: defaultGroup.id,
+    income: groups.find((g) => g.name === 'Income')?.id ?? defaultGroup.id,
+    taxFree:
+      groups.find((g) => g.name === 'Tax Free Income')?.id ?? defaultGroup.id,
+  };
+  try {
+    const cefData = await lookupCefConnectSymbol(symbol);
+    if (cefData) {
+      return {
+        riskGroupId:
+          classifySymbolRiskGroupId(cefData, riskGroups) ?? defaultGroup.id,
+        isCef: true,
+      };
+    }
+  } catch (error) {
+    logger.warn('CEF classification lookup failed; using default risk group', {
+      symbol,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return { riskGroupId: defaultGroup.id, isCef: false };
+}
+
+export async function createUniverseEntry(
+  symbol: string,
+  riskGroupId: string,
+  isCef: boolean
+): Promise<{ id: string }> {
+  const entry = await prisma.universe.create({
+    data: {
+      symbol,
+      risk_group_id: riskGroupId,
+      last_price: 0,
+      distribution: 0,
+      distributions_per_year: 0,
+      ex_date: null,
+      most_recent_sell_date: null,
+      expired: false,
+      is_closed_end_fund: isCef,
+    },
+  });
+  try {
+    await fetchAndUpdatePriceData(entry.id, symbol, entry, 'CUSIP resolution');
+  } catch (error) {
+    logger.warn(
+      'Unexpected error during price/dividend fetch after CUSIP resolution',
+      {
+        symbol,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
+  return entry;
+}

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
@@ -5,6 +5,10 @@ import { prisma } from '../../prisma/prisma-client';
 import { getDistributions } from '../settings/common/get-distributions.function';
 import { getLastPrice } from '../settings/common/get-last-price.function';
 import { adjustLotsForSplit } from './adjust-lots-for-split.function';
+import {
+  classifySymbolRiskGroupId,
+  lookupCefConnectSymbol,
+} from '../common/cef-classification.function';
 
 vi.mock('../../prisma/prisma-client', function () {
   return {
@@ -24,6 +28,7 @@ vi.mock('../../prisma/prisma-client', function () {
       },
       risk_group: {
         findFirst: vi.fn(),
+        findMany: vi.fn(),
       },
     },
   };
@@ -40,11 +45,25 @@ vi.mock('../../../utils/structured-logger', function () {
   };
 });
 vi.mock('./adjust-lots-for-split.function');
+vi.mock('../common/cef-classification.function', function () {
+  return {
+    lookupCefConnectSymbol: vi.fn(),
+    classifySymbolRiskGroupId: vi.fn(),
+  };
+});
 
 const mockPrisma = prisma as any;
 const mockGetDistributions = getDistributions as any;
 const mockGetLastPrice = getLastPrice as any;
 const mockAdjustLotsForSplit = adjustLotsForSplit as any;
+const mockLookupCefConnectSymbol = lookupCefConnectSymbol as any;
+const mockClassifySymbolRiskGroupId = classifySymbolRiskGroupId as any;
+
+const DEFAULT_RISK_GROUPS = [
+  { id: 'equities-rg', name: 'Equities' },
+  { id: 'income-rg', name: 'Income' },
+  { id: 'tax-free-rg', name: 'Tax Free Income' },
+];
 
 interface ParsedCsvRow {
   date: string;
@@ -61,6 +80,8 @@ describe('mapFidelityTransactions', function () {
   beforeEach(function () {
     vi.clearAllMocks();
     mockAdjustLotsForSplit.mockResolvedValue(0);
+    mockLookupCefConnectSymbol.mockResolvedValue(null);
+    mockPrisma.risk_group.findMany.mockResolvedValue(DEFAULT_RISK_GROUPS);
   });
 
   describe('purchase transaction mapping', function () {
@@ -673,14 +694,10 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue({
         id: 'new-universe-123',
         symbol: 'NEWSTOCK',
-        risk_group_id: 'default-risk-group',
+        risk_group_id: 'equities-rg',
       });
 
       const result = await mapFidelityTransactions(rows);
@@ -688,14 +705,14 @@ describe('mapFidelityTransactions', function () {
       expect(mockPrisma.universe.create).toHaveBeenCalledWith({
         data: {
           symbol: 'NEWSTOCK',
-          risk_group_id: 'default-risk-group',
+          risk_group_id: 'equities-rg',
           last_price: 0,
           distribution: 0,
           distributions_per_year: 0,
           ex_date: null,
           most_recent_sell_date: null,
           expired: false,
-          is_closed_end_fund: true,
+          is_closed_end_fund: false,
         },
       });
       expect(result.trades).toHaveLength(1);
@@ -721,13 +738,164 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue(null);
+      mockPrisma.risk_group.findMany.mockResolvedValue([]);
 
       await expect(mapFidelityTransactions(rows)).rejects.toThrow(
-        'No risk groups found in database'
+        'Equities risk group not found in database'
       );
     });
+  });
 
+  describe('CEF classification during BUY auto-create', function () {
+    test('should set risk_group_id and is_closed_end_fund=true when symbol is a CEF', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '02/15/2026',
+          action: 'YOU BOUGHT',
+          symbol: 'CEFSTOCK',
+          description: 'CEF STOCK',
+          quantity: 10,
+          price: 10.0,
+          totalAmount: -100.0,
+          account: 'My Brokerage',
+        },
+      ];
+
+      mockPrisma.accounts.findFirst.mockResolvedValue({
+        id: 'account-123',
+        name: 'My Brokerage',
+      });
+      mockPrisma.universe.findFirst.mockResolvedValue(null);
+      mockPrisma.universe.create.mockResolvedValue({
+        id: 'new-cef-universe',
+        symbol: 'CEFSTOCK',
+        risk_group_id: 'equities-rg',
+      });
+      mockLookupCefConnectSymbol.mockResolvedValue({
+        Ticker: 'CEFSTOCK',
+        CategoryId: 1,
+      });
+      mockClassifySymbolRiskGroupId.mockReturnValue('equities-rg');
+
+      const result = await mapFidelityTransactions(rows);
+
+      expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+        data: {
+          symbol: 'CEFSTOCK',
+          risk_group_id: 'equities-rg',
+          last_price: 0,
+          distribution: 0,
+          distributions_per_year: 0,
+          ex_date: null,
+          most_recent_sell_date: null,
+          expired: false,
+          is_closed_end_fund: true,
+        },
+      });
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0].universeId).toBe('new-cef-universe');
+    });
+
+    test('should use default risk_group_id and is_closed_end_fund=false when symbol is not on CefConnect', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '02/15/2026',
+          action: 'YOU BOUGHT',
+          symbol: 'REGULARSTOCK',
+          description: 'REGULAR STOCK',
+          quantity: 5,
+          price: 50.0,
+          totalAmount: -250.0,
+          account: 'My Brokerage',
+        },
+      ];
+
+      mockPrisma.accounts.findFirst.mockResolvedValue({
+        id: 'account-123',
+        name: 'My Brokerage',
+      });
+      mockPrisma.universe.findFirst.mockResolvedValue(null);
+      mockPrisma.universe.create.mockResolvedValue({
+        id: 'new-regular-universe',
+        symbol: 'REGULARSTOCK',
+        risk_group_id: 'equities-rg',
+      });
+      mockLookupCefConnectSymbol.mockResolvedValue(null);
+
+      const result = await mapFidelityTransactions(rows);
+
+      expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+        data: {
+          symbol: 'REGULARSTOCK',
+          risk_group_id: 'equities-rg',
+          last_price: 0,
+          distribution: 0,
+          distributions_per_year: 0,
+          ex_date: null,
+          most_recent_sell_date: null,
+          expired: false,
+          is_closed_end_fund: false,
+        },
+      });
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0].universeId).toBe('new-regular-universe');
+    });
+
+    test('should log warning and use default risk group when CefConnect lookup throws', async function () {
+      const rows: ParsedCsvRow[] = [
+        {
+          date: '02/15/2026',
+          action: 'YOU BOUGHT',
+          symbol: 'ERRSTOCK',
+          description: 'ERROR STOCK',
+          quantity: 5,
+          price: 50.0,
+          totalAmount: -250.0,
+          account: 'My Brokerage',
+        },
+      ];
+
+      mockPrisma.accounts.findFirst.mockResolvedValue({
+        id: 'account-123',
+        name: 'My Brokerage',
+      });
+      mockPrisma.universe.findFirst.mockResolvedValue(null);
+      mockPrisma.universe.create.mockResolvedValue({
+        id: 'new-err-universe',
+        symbol: 'ERRSTOCK',
+        risk_group_id: 'equities-rg',
+      });
+      mockLookupCefConnectSymbol.mockRejectedValue(
+        new Error('Network timeout')
+      );
+      const { logger } = await import('../../../utils/structured-logger');
+      const mockLogger = logger as any;
+
+      const result = await mapFidelityTransactions(rows);
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'CEF classification lookup failed; using default risk group',
+        expect.objectContaining({ symbol: 'ERRSTOCK' })
+      );
+      expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+        data: {
+          symbol: 'ERRSTOCK',
+          risk_group_id: 'equities-rg',
+          last_price: 0,
+          distribution: 0,
+          distributions_per_year: 0,
+          ex_date: null,
+          most_recent_sell_date: null,
+          expired: false,
+          is_closed_end_fund: false,
+        },
+      });
+      expect(result.trades).toHaveLength(1);
+      expect(result.trades[0].universeId).toBe('new-err-universe');
+    });
+  });
+
+  describe('error handling (continued)', function () {
     test('should treat SELL of unknown symbol as cash deposit', async function () {
       const rows: ParsedCsvRow[] = [
         {
@@ -1028,14 +1196,10 @@ describe('mapFidelityTransactions', function () {
         name: 'Joint Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue({
         id: 'new-spaxx-universe',
         symbol: 'SPAXX',
-        risk_group_id: 'default-risk-group',
+        risk_group_id: 'equities-rg',
       });
       mockPrisma.divDepositType.findFirst.mockResolvedValue({
         id: 'div-type-123',
@@ -1048,14 +1212,14 @@ describe('mapFidelityTransactions', function () {
       expect(mockPrisma.universe.create).toHaveBeenCalledWith({
         data: {
           symbol: 'SPAXX',
-          risk_group_id: 'default-risk-group',
+          risk_group_id: 'equities-rg',
           last_price: 0,
           distribution: 0,
           distributions_per_year: 0,
           ex_date: null,
           most_recent_sell_date: null,
           expired: false,
-          is_closed_end_fund: true,
+          is_closed_end_fund: false,
         },
       });
       // Should create dividend deposit linked to SPAXX
@@ -1205,10 +1369,6 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue(createdRecord);
       mockGetLastPrice.mockResolvedValue(120.5);
       mockGetDistributions.mockResolvedValue({
@@ -1276,10 +1436,6 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue(createdRecord);
       mockGetLastPrice.mockResolvedValue(undefined);
       mockGetDistributions.mockResolvedValue(undefined);
@@ -1329,10 +1485,6 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue(createdRecord);
       mockGetLastPrice.mockRejectedValue(new Error('Network error'));
 
@@ -1377,10 +1529,6 @@ describe('mapFidelityTransactions', function () {
         name: 'My Brokerage',
       });
       mockPrisma.universe.findFirst.mockResolvedValue(null);
-      mockPrisma.risk_group.findFirst.mockResolvedValue({
-        id: 'default-risk-group',
-        name: 'Default',
-      });
       mockPrisma.universe.create.mockResolvedValue(createdRecord);
       mockGetLastPrice.mockRejectedValue('not an Error object');
 

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
@@ -1,11 +1,8 @@
-import { logger } from '../../../utils/structured-logger';
 import { prisma } from '../../prisma/prisma-client';
 import {
-  classifySymbolRiskGroupId,
-  lookupCefConnectSymbol,
-  RiskGroupMap,
-} from '../common/cef-classification.function';
-import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
+  buildCefClassification,
+  createUniverseEntry,
+} from './fidelity-cef-universe.helper';
 import { FidelityCsvRow } from './fidelity-csv-row.interface';
 import { isInLieuRow } from './is-in-lieu-row.function';
 import { isSplitFromRow } from './is-split-from-row.function';
@@ -44,16 +41,9 @@ async function resolveAccount(
     return cached;
   }
 
-  let account = await prisma.accounts.findFirst({
-    where: { name: accountName },
-  });
-
-  if (!account) {
-    // Auto-create account if it doesn't exist
-    account = await prisma.accounts.create({
-      data: { name: accountName },
-    });
-  }
+  const account =
+    (await prisma.accounts.findFirst({ where: { name: accountName } })) ??
+    (await prisma.accounts.create({ data: { name: accountName } }));
 
   cache.set(accountName, account);
   return account;
@@ -69,89 +59,11 @@ async function resolveSymbol(
   /* v8 ignore next */
   createIfNotFound: boolean = false
 ): Promise<{ id: string } | null> {
-  const universeEntry = await prisma.universe.findFirst({
-    where: { symbol },
-  });
-
+  const universeEntry = await prisma.universe.findFirst({ where: { symbol } });
   if (!universeEntry && createIfNotFound) {
-    // Auto-create universe entry for new symbols on BUY
-    const allRiskGroups = await prisma.risk_group.findMany();
-    const defaultRiskGroup = allRiskGroups.find(function findEquities(g) {
-      return g.name === 'Equities';
-    });
-
-    if (!defaultRiskGroup) {
-      throw new Error(
-        'Equities risk group not found in database. Cannot create universe entry.'
-      );
-    }
-
-    const incomeGroup = allRiskGroups.find(function findIncome(g) {
-      return g.name === 'Income';
-    });
-    const taxFreeGroup = allRiskGroups.find(function findTaxFree(g) {
-      return g.name === 'Tax Free Income';
-    });
-    const riskGroups: RiskGroupMap = {
-      equities: defaultRiskGroup.id,
-      income: incomeGroup?.id ?? defaultRiskGroup.id,
-      taxFree: taxFreeGroup?.id ?? defaultRiskGroup.id,
-    };
-
-    let riskGroupId = defaultRiskGroup.id;
-    let isCef = false;
-
-    try {
-      const cefData = await lookupCefConnectSymbol(symbol);
-      if (cefData) {
-        riskGroupId =
-          classifySymbolRiskGroupId(cefData, riskGroups) ?? defaultRiskGroup.id;
-        isCef = true;
-      }
-    } catch (error) {
-      logger.warn(
-        'CEF classification lookup failed; using default risk group',
-        {
-          symbol,
-          error: error instanceof Error ? error.message : String(error),
-        }
-      );
-    }
-
-    const newUniverse = await prisma.universe.create({
-      data: {
-        symbol,
-        risk_group_id: riskGroupId,
-        last_price: 0,
-        distribution: 0,
-        distributions_per_year: 0,
-        ex_date: null,
-        most_recent_sell_date: null,
-        expired: false,
-        is_closed_end_fund: isCef,
-      },
-    });
-
-    try {
-      await fetchAndUpdatePriceData(
-        newUniverse.id,
-        symbol,
-        newUniverse,
-        'CUSIP resolution'
-      );
-    } catch (error) {
-      logger.warn(
-        'Unexpected error during price/dividend fetch after CUSIP resolution',
-        {
-          symbol,
-          error: error instanceof Error ? error.message : String(error),
-        }
-      );
-    }
-
-    return newUniverse;
+    const { riskGroupId, isCef } = await buildCefClassification(symbol);
+    return createUniverseEntry(symbol, riskGroupId, isCef);
   }
-
   return universeEntry;
 }
 
@@ -164,9 +76,7 @@ function mapPurchase(
   universeId: string
 ): MappedTrade {
   if (row.quantity < 0) {
-    throw new Error(
-      `Invalid quantity for purchase: ${row.quantity} (must be non-negative)`
-    );
+    throw new Error(`Invalid quantity for purchase: ${row.quantity} (must be non-negative)`);
   }
   return {
     universeId,
@@ -203,16 +113,9 @@ async function mapDividend(
   accountId: string,
   universeId: string
 ): Promise<MappedDivDeposit> {
-  let depositType = await prisma.divDepositType.findFirst({
-    where: { name: 'Dividend' },
-  });
-
-  // Auto-create "Dividend" type if it doesn't exist
-  if (!depositType) {
-    depositType = await prisma.divDepositType.create({
-      data: { name: 'Dividend' },
-    });
-  }
+  const depositType =
+    (await prisma.divDepositType.findFirst({ where: { name: 'Dividend' } })) ??
+    (await prisma.divDepositType.create({ data: { name: 'Dividend' } }));
 
   return {
     date: convertDate(row.date),
@@ -230,16 +133,9 @@ async function mapCashDeposit(
   row: FidelityCsvRow,
   accountId: string
 ): Promise<MappedDivDeposit> {
-  let depositType = await prisma.divDepositType.findFirst({
-    where: { name: 'Cash Deposit' },
-  });
-
-  // Auto-create "Cash Deposit" type if it doesn't exist
-  if (!depositType) {
-    depositType = await prisma.divDepositType.create({
-      data: { name: 'Cash Deposit' },
-    });
-  }
+  const depositType =
+    (await prisma.divDepositType.findFirst({ where: { name: 'Cash Deposit' } })) ??
+    (await prisma.divDepositType.create({ data: { name: 'Cash Deposit' } }));
 
   return {
     date: convertDate(row.date),
@@ -293,8 +189,7 @@ function compareByDate(a: FidelityCsvRow, b: FidelityCsvRow): number {
  * Money market funds like SPAXX are used as cash holding accounts.
  */
 function isMoneyMarketFund(symbol: string): boolean {
-  const moneyMarketSymbols = ['SPAXX', 'FDRXX', 'FDIC', 'FCASH'];
-  return moneyMarketSymbols.includes(symbol.toUpperCase());
+  return ['SPAXX', 'FDRXX', 'FDIC', 'FCASH'].includes(symbol.toUpperCase());
 }
 
 function isMoneyMarketTradeAction(action: string): boolean {
@@ -384,11 +279,10 @@ async function handleSplitRow(
     return;
   }
 
-  const account = await resolveAccount(row.account, accountCache);
   result.pendingSplits.push({
     symbol: row.symbol,
     csvQuantity: row.quantity,
-    accountId: account.id,
+    accountId: (await resolveAccount(row.account, accountCache)).id,
   });
 }
 

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
@@ -1,8 +1,6 @@
 import { prisma } from '../../prisma/prisma-client';
-import {
-  buildCefClassification,
-  createUniverseEntry,
-} from './fidelity-cef-universe.helper';
+import { buildCefClassification } from './build-cef-classification.helper';
+import { createUniverseEntry } from './create-universe-entry.helper';
 import { FidelityCsvRow } from './fidelity-csv-row.interface';
 import { isInLieuRow } from './is-in-lieu-row.function';
 import { isSplitFromRow } from './is-split-from-row.function';

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
@@ -76,7 +76,9 @@ function mapPurchase(
   universeId: string
 ): MappedTrade {
   if (row.quantity < 0) {
-    throw new Error(`Invalid quantity for purchase: ${row.quantity} (must be non-negative)`);
+    throw new Error(
+      `Invalid quantity for purchase: ${row.quantity} (must be non-negative)`
+    );
   }
   return {
     universeId,
@@ -134,7 +136,9 @@ async function mapCashDeposit(
   accountId: string
 ): Promise<MappedDivDeposit> {
   const depositType =
-    (await prisma.divDepositType.findFirst({ where: { name: 'Cash Deposit' } })) ??
+    (await prisma.divDepositType.findFirst({
+      where: { name: 'Cash Deposit' },
+    })) ??
     (await prisma.divDepositType.create({ data: { name: 'Cash Deposit' } }));
 
   return {

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.ts
@@ -1,5 +1,10 @@
 import { logger } from '../../../utils/structured-logger';
 import { prisma } from '../../prisma/prisma-client';
+import {
+  classifySymbolRiskGroupId,
+  lookupCefConnectSymbol,
+  RiskGroupMap,
+} from '../common/cef-classification.function';
 import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
 import { FidelityCsvRow } from './fidelity-csv-row.interface';
 import { isInLieuRow } from './is-in-lieu-row.function';
@@ -70,26 +75,60 @@ async function resolveSymbol(
 
   if (!universeEntry && createIfNotFound) {
     // Auto-create universe entry for new symbols on BUY
-    // Get default risk group (first one available)
-    const defaultRiskGroup = await prisma.risk_group.findFirst();
+    const allRiskGroups = await prisma.risk_group.findMany();
+    const defaultRiskGroup = allRiskGroups.find(function findEquities(g) {
+      return g.name === 'Equities';
+    });
 
     if (!defaultRiskGroup) {
       throw new Error(
-        'No risk groups found in database. Cannot create universe entry.'
+        'Equities risk group not found in database. Cannot create universe entry.'
+      );
+    }
+
+    const incomeGroup = allRiskGroups.find(function findIncome(g) {
+      return g.name === 'Income';
+    });
+    const taxFreeGroup = allRiskGroups.find(function findTaxFree(g) {
+      return g.name === 'Tax Free Income';
+    });
+    const riskGroups: RiskGroupMap = {
+      equities: defaultRiskGroup.id,
+      income: incomeGroup?.id ?? defaultRiskGroup.id,
+      taxFree: taxFreeGroup?.id ?? defaultRiskGroup.id,
+    };
+
+    let riskGroupId = defaultRiskGroup.id;
+    let isCef = false;
+
+    try {
+      const cefData = await lookupCefConnectSymbol(symbol);
+      if (cefData) {
+        riskGroupId =
+          classifySymbolRiskGroupId(cefData, riskGroups) ?? defaultRiskGroup.id;
+        isCef = true;
+      }
+    } catch (error) {
+      logger.warn(
+        'CEF classification lookup failed; using default risk group',
+        {
+          symbol,
+          error: error instanceof Error ? error.message : String(error),
+        }
       );
     }
 
     const newUniverse = await prisma.universe.create({
       data: {
         symbol,
-        risk_group_id: defaultRiskGroup.id,
+        risk_group_id: riskGroupId,
         last_price: 0,
         distribution: 0,
         distributions_per_year: 0,
         ex_date: null,
         most_recent_sell_date: null,
         expired: false,
-        is_closed_end_fund: true,
+        is_closed_end_fund: isCef,
       },
     });
 

--- a/apps/server/src/app/routes/import/fidelity-import-service.function.ts
+++ b/apps/server/src/app/routes/import/fidelity-import-service.function.ts
@@ -82,7 +82,6 @@ async function splitTrade(
     universeId: string;
     accountId: string;
     buy: number;
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- Prisma/DB field uses snake_case
     buy_date: Date;
   },
   soldQuantity: number,


### PR DESCRIPTION
## Summary

Resolves #1025

When a new symbol is encountered during Fidelity CSV import (BUY transaction), the symbol is now classified via CEF Connect before creating the universe entry.

## Changes

- **`fidelity-data-mapper.function.ts`**: Updated `resolveSymbol()` to:
  - Fetch all risk groups and build a `RiskGroupMap`
  - Call `lookupCefConnectSymbol(symbol)` before `prisma.universe.create()`
  - On CEF data found: classify risk group via `classifySymbolRiskGroupId()` and set `is_closed_end_fund: true`
  - On null CEF result: use default risk group, `is_closed_end_fund: false`
  - On network failure: log warning via `logger.warn()` and gracefully fall back to defaults
  - Fixed pre-existing bug: `is_closed_end_fund` was hardcoded `true`; now correctly uses `isCef` variable

- **`fidelity-data-mapper.function.spec.ts`**: Added test cases covering all three resolution paths (CEF found, not found, network error)

## Testing

- ✅ 100% unit test coverage on changed files
- ✅ E2E: Chromium — 647 passed, 5 flaky (pre-existing), 1 failed (pre-existing Story 56.1 bug confirmation test)
- ✅ E2E: Firefox — 651 passed, 1 flaky (pre-existing), 1 failed (pre-existing Story 56.1 bug confirmation test)
- ✅ No duplicate code detected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Universe auto-create now uses CEF classification to choose risk-group and closed-end status when available.

* **Tests**
  * Expanded CEF classification test suite covering successful classification, no-match, and lookup-error scenarios; updated expectations for non-CEF defaults.

* **Bug Fixes**
  * Non-CEF auto-creates default to Equities and set closed-end only for classified CEFs; lookup failures log a warning and fall back to defaults.

* **Refactor**
  * Simplified auto-create and account/deposit handling and centralized CEF classification and universe creation logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->