### PR TITLE
test(e2e): add CSV import regression test (Story 69.1)

### DIFF
--- a/apps/dms-material-e2e/fixtures/fidelity-regression-69.csv
+++ b/apps/dms-material-e2e/fixtures/fidelity-regression-69.csv
@@ -1,0 +1,4 @@
+Run Date,Account,Account Number,Action,Symbol,Description,Type,Price ($),Quantity,Commission ($),Fees ($),Accrued Interest ($),Amount ($),Settlement Date
+08/15/2025,Regression 69 Test Account,99887766,YOU BOUGHT,REGT,REGT INC COMMON STOCK,Stock,10.00,100,,,,-1000.00,08/17/2025
+07/10/2025,Regression 69 Test Account,99887766,YOU BOUGHT,REGT,REGT INC COMMON STOCK,Stock,9.50,200,,,,-1900.00,07/12/2025
+06/05/2025,Regression 69 Test Account,99887766,YOU BOUGHT,REGT,REGT INC COMMON STOCK,Stock,9.00,150,,,,-1350.00,06/07/2025

--- a/apps/dms-material-e2e/src/csv-import-regression-69.spec.ts
+++ b/apps/dms-material-e2e/src/csv-import-regression-69.spec.ts
@@ -1,0 +1,93 @@
+import path from 'path';
+import { expect, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedImportData } from './helpers/seed-import-data.helper';
+
+const FIXTURES_DIR = path.resolve(__dirname, '..', 'fixtures');
+
+/**
+ * CSV Import Regression Tests — Epic 69
+ *
+ * Story 69.1: Failing E2E test reproducing the 400 error on CSV import.
+ * The server returns 400 Bad Request when uploading a valid Fidelity CSV
+ * due to a regression introduced in Epics 63–66.
+ */
+test.describe('CSV Import Regression (Epic 69)', () => {
+  let cleanupFn: (() => Promise<void>) | null = null;
+  let testAccountId: string | null = null;
+
+  test.beforeAll(async ({ request }) => {
+    const accountResponse = await request.post('/api/accounts/add', {
+      data: { name: 'Regression 69 Test Account' },
+    });
+    if (!accountResponse.ok()) {
+      throw new Error(
+        `Failed to create test account: ${accountResponse.status()}`
+      );
+    }
+    const accounts = (await accountResponse.json()) as Array<{ id: string }>;
+    if (!accounts[0]?.id) {
+      throw new Error('Created account has no id');
+    }
+    testAccountId = accounts[0].id;
+
+    const seedResult = await seedImportData('REGT');
+    cleanupFn = seedResult.cleanup;
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (cleanupFn) {
+      await cleanupFn();
+    }
+    if (testAccountId) {
+      await request.delete(`/api/accounts/${testAccountId}`);
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should import regression-69 CSV without 400 error', async ({
+    page,
+  }) => {
+    const responsePromise = page.waitForResponse(function matchImportApi(
+      response
+    ) {
+      return response.url().includes('/api/import/fidelity');
+    });
+
+    // Open import dialog
+    const importButton = page.locator(
+      '[data-testid="import-transactions-button"]'
+    );
+    await expect(importButton).toBeVisible({ timeout: 10000 });
+    await importButton.click();
+    await expect(
+      page.getByRole('heading', { name: 'Import Fidelity Transactions' })
+    ).toBeVisible({ timeout: 5000 });
+
+    // Upload fixture CSV
+    const filePath = path.join(FIXTURES_DIR, 'fidelity-regression-69.csv');
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(filePath);
+
+    // Click upload
+    const uploadButton = page.locator('[data-testid="upload-button"]');
+    await expect(uploadButton).toBeEnabled({ timeout: 5000 });
+    await uploadButton.click();
+
+    const response = await responsePromise;
+    const responseBody = (await response.json()) as {
+      success: boolean;
+      imported: number;
+      errors: string[];
+    };
+
+    expect(responseBody.success).toBe(true);
+    expect(responseBody.imported).toBeGreaterThan(0);
+  });
+});

--- a/apps/dms-material-e2e/src/csv-import-regression-69.spec.ts
+++ b/apps/dms-material-e2e/src/csv-import-regression-69.spec.ts
@@ -37,11 +37,14 @@ test.describe('CSV Import Regression (Epic 69)', () => {
   });
 
   test.afterAll(async ({ request }) => {
-    if (cleanupFn) {
-      await cleanupFn();
-    }
-    if (testAccountId) {
-      await request.delete(`/api/accounts/${testAccountId}`);
+    try {
+      if (cleanupFn) {
+        await cleanupFn();
+      }
+    } finally {
+      if (testAccountId) {
+        await request.delete(`/api/accounts/${testAccountId}`);
+      }
     }
   });
 
@@ -54,10 +57,11 @@ test.describe('CSV Import Regression (Epic 69)', () => {
   test('should import regression-69 CSV without 400 error', async ({
     page,
   }) => {
-    const responsePromise = page.waitForResponse(function matchImportApi(
-      response
-    ) {
-      return response.url().includes('/api/import/fidelity');
+    const responsePromise = page.waitForResponse((response) => {
+      return (
+        response.url().includes('/api/import/fidelity') &&
+        response.request().method() === 'POST'
+      );
     });
 
     // Open import dialog
@@ -81,6 +85,7 @@ test.describe('CSV Import Regression (Epic 69)', () => {
     await uploadButton.click();
 
     const response = await responsePromise;
+    expect(response.status()).toBe(200);
     const responseBody = (await response.json()) as {
       success: boolean;
       imported: number;

--- a/apps/dms-material-e2e/src/helpers/seed-import-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-import-data.helper.ts
@@ -149,9 +149,11 @@ async function createSeedData(
  * Seeds universe and divDepositType data for fidelity import E2E tests.
  * Account creation should be done via the API (request.post).
  */
-export async function seedImportData(): Promise<ImportSeederResult> {
+export async function seedImportData(
+  customSymbol?: string
+): Promise<ImportSeederResult> {
   const prisma = await initializePrismaClient();
-  const symbol = 'IMPORTTEST1';
+  const symbol = customSymbol ?? 'IMPORTTEST1';
 
   try {
     return await createSeedData(prisma, symbol);


### PR DESCRIPTION
## Summary
Adds an E2E regression test for CSV import (Epic 69).

### Changes
- **New fixture**: `apps/dms-material-e2e/fixtures/fidelity-regression-69.csv` — 3 synthetic buy rows for ticker REGT
- **New spec**: `apps/dms-material-e2e/src/csv-import-regression-69.spec.ts` — uploads fixture CSV via the Universe import dialog and asserts success
- **Modified helper**: `apps/dms-material-e2e/src/helpers/seed-import-data.helper.ts` — added optional `customSymbol` parameter to `seedImportData()`

### Finding
The CSV import works correctly (no 400 regression detected). The test serves as a green regression guard. Stories 69.2 and 69.3 may need scope adjustment.

Closes #1039

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite for CSV import functionality to validate that Fidelity transaction imports complete successfully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->