### PR TITLE
fix: handle 1-past + 1-future distribution row edge case (Story 71.2)

### DIFF
--- a/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.spec.ts
@@ -507,4 +507,23 @@ describe('getDistributions', () => {
 
     expect(result?.distributions_per_year).toBe(52);
   });
+
+  // Story 71.1 / 71.2: Edge case — 1 past row + 1 future row (no fallback pair)
+  // Before fix: futureRows.length < 2 → returned 1 regardless of actual cadence.
+  // Fix: use the past-to-future interval when exactly 1 of each is available.
+
+  test('BUG(71-1): 1 past + 1 future row ~30 days apart returns distributions_per_year=12', async () => {
+    // System time: 2025-08-21T10:00:00Z (set in beforeEach)
+    // Only 1 past row and 1 future row — recentRows.length === 1, futureRows.length === 1.
+    const minimalPair: ProcessedRow[] = [
+      { amount: 0.25, date: new Date('2025-08-15') }, // past
+      { amount: 0.25, date: new Date('2025-09-14') }, // future (~30 days later)
+    ];
+
+    mockFetchDividendHistory.mockResolvedValueOnce(minimalPair);
+
+    const result = await getDistributions('MINIMAL-MONTHLY');
+
+    expect(result?.distributions_per_year).toBe(12);
+  });
 });

--- a/apps/server/src/app/routes/settings/common/get-distributions.function.ts
+++ b/apps/server/src/app/routes/settings/common/get-distributions.function.ts
@@ -72,6 +72,14 @@ function calculateDistributionsPerYear(
       })
       .slice(0, 2);
 
+    // If we have 1 past row and 1 future row, use them as the interval pair
+    if (recentRows.length === 1 && futureRows.length === 1) {
+      const crossDaysBetween =
+        (futureRows[0].date.valueOf() - recentRows[0].date.valueOf()) /
+        (1000 * 60 * 60 * 24);
+      return intervalToDistributionsPerYear(crossDaysBetween);
+    }
+
     if (futureRows.length < 2) {
       return 1;
     }


### PR DESCRIPTION
## Story 71.2: Fix distributions_per_year for 1-past + 1-future row edge case

Closes #1049

### Problem
When `calculateDistributionsPerYear` encounters exactly 1 past row and 1 future row, it falls through to `futureRows.length < 2` and returns 1 (annual), regardless of the actual distribution cadence. This edge case was documented by Story 71.1's `test.fails()`.

### Fix
In the `recentRows.length <= 1` branch, before the `futureRows.length < 2` guard returns 1, check if we have exactly 1 past row and 1 future row. If so, use the past-to-future interval to determine the cadence.

### Changes
- **`get-distributions.function.ts`**: Added cross-pair interval check when `recentRows.length === 1 && futureRows.length === 1`
- **`get-distributions.function.spec.ts`**: Added passing test for the 1-past + 1-future monthly edge case

### Testing
- All 29 unit tests pass
- Lint clean
- No duplicates
- Format clean