### PR TITLE
fix(base-table): pin row height and constrain icon-button inflation (Story 67-2)

### DIFF
--- a/apps/dms-material-e2e/src/universe-row-heights.spec.ts
+++ b/apps/dms-material-e2e/src/universe-row-heights.spec.ts
@@ -86,9 +86,6 @@ test.describe('Universe Row Height Consistency — Epic 67 / Story 67.1', () => 
   test('all visible rows have equal offsetHeight (diagnoses icon-button inflation)', async ({
     page,
   }) => {
-    // Mark as expected failure — remove this line after Story 67.2 fix.
-    test.fail();
-
     const rowHeights = await page.evaluate(function measureSeededRowHeights(
       symbols: string[]
     ): number[] {

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.scss
@@ -1,3 +1,15 @@
+// Pin all data rows to a single consistent height so CDK virtual scroll
+// receives a stable itemSize regardless of cell content.
+:host {
+  --mat-table-row-item-container-height: 52px;
+}
+
+// Prevent mat-icon-button from inflating cell height beyond the row height.
+td.mat-mdc-cell button.mat-mdc-icon-button {
+  height: var(--mat-table-row-item-container-height);
+  width: var(--mat-table-row-item-container-height);
+}
+
 .table-container {
   position: relative;
   height: 100%;


### PR DESCRIPTION
## Summary

Pins `--mat-table-row-item-container-height` to `52px` on `:host` in `base-table.component.scss` so all table rows share one consistent height regardless of whether they contain a `mat-icon-button`.

Adds an explicit height/width constraint on `td.mat-mdc-cell button.mat-mdc-icon-button` using the same CSS custom property, preventing icon-button cells from inflating the row beyond the CDK virtual-scroll `itemSize`.

Removes the `test.fail()` marker from `universe-row-heights.spec.ts` added in Story 67.1 now that the height-consistency assertion is expected to pass.

## Changes

- `apps/dms-material/src/app/shared/components/base-table/base-table.component.scss` — pin CSS custom property and constrain icon-button height
- `apps/dms-material-e2e/src/universe-row-heights.spec.ts` — remove `test.fail()` marker

## Testing

- `pnpm nx run dms-material:lint` — passed
- `pnpm nx run dms-material:build` — passed
- `pnpm nx run dms-material:test` — passed
- `pnpm dupcheck` — 0 clones found
- `pnpm format` — no changes

Closes #1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inconsistent table row heights that caused visual irregularities
  * Optimized virtual scrolling performance with standardized row container sizing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->