### PR TITLE
test: add E2E test for global error logs page (Story 70.2)

### DIFF
--- a/apps/dms-material-e2e/src/error-logs.spec.ts
+++ b/apps/dms-material-e2e/src/error-logs.spec.ts
@@ -14,6 +14,8 @@ test.describe('Error Logs Navigation', () => {
     await navLink.click();
 
     await expect(page).toHaveURL(/\/global\/error-logs$/);
-    await expect(page.locator('mat-toolbar', { hasText: 'Error Logs' })).toBeVisible();
+    await expect(
+      page.locator('mat-toolbar', { hasText: 'Error Logs' })
+    ).toBeVisible();
   });
 });

--- a/apps/dms-material-e2e/src/error-logs.spec.ts
+++ b/apps/dms-material-e2e/src/error-logs.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+import { login } from './helpers/login.helper';
+
+test.describe('Error Logs Navigation', () => {
+  test.beforeEach(async function loginBeforeEach({ page }) {
+    await login(page);
+  });
+
+  test('navigates to error logs page via nav link', async function navigateToErrorLogs({
+    page,
+  }) {
+    const navLink = page.locator('[data-testid="global-nav-error-logs"]');
+    await navLink.click();
+
+    await expect(page).toHaveURL(/\/global\/error-logs$/);
+    await expect(page.locator('mat-toolbar', { hasText: 'Error Logs' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Story 70.2: E2E Test for Global Error Logs Page

Closes #1046

### Changes
Added E2E test in `apps/dms-material-e2e/src/error-logs.spec.ts` that:
1. Logs in
2. Clicks the `[data-testid="global-nav-error-logs"]` nav link
3. Asserts URL ends with `/global/error-logs`
4. Asserts `mat-toolbar` containing "Error Logs" text is visible

### E2E Results
- **Chromium**: error-logs test passed (test 276 of 656). 5 failures are pre-existing (universe-scrolling-regression, accessibility, add-symbol).
- All other tests continue to pass.

### Quality
- `pnpm all` clean (lint, build)
- `pnpm format` clean
- `pnpm dupcheck` clean