### PR TITLE
test(e2e): add empty universe state regression test (Story 68.2)

### DIFF
--- a/apps/dms-material-e2e/src/universe-table-workflows.spec.ts
+++ b/apps/dms-material-e2e/src/universe-table-workflows.spec.ts
@@ -1020,3 +1020,28 @@ test.describe('Universe Table Workflows', () => {
     });
   });
 });
+
+/**
+ * Regression guard for Epic 68 / Story 68.2.
+ * The showEmptyState$ computed signal and its @if template block were removed
+ * in Story 68.1. This test ensures the empty-state overlay cannot be
+ * accidentally re-introduced when the universe table has no data rows.
+ */
+test.describe('Empty Universe State', () => {
+  test.beforeEach(async ({ page }) => {
+    // Do NOT seed any universe data — we want the table empty.
+    await login(page);
+    await page.goto('/global/universe');
+    await expect(page.locator('dms-base-table')).toBeVisible();
+  });
+
+  test('should not show empty-state overlay when universe has no rows', async ({
+    page,
+  }) => {
+    // Assert the overlay element is absent entirely
+    await expect(page.locator('.empty-state')).toHaveCount(0);
+
+    // Assert column headers are visible and not obscured
+    await expect(page.locator('th.mat-mdc-header-cell').first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds E2E regression test confirming no .empty-state overlay appears on the Universe screen when no data rows exist. Guards against re-introduction of the showEmptyState block removed in Story 68.1.

### Changes
- Added Empty Universe State test.describe block in universe-table-workflows.spec.ts
- Test navigates to /global/universe without seeding data
- Asserts .empty-state has count 0 and column headers are visible

### Testing
- E2E Chromium: 643 passed, new test green
- E2E Firefox: 652 passed, new test green
- No duplicates (pnpm dupcheck)

Closes #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the empty universe table state, verifying that the empty-state overlay does not appear and table headers remain visible when no data is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->