### PR TITLE
feat(universe): remove empty-state overlay from universe screen (Story 68.1)

### DIFF
--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -79,13 +79,6 @@
       </button>
     </mat-card-content>
   </mat-card>
-  } @if (showEmptyState$()) {
-  <mat-card class="empty-state">
-    <mat-card-content>
-      <mat-icon>info</mat-icon>
-      <p>No results found</p>
-    </mat-card-content>
-  </mat-card>
   }
 
   <div class="table-wrapper">

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -176,11 +176,6 @@ export class GlobalUniverseComponent implements OnDestroy {
     });
   });
 
-  // eslint-disable-next-line @smarttools/no-anonymous-functions -- computed signal
-  readonly showEmptyState$ = computed(() => {
-    return this.globalLoading.isLoading() && this.filteredData$().length === 0;
-  });
-
   onSortChange(sort: Sort): void {
     const shiftKey = this.baseTable()?.getLastShiftKey() ?? false;
     if (sort.direction === '' && !shiftKey) {


### PR DESCRIPTION
## Summary

Removes the misleading "No results found" empty-state overlay that appeared above the column headers on the Universe screen during initial data load.

### Changes
- Removed the `@if (showEmptyState$())` template block from `global-universe.component.html`
- Removed the `showEmptyState$` computed signal from `global-universe.component.ts`
- `MatCardModule` retained in imports — still used by the error card

### Testing
- All unit tests pass (`CI=1 pnpm all`)
- E2E tests pass on Chromium and Firefox (pre-existing failures unrelated)
- No code duplication introduced (`pnpm dupcheck`)

Closes #1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the "No results found" empty state message that appeared during data loading, streamlining the user interface and improving the data display experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->