### PR TITLE
feat(66-3): apply CEF classification during manual add-symbol (closes #1027)

### DIFF
--- a/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.spec.ts
+++ b/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.spec.ts
@@ -3,7 +3,7 @@ import { prisma } from '../../../prisma/prisma-client';
 import {
   lookupCefConnectSymbol,
   classifySymbolRiskGroupId,
-} from '../common/cef-classification.function';
+} from '../../common/cef-classification.function';
 import { getDistributions } from '../../settings/common/get-distributions.function';
 import { getLastPrice } from '../../settings/common/get-last-price.function';
 import { vi } from 'vitest';
@@ -25,7 +25,7 @@ vi.mock('../../../prisma/prisma-client', function () {
   };
 });
 
-vi.mock('../common/cef-classification.function', function () {
+vi.mock('../../common/cef-classification.function', function () {
   return {
     lookupCefConnectSymbol: vi.fn(),
     classifySymbolRiskGroupId: vi.fn(),

--- a/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.spec.ts
+++ b/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.spec.ts
@@ -1,8 +1,13 @@
 import { addSymbol } from './add-symbol.function';
 import { prisma } from '../../../prisma/prisma-client';
+import {
+  lookupCefConnectSymbol,
+  classifySymbolRiskGroupId,
+} from '../common/cef-classification.function';
 import { getDistributions } from '../../settings/common/get-distributions.function';
 import { getLastPrice } from '../../settings/common/get-last-price.function';
 import { vi } from 'vitest';
+import { logger } from '../../../../utils/structured-logger';
 
 vi.mock('../../../prisma/prisma-client', function () {
   return {
@@ -14,8 +19,16 @@ vi.mock('../../../prisma/prisma-client', function () {
       },
       risk_group: {
         findUnique: vi.fn(),
+        findMany: vi.fn(),
       },
     },
+  };
+});
+
+vi.mock('../common/cef-classification.function', function () {
+  return {
+    lookupCefConnectSymbol: vi.fn(),
+    classifySymbolRiskGroupId: vi.fn(),
   };
 });
 
@@ -33,6 +46,19 @@ vi.mock('../../../../utils/structured-logger', function () {
 const mockPrisma = prisma as any;
 const mockGetDistributions = getDistributions as any;
 const mockGetLastPrice = getLastPrice as any;
+const mockLookupCefConnectSymbol = lookupCefConnectSymbol as ReturnType<
+  typeof vi.fn
+>;
+const mockClassifySymbolRiskGroupId = classifySymbolRiskGroupId as ReturnType<
+  typeof vi.fn
+>;
+const mockLogger = logger as any;
+
+const mockRiskGroups = [
+  { id: 'eq-id', name: 'Equities' },
+  { id: 'inc-id', name: 'Income' },
+  { id: 'tf-id', name: 'Tax Free Income' },
+];
 
 const mockDefaultRecord = {
   id: 'test-universe-id',
@@ -52,6 +78,99 @@ const mockDefaultRecord = {
 describe('addSymbol', function () {
   beforeEach(function () {
     vi.clearAllMocks();
+    mockPrisma.risk_group.findMany.mockResolvedValue(mockRiskGroups);
+    mockLookupCefConnectSymbol.mockResolvedValue(null);
+  });
+
+  test('should apply CEF classification when symbol is found on CefConnect', async function () {
+    const request = {
+      symbol: 'ETW',
+      risk_group_id: 'test-risk-group-id',
+    };
+
+    const mockCefData = { Ticker: 'ETW', CategoryId: 1 };
+
+    mockPrisma.universe.findFirst.mockResolvedValue(null);
+    mockPrisma.risk_group.findUnique.mockResolvedValue({
+      id: 'test-risk-group-id',
+      name: 'Equities',
+    });
+    mockLookupCefConnectSymbol.mockResolvedValue(mockCefData);
+    mockClassifySymbolRiskGroupId.mockReturnValue('eq-id');
+    mockPrisma.universe.create.mockResolvedValue({
+      ...mockDefaultRecord,
+      symbol: 'ETW',
+      risk_group_id: 'eq-id',
+      is_closed_end_fund: true,
+    } as any);
+    mockGetLastPrice.mockResolvedValue(undefined);
+    mockGetDistributions.mockResolvedValue(undefined);
+
+    await addSymbol(request);
+
+    expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        risk_group_id: 'eq-id',
+        is_closed_end_fund: true,
+      }),
+    });
+  });
+
+  test('should use request risk_group_id when symbol is not found on CefConnect', async function () {
+    const request = {
+      symbol: 'SPY',
+      risk_group_id: 'test-risk-group-id',
+    };
+
+    mockPrisma.universe.findFirst.mockResolvedValue(null);
+    mockPrisma.risk_group.findUnique.mockResolvedValue({
+      id: 'test-risk-group-id',
+      name: 'Equities',
+    });
+    mockLookupCefConnectSymbol.mockResolvedValue(null);
+    mockPrisma.universe.create.mockResolvedValue(mockDefaultRecord as any);
+    mockGetLastPrice.mockResolvedValue(undefined);
+    mockGetDistributions.mockResolvedValue(undefined);
+
+    await addSymbol(request);
+
+    expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        risk_group_id: 'test-risk-group-id',
+        is_closed_end_fund: false,
+      }),
+    });
+  });
+
+  test('should warn and use request risk_group_id when CefConnect lookup throws', async function () {
+    const request = {
+      symbol: 'SPY',
+      risk_group_id: 'test-risk-group-id',
+    };
+
+    mockPrisma.universe.findFirst.mockResolvedValue(null);
+    mockPrisma.risk_group.findUnique.mockResolvedValue({
+      id: 'test-risk-group-id',
+      name: 'Equities',
+    });
+    mockLookupCefConnectSymbol.mockRejectedValue(new Error('Network error'));
+    mockPrisma.universe.create.mockResolvedValue(mockDefaultRecord as any);
+    mockGetLastPrice.mockResolvedValue(undefined);
+    mockGetDistributions.mockResolvedValue(undefined);
+
+    const result = await addSymbol(request);
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'CEF classification lookup failed; using request risk_group_id',
+      expect.objectContaining({ symbol: 'SPY' })
+    );
+    expect(mockPrisma.universe.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        risk_group_id: 'test-risk-group-id',
+        is_closed_end_fund: false,
+      }),
+    });
+    expect(result.fetchFailed).toBe(true);
   });
 
   test('should save symbol first then fetch price and dividend on success', async function () {

--- a/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
+++ b/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
@@ -4,7 +4,7 @@ import {
   classifySymbolRiskGroupId,
   lookupCefConnectSymbol,
   RiskGroupMap,
-} from '../common/cef-classification.function';
+} from '../../common/cef-classification.function';
 import { fetchAndUpdatePriceData } from '../fetch-and-update-price-data.function';
 import type { UniverseRecord } from '../universe-record.interface';
 

--- a/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
+++ b/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
@@ -76,18 +76,36 @@ function mapUniverseRecordToResult(
   };
 }
 
+async function buildRiskGroups(fallbackId: string): Promise<RiskGroupMap> {
+  const groups = await prisma.risk_group.findMany();
+  return {
+    equities:
+      groups.find(function findEquities(g) {
+        return g.name === 'Equities';
+      })?.id ?? fallbackId,
+    income:
+      groups.find(function findIncome(g) {
+        return g.name === 'Income';
+      })?.id ?? fallbackId,
+    taxFree:
+      groups.find(function findTaxFree(g) {
+        return g.name === 'Tax Free Income';
+      })?.id ?? fallbackId,
+  };
+}
+
 async function resolveCefClassification(
   upperSymbol: string,
-  risk_group_id: string,
+  requestRiskGroupId: string,
   riskGroups: RiskGroupMap
 ): Promise<{ effectiveRiskGroupId: string; isCef: boolean }> {
-  let effectiveRiskGroupId = risk_group_id;
+  let effectiveRiskGroupId = requestRiskGroupId;
   let isCef = false;
   try {
     const cefData = await lookupCefConnectSymbol(upperSymbol);
     if (cefData) {
       effectiveRiskGroupId =
-        classifySymbolRiskGroupId(cefData, riskGroups) ?? risk_group_id;
+        classifySymbolRiskGroupId(cefData, riskGroups) ?? requestRiskGroupId;
       isCef = true;
     }
   } catch (error) {
@@ -110,22 +128,7 @@ export async function addSymbol(
 
   await validateSymbolAndRiskGroup(upperSymbol, risk_group_id);
 
-  const groups = await prisma.risk_group.findMany();
-  const riskGroups: RiskGroupMap = {
-    equities:
-      groups.find(function findEquities(g) {
-        return g.name === 'Equities';
-      })?.id ?? risk_group_id,
-    income:
-      groups.find(function findIncome(g) {
-        return g.name === 'Income';
-      })?.id ?? risk_group_id,
-    taxFree:
-      groups.find(function findTaxFree(g) {
-        return g.name === 'Tax Free Income';
-      })?.id ?? risk_group_id,
-  };
-
+  const riskGroups = await buildRiskGroups(risk_group_id);
   const { effectiveRiskGroupId, isCef } = await resolveCefClassification(
     upperSymbol,
     risk_group_id,

--- a/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
+++ b/apps/server/src/app/routes/universe/add-symbol/add-symbol.function.ts
@@ -1,5 +1,10 @@
 import { logger } from '../../../../utils/structured-logger';
 import { prisma } from '../../../prisma/prisma-client';
+import {
+  classifySymbolRiskGroupId,
+  lookupCefConnectSymbol,
+  RiskGroupMap,
+} from '../common/cef-classification.function';
 import { fetchAndUpdatePriceData } from '../fetch-and-update-price-data.function';
 import type { UniverseRecord } from '../universe-record.interface';
 
@@ -71,6 +76,32 @@ function mapUniverseRecordToResult(
   };
 }
 
+async function resolveCefClassification(
+  upperSymbol: string,
+  risk_group_id: string,
+  riskGroups: RiskGroupMap
+): Promise<{ effectiveRiskGroupId: string; isCef: boolean }> {
+  let effectiveRiskGroupId = risk_group_id;
+  let isCef = false;
+  try {
+    const cefData = await lookupCefConnectSymbol(upperSymbol);
+    if (cefData) {
+      effectiveRiskGroupId =
+        classifySymbolRiskGroupId(cefData, riskGroups) ?? risk_group_id;
+      isCef = true;
+    }
+  } catch (error) {
+    logger.warn(
+      'CEF classification lookup failed; using request risk_group_id',
+      {
+        symbol: upperSymbol,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
+  }
+  return { effectiveRiskGroupId, isCef };
+}
+
 export async function addSymbol(
   request: AddSymbolRequest
 ): Promise<AddSymbolResult> {
@@ -79,17 +110,39 @@ export async function addSymbol(
 
   await validateSymbolAndRiskGroup(upperSymbol, risk_group_id);
 
+  const groups = await prisma.risk_group.findMany();
+  const riskGroups: RiskGroupMap = {
+    equities:
+      groups.find(function findEquities(g) {
+        return g.name === 'Equities';
+      })?.id ?? risk_group_id,
+    income:
+      groups.find(function findIncome(g) {
+        return g.name === 'Income';
+      })?.id ?? risk_group_id,
+    taxFree:
+      groups.find(function findTaxFree(g) {
+        return g.name === 'Tax Free Income';
+      })?.id ?? risk_group_id,
+  };
+
+  const { effectiveRiskGroupId, isCef } = await resolveCefClassification(
+    upperSymbol,
+    risk_group_id,
+    riskGroups
+  );
+
   const universeRecord = await prisma.universe.create({
     data: {
       symbol: upperSymbol,
-      risk_group_id,
+      risk_group_id: effectiveRiskGroupId,
       last_price: 0,
       distribution: 0,
       distributions_per_year: 0,
       ex_date: null,
       most_recent_sell_date: null,
       expired: false,
-      is_closed_end_fund: false,
+      is_closed_end_fund: isCef,
     },
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Implemented Closed-End Fund (CEF) classification functionality for symbol creation, automatically determining appropriate risk group assignments based on CEF data lookups with graceful fallback support when CEF data is unavailable.

## Tests
* Expanded test suite with comprehensive scenarios covering successful CEF classification behavior, missing CEF data fallback handling, lookup failure recovery, and associated warning logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->