### PR TITLE
fix(universe): re-sort data after cell edit (#72.2)

### DIFF
--- a/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
+++ b/apps/dms-material-e2e/src/universe-resort-on-edit.spec.ts
@@ -23,9 +23,6 @@ test.describe('Universe Re-sort After Cell Edit', () => {
   test('BUG(72-1): row re-sorts after cell edit', async function verifyRowResortAfterCellEdit({
     page,
   }) {
-    // Mark as expected failure — the bug prevents re-sort
-    test.fail();
-
     // Sort by Ex-Date ascending
     const exDateHeader = page.locator('[data-sort-header="ex_date"]');
     await exDateHeader.click();

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -289,6 +289,7 @@ export class GlobalUniverseComponent implements OnDestroy {
       validationService: this.validationService,
       emitCellEdit: this.cellEdit.emit.bind(this.cellEdit),
     });
+    this.sortColumns$.set([...this.sortColumns$()]);
   }
 
   onSymbolFilterChange(value: string): void {


### PR DESCRIPTION
## Story 72.2: Fix Universe Re-sort After Cell Edit

### Problem
When editing a cell in the universe table (e.g., changing ex_date), the table does not re-sort to reflect the new value. This is because `handleCellEdit()` mutates the row object in-place, but neither the `data()` nor `sortColumns()` signals change reference, so the `dataSource` computed signal does not re-evaluate.

### Fix
After `handleCellEdit()` completes in `onCellEdit()`, spread-copy `sortColumns$` to create a new array reference: `this.sortColumns$.set([...this.sortColumns$()])`. This triggers the `dataSource` computed to re-sort.

### Changes
- `global-universe.component.ts`: Added `sortColumns$` refresh after `handleCellEdit()`
- `universe-resort-on-edit.spec.ts`: Removed `test.fail()` since the bug is now fixed

### Testing
- All existing unit tests pass (`pnpm all`)
- 0 code clones (`pnpm dupcheck`)
- Format check clean

Closes #1054