### PR TITLE
fix(routing): restore error-logs route and create component (Story 70.1)

### DIFF
--- a/apps/dms-material/src/app/app.routes.ts
+++ b/apps/dms-material/src/app/app.routes.ts
@@ -82,6 +82,13 @@ export const appRoutes: Route[] = [
           ),
       },
       {
+        path: 'global/error-logs',
+        loadComponent: async () =>
+          import('./global/global-error-logs/global-error-logs').then(
+            (m) => m.GlobalErrorLogsComponent
+          ),
+      },
+      {
         path: 'account/:accountId',
         loadComponent: async () =>
           import('./account-panel/account-panel.component').then(

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -4,7 +4,7 @@
 <mat-card>
   @if (loading$()) {
   <mat-card-content>
-      <mat-spinner diameter="40" aria-label="Loading error logs"></mat-spinner>
+    <mat-spinner diameter="40" aria-label="Loading error logs"></mat-spinner>
   </mat-card-content>
   } @else if (errorMessage$()) {
   <mat-card-content>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -8,7 +8,7 @@
   </mat-card-content>
   } @else if (errorMessage$()) {
   <mat-card-content>
-    <p>{{ errorMessage$() }}</p>
+    <p role="alert" aria-live="polite">{{ errorMessage$() }}</p>
   </mat-card-content>
   } @else {
   <mat-card-content>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -1,0 +1,35 @@
+<mat-toolbar color="primary">
+  <span>Error Logs</span>
+</mat-toolbar>
+<mat-card>
+  @if (loading$()) {
+  <mat-card-content>
+      <mat-spinner diameter="40" aria-label="Loading error logs"></mat-spinner>
+  </mat-card-content>
+  } @else if (errorMessage$()) {
+  <mat-card-content>
+    <p>{{ errorMessage$() }}</p>
+  </mat-card-content>
+  } @else {
+  <mat-card-content>
+    <table mat-table [dataSource]="logs$()">
+      <ng-container matColumnDef="timestamp">
+        <th mat-header-cell *matHeaderCellDef>Timestamp</th>
+        <td mat-cell *matCellDef="let log">
+          {{ log.timestamp | date: 'short' }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="level">
+        <th mat-header-cell *matHeaderCellDef>Level</th>
+        <td mat-cell *matCellDef="let log">{{ log.level }}</td>
+      </ng-container>
+      <ng-container matColumnDef="message">
+        <th mat-header-cell *matHeaderCellDef>Message</th>
+        <td mat-cell *matCellDef="let log">{{ log.message }}</td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </mat-card-content>
+  }
+</mat-card>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
@@ -1,0 +1,64 @@
+import { DatePipe } from '@angular/common';
+import { HttpClient } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTableModule } from '@angular/material/table';
+import { MatToolbarModule } from '@angular/material/toolbar';
+
+interface ErrorLogEntry {
+  id: string;
+  timestamp: string;
+  level: string;
+  message: string;
+  requestId?: string;
+}
+
+interface ErrorLogResponse {
+  logs: ErrorLogEntry[];
+  totalCount: number;
+  currentPage: number;
+  totalPages: number;
+}
+
+@Component({
+  selector: 'dms-global-error-logs',
+  standalone: true,
+  imports: [
+    DatePipe,
+    MatCardModule,
+    MatProgressSpinnerModule,
+    MatTableModule,
+    MatToolbarModule,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './global-error-logs.html',
+})
+export class GlobalErrorLogsComponent implements OnInit {
+  private readonly http = inject(HttpClient);
+
+  readonly loading$ = signal(true);
+  readonly errorMessage$ = signal('');
+  readonly logs$ = signal<ErrorLogEntry[]>([]);
+  readonly displayedColumns = ['timestamp', 'level', 'message'];
+
+  ngOnInit(): void {
+    const self = this;
+    this.http.get<ErrorLogResponse>('/api/logs/errors').subscribe({
+      next: function onLogsSuccess(response) {
+        self.logs$.set(response.logs);
+        self.loading$.set(false);
+      },
+      error: function onLogsError() {
+        self.errorMessage$.set('Failed to load error logs.');
+        self.loading$.set(false);
+      },
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Restores the `global/error-logs` route that was accidentally removed and creates the `GlobalErrorLogsComponent` that was never implemented.

## Changes

- **`app.routes.ts`**: Added lazy-loaded route entry for `global/error-logs` after `global/cusip-cache`
- **`global-error-logs.ts`**: New standalone Angular component that fetches and displays error logs from `/api/logs/errors` with loading spinner, error handling, and mat-table display
- **`global-error-logs.html`**: Template with mat-toolbar header, mat-spinner (with aria-label), error message display, and mat-table with timestamp/level/message columns

## Testing

- `CI=1 pnpm all` passes
- Chromium E2E: pre-existing failures only
- Firefox E2E: 515 passed (infrastructure failure in second half unrelated to changes)
- `pnpm dupcheck` clean
- `pnpm format` applied

Closes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Global Error Logs view. Users can now navigate to a dedicated section to review system error entries. The interface displays error information including timestamps, severity levels, and detailed messages in a table format, with loading and error state indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->