### PR TITLE
test(distributions): add test.fails() for 1-past+1-future edge case (Story 71.1)

### DIFF
--- a/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
@@ -513,18 +513,21 @@ describe('getDistributions', () => {
   // when there is exactly 1 past + 1 future, frequency falls to the default (1).
   // This is incorrect for monthly (or other known-cadence) payers.
 
-  test.fails('BUG(71-1): 1 past + 1 future row 30 days apart should return 12 but returns 1', async () => {
-    // System time: 2025-08-21T10:00:00Z (set in beforeEach)
-    // Exactly 1 past row and 1 future row, ~30 days apart (monthly cadence).
-    const edgeCaseRows: ProcessedRow[] = [
-      { amount: 0.1, date: new Date('2025-08-01') }, // past
-      { amount: 0.1, date: new Date('2025-08-31') }, // future (+30 days)
-    ];
+  test.fails(
+    'BUG(71-1): 1 past + 1 future row 30 days apart should return 12 but returns 1',
+    async () => {
+      // System time: 2025-08-21T10:00:00Z (set in beforeEach)
+      // Exactly 1 past row and 1 future row, ~30 days apart (monthly cadence).
+      const edgeCaseRows: ProcessedRow[] = [
+        { amount: 0.1, date: new Date('2025-08-01') }, // past
+        { amount: 0.1, date: new Date('2025-08-31') }, // future (+30 days)
+      ];
 
-    mockFetchDividendHistory.mockResolvedValueOnce(edgeCaseRows);
+      mockFetchDividendHistory.mockResolvedValueOnce(edgeCaseRows);
 
-    const result = await getDistributions('EDGE-MONTHLY');
+      const result = await getDistributions('EDGE-MONTHLY');
 
-    expect(result?.distributions_per_year).toBe(12);
-  });
+      expect(result?.distributions_per_year).toBe(12);
+    }
+  );
 });

--- a/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
@@ -507,4 +507,24 @@ describe('getDistributions', () => {
 
     expect(result?.distributions_per_year).toBe(52);
   });
+
+  // Story 71.1: Edge case where calculateDistributionsPerYear has only 1 past
+  // and 1 future row. The future-row fallback requires >= 2 future rows, so
+  // when there is exactly 1 past + 1 future, frequency falls to the default (1).
+  // This is incorrect for monthly (or other known-cadence) payers.
+
+  test.fails('BUG(71-1): 1 past + 1 future row 30 days apart should return 12 but returns 1', async () => {
+    // System time: 2025-08-21T10:00:00Z (set in beforeEach)
+    // Exactly 1 past row and 1 future row, ~30 days apart (monthly cadence).
+    const edgeCaseRows: ProcessedRow[] = [
+      { amount: 0.1, date: new Date('2025-08-01') }, // past
+      { amount: 0.1, date: new Date('2025-08-31') }, // future (+30 days)
+    ];
+
+    mockFetchDividendHistory.mockResolvedValueOnce(edgeCaseRows);
+
+    const result = await getDistributions('EDGE-MONTHLY');
+
+    expect(result?.distributions_per_year).toBe(12);
+  });
 });


### PR DESCRIPTION
## Story 71.1: Investigate sync-from-screener distributions_per_year persistence\n\nCloses #1047\n\n### Investigation Findings\n\n**AC1**: `distributions_per_year` IS correctly included in `updateExistingUniverseRecord`'s `prisma.universe.update` call (line ~121 of `sync-from-screener/index.ts`). The field was never omitted.\n\n**AC2**: The remaining bug is **upstream** in `calculateDistributionsPerYear` (in `get-distributions.function.ts`). When a symbol has exactly 1 past + 1 future distribution row, the future-rows fallback requires >= 2 future rows, so it returns the default (1) instead of calculating the interval from the available past+future pair.\n\n**AC3**: Added a `test.fails()` test that demonstrates this edge case: 1 past + 1 future row 30 days apart should return 12 (monthly) but returns 1.\n\n**AC4**: Pre-existing branch coverage threshold failure (98.99% vs 100%) exists on `main` — not caused by this change. All tests pass.\n\n### Changes\n- `apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts`: Added `test.fails()` for BUG(71-1) edge case