### PR TITLE
feat(75-1): add system E2E test infrastructure with DB-clear fixture and screener refresh test

### DIFF
--- a/apps/dms-material-e2e/playwright.config.ts
+++ b/apps/dms-material-e2e/playwright.config.ts
@@ -75,16 +75,29 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
+      testIgnore: ['**/system-integration.spec.ts'],
       use: { ...devices['Desktop Chrome'] },
     },
 
     {
       name: 'firefox',
+      testIgnore: ['**/system-integration.spec.ts'],
       use: {
         ...devices['Desktop Firefox'],
         // Firefox on Linux resolves 'localhost' to ::1 (IPv6), but the dev server
         // only listens on IPv4. Override baseURL to use 127.0.0.1 explicitly.
         baseURL: 'http://127.0.0.1:4301',
+      },
+    },
+
+    {
+      name: 'integration',
+      testMatch: ['**/system-integration.spec.ts'],
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:4201',
+        navigationTimeout: 120_000,
+        actionTimeout: 60_000,
       },
     },
 

--- a/apps/dms-material-e2e/src/system-integration.spec.ts
+++ b/apps/dms-material-e2e/src/system-integration.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from 'playwright/test';
 
 import { login } from './helpers/login.helper';
 

--- a/apps/dms-material-e2e/src/system-integration.spec.ts
+++ b/apps/dms-material-e2e/src/system-integration.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+import { login } from './helpers/login.helper';
+
+test.describe('System Integration — Epic 75', () => {
+  test.beforeAll(async ({ request }) => {
+    const response = await request.delete(
+      'http://localhost:3000/api/test/reset'
+    );
+    if (!response.ok()) {
+      throw new Error(
+        `DB reset failed: ${response.status()} ${await response.text()}`
+      );
+    }
+  });
+
+  test('screener refresh populates the screener table', async ({ page }) => {
+    await login(page);
+    await page.goto('/global/screener');
+    await page.waitForLoadState('networkidle');
+
+    const button = page.locator('[data-testid="refresh-button"]');
+    const overlay = page.locator('[data-testid="loading-overlay"]');
+
+    await expect(button).toBeVisible();
+    await button.click();
+
+    // Overlay must appear quickly after click
+    await expect(overlay).toBeVisible({ timeout: 10_000 });
+
+    // Wait for CefConnect fetch to complete (live network — allow up to 2 min)
+    await expect(overlay).toBeHidden({ timeout: 120_000 });
+
+    // Assert at least one row is present in the screener table
+    const rows = page.locator('.ag-row');
+    await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
+  });
+});

--- a/apps/server/src/app/routes/test/index.ts
+++ b/apps/server/src/app/routes/test/index.ts
@@ -6,9 +6,11 @@ export default function registerTestRoutes(fastify: FastifyInstance): void {
   fastify.delete(
     '/reset',
     async function handleTestReset(_, reply): Promise<void> {
-      if (process.env['NODE_ENV'] === 'production') {
+      const env = process.env['NODE_ENV'];
+      const allowedEnvs = ['development', 'test', 'local'];
+      if (env === undefined || !allowedEnvs.includes(env)) {
         reply.status(403);
-        return reply.send({ error: 'Not available in production' });
+        return reply.send({ error: 'Not available in this environment' });
       }
       // Clear in FK-safe order: dependent tables first
       await prisma.trades.deleteMany();

--- a/apps/server/src/app/routes/test/index.ts
+++ b/apps/server/src/app/routes/test/index.ts
@@ -1,0 +1,23 @@
+import { FastifyInstance } from 'fastify';
+
+import { prisma } from '../../prisma/prisma-client';
+
+export default function registerTestRoutes(fastify: FastifyInstance): void {
+  fastify.delete(
+    '/reset',
+    async function handleTestReset(_, reply): Promise<void> {
+      if (process.env['NODE_ENV'] === 'production') {
+        reply.status(403);
+        return reply.send({ error: 'Not available in production' });
+      }
+      // Clear in FK-safe order: dependent tables first
+      await prisma.trades.deleteMany();
+      await prisma.divDeposits.deleteMany();
+      await prisma.screener.deleteMany();
+      await prisma.universe.deleteMany();
+      return reply.send({
+        cleared: ['trades', 'divDeposits', 'screener', 'universe'],
+      });
+    }
+  );
+}


### PR DESCRIPTION
Closes #1064

## Summary

This PR introduces a system integration E2E test infrastructure as the foundation for Epic 75. It adds a clean-database fixture and a live screener-refresh test that can be extended in subsequent stories.

## Changes

- **DELETE /api/test/reset endpoint** (`apps/server/src/app/routes/test/index.ts`): Clears `trades`, `divDeposits`, `screener`, and `universe` tables in FK-safe order. Guarded by `NODE_ENV !== 'production'`.
- **system-integration.spec.ts** (`apps/dms-material-e2e/src/`): Playwright test that resets the DB in `beforeAll`, navigates to the screener page, clicks the refresh button, waits up to 120 s for the loading overlay to disappear (allowing time for live CefConnect fetch), and asserts at least one AG-Grid row is visible.
- **Integration Playwright project** (`playwright.config.ts`): A new `integration` project with `testMatch: ['**/system-integration.spec.ts']` and `baseURL: http://localhost:4201`. Both `chromium` and `firefox` projects now include `testIgnore: ['**/system-integration.spec.ts']` so the default CI suite is unchanged.

## Testing

The integration test requires a live dev stack and is **not run by default `pnpm all`**. To run it manually:

```sh
# Start dev stack
pnpm nx run dms-material:serve        # port 4201
pnpm nx run server:serve              # port 3000

# Run integration project
pnpm nx run dms-material-e2e:e2e --project=integration
```

Default CI suite (`pnpm all` + chromium/firefox e2e) is unaffected — `system-integration.spec.ts` is excluded via `testIgnore`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added system integration test suite to validate core workflows and application functionality.

* **Chores**
  * Updated test environment configuration and infrastructure to support comprehensive testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->