### PR TITLE
test(e2e): add failing test for universe re-sort after cell edit

### DIFF
--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line sonarjs/no-empty-test-file -- test.fail() not recognized by plugin
 import { expect, test } from 'playwright/test';
 
 import { login } from './helpers/login.helper';

--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -20,47 +20,46 @@ test.describe('Universe Re-sort After Cell Edit', () => {
     await cleanup();
   });
 
-  test(
-    'BUG(72-1): row re-sorts after cell edit',
-    async function verifyRowResortAfterCellEdit({ page }) {
-      // Mark as expected failure — the bug prevents re-sort
-      test.fail();
+  test('BUG(72-1): row re-sorts after cell edit', async function verifyRowResortAfterCellEdit({
+    page,
+  }) {
+    // Mark as expected failure — the bug prevents re-sort
+    test.fail();
 
-      // Sort by Ex-Date ascending
-      const exDateHeader = page.locator('[data-sort-header="ex_date"]');
-      await exDateHeader.click();
-      await page.waitForTimeout(500);
+    // Sort by Ex-Date ascending
+    const exDateHeader = page.locator('[data-sort-header="ex_date"]');
+    await exDateHeader.click();
+    await page.waitForTimeout(500);
 
-      // Verify sort is active
-      const sortDir = await exDateHeader.getAttribute('aria-sort');
-      expect(sortDir).toMatch(/ascending|descending/);
+    // Verify sort is active
+    const sortDir = await exDateHeader.getAttribute('aria-sort');
+    expect(sortDir).toMatch(/ascending|descending/);
 
-      // Record the first row's symbol before editing
-      const firstRowSymbol = page.locator(
-        'tr.mat-mdc-row:first-child td:first-child'
-      );
-      const originalSymbol = await firstRowSymbol.textContent();
+    // Record the first row's symbol before editing
+    const firstRowSymbol = page.locator(
+      'tr.mat-mdc-row:first-child td:first-child'
+    );
+    const originalSymbol = await firstRowSymbol.textContent();
 
-      // Click the first row's ex-date cell to enter edit mode
-      const exDateCell = page.locator('[data-testid="ex-date-cell-0"]');
-      await exDateCell.click();
+    // Click the first row's ex-date cell to enter edit mode
+    const exDateCell = page.locator('[data-testid="ex-date-cell-0"]');
+    await exDateCell.click();
 
-      // Wait for the datepicker input to appear
-      const dateInput = page.locator('[data-testid="ex-date-picker"]');
-      await expect(dateInput).toBeVisible({ timeout: 5000 });
+    // Wait for the datepicker input to appear
+    const dateInput = page.locator('[data-testid="ex-date-picker"]');
+    await expect(dateInput).toBeVisible({ timeout: 5000 });
 
-      // Set the date to far in the future so the row should move to the bottom
-      await dateInput.fill('12/31/2099');
-      await page.keyboard.press('Enter');
+    // Set the date to far in the future so the row should move to the bottom
+    await dateInput.fill('12/31/2099');
+    await page.keyboard.press('Enter');
 
-      // Wait for the edit to be processed
-      await page.waitForTimeout(500);
+    // Wait for the edit to be processed
+    await page.waitForTimeout(500);
 
-      // After the edit, the first row should have a DIFFERENT symbol
-      // because the original first row (with the earliest date) now has
-      // a date far in the future and should have moved to the bottom.
-      const newFirstSymbol = await firstRowSymbol.textContent();
-      expect(newFirstSymbol?.trim()).not.toBe(originalSymbol?.trim());
-    }
-  );
+    // After the edit, the first row should have a DIFFERENT symbol
+    // because the original first row (with the earliest date) now has
+    // a date far in the future and should have moved to the bottom.
+    const newFirstSymbol = await firstRowSymbol.textContent();
+    expect(newFirstSymbol?.trim()).not.toBe(originalSymbol?.trim());
+  });
 });

--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -1,4 +1,4 @@
-// eslint-disable-next-line sonarjs/no-empty-test-file -- test.fail() not recognized by plugin
+/* eslint-disable sonarjs/no-empty-test-file -- test.fail() not recognized by plugin */
 import { expect, test } from 'playwright/test';
 
 import { login } from './helpers/login.helper';

--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable sonarjs/no-empty-test-file -- test.fail() not recognized by plugin */
 import { expect, test } from 'playwright/test';
 
 import { login } from './helpers/login.helper';
@@ -21,9 +20,12 @@ test.describe('Universe Re-sort After Cell Edit', () => {
     await cleanup();
   });
 
-  test.fail(
-    'BUG(72-1): row does not re-sort after cell edit',
+  test(
+    'BUG(72-1): row re-sorts after cell edit',
     async function verifyRowResortAfterCellEdit({ page }) {
+      // Mark as expected failure — the bug prevents re-sort
+      test.fail();
+
       // Sort by Ex-Date ascending
       const exDateHeader = page.locator('[data-sort-header="ex_date"]');
       await exDateHeader.click();

--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedUniverseData } from './helpers/seed-universe-data.helper';
+
+test.describe('Universe Re-sort After Cell Edit', () => {
+  let cleanup: () => Promise<void>;
+
+  test.beforeEach(async function setupUniverseData({ page }) {
+    const seeder = await seedUniverseData();
+    cleanup = seeder.cleanup;
+
+    await login(page);
+    await page.goto('/global/universe');
+    await expect(page.locator('dms-base-table')).toBeVisible();
+    await page.waitForSelector('tr.mat-mdc-row', { timeout: 15000 });
+  });
+
+  test.afterEach(async function cleanupUniverseData() {
+    await cleanup();
+  });
+
+  test.fail(
+    'BUG(72-1): row does not re-sort after cell edit',
+    async function verifyRowResortAfterCellEdit({ page }) {
+      // Sort by Ex-Date ascending
+      const exDateHeader = page.locator('[data-sort-header="ex_date"]');
+      await exDateHeader.click();
+      await page.waitForTimeout(500);
+
+      // Verify sort is active
+      const sortDir = await exDateHeader.getAttribute('aria-sort');
+      expect(sortDir).toMatch(/ascending|descending/);
+
+      // Record the first row's symbol before editing
+      const firstRowSymbol = page.locator(
+        'tr.mat-mdc-row:first-child td:first-child'
+      );
+      const originalSymbol = await firstRowSymbol.textContent();
+
+      // Click the first row's ex-date cell to enter edit mode
+      const exDateCell = page.locator('[data-testid="ex-date-cell-0"]');
+      await exDateCell.click();
+
+      // Wait for the datepicker input to appear
+      const dateInput = page.locator('[data-testid="ex-date-picker"]');
+      await expect(dateInput).toBeVisible({ timeout: 5000 });
+
+      // Set the date to far in the future so the row should move to the bottom
+      await dateInput.fill('12/31/2099');
+      await page.keyboard.press('Enter');
+
+      // Wait for the edit to be processed
+      await page.waitForTimeout(500);
+
+      // After the edit, the first row should have a DIFFERENT symbol
+      // because the original first row (with the earliest date) now has
+      // a date far in the future and should have moved to the bottom.
+      const newFirstSymbol = await firstRowSymbol.textContent();
+      expect(newFirstSymbol?.trim()).not.toBe(originalSymbol?.trim());
+    }
+  );
+});


### PR DESCRIPTION
## Summary

Adds a failing E2E test (`test.fail()`) that demonstrates rows in the universe table do not re-sort after a cell is edited.

## Test Plan

1. Seed universe data (5 symbols, one with past ex_date, four with future)
2. Sort by Ex-Date ascending
3. Record first row symbol (the one with the earliest date)
4. Edit that row's ex_date to 12/31/2099 (far future)
5. Assert first row now shows a different symbol (since original should have moved to bottom)

The test currently fails as expected because the table does not re-sort after the edit — the row stays in place despite having a new date that should change its sort position.

## Bug Reference

BUG(72-1): Universe table does not re-sort after cell edit

Refs #1052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test coverage for universe table sorting behavior during cell edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->