### PR TITLE
feat(75-2): Add universe sync and distributions_per_year verification to system E2E test

### DIFF
--- a/apps/dms-material-e2e/src/system-integration.spec.ts
+++ b/apps/dms-material-e2e/src/system-integration.spec.ts
@@ -70,10 +70,7 @@ test.describe('System Integration — Epic 75', () => {
       'http://localhost:3000/api/universe'
     );
     expect(universeResponse.ok()).toBeTruthy();
-    const universes: Array<{
-      symbol: string;
-      distributions_per_year: number;
-    }> = await universeResponse.json();
+    const universes = (await universeResponse.json()) as any[];
 
     const bySymbol = Object.fromEntries(universes.map((u) => [u.symbol, u]));
     for (const sym of TARGET_SYMBOLS) {

--- a/apps/dms-material-e2e/src/system-integration.spec.ts
+++ b/apps/dms-material-e2e/src/system-integration.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'playwright/test';
 
 import { login } from './helpers/login.helper';
 
+const TARGET_SYMBOLS = ['OXLC', 'NHS', 'DHY', 'CIK', 'DMB'];
+
 test.describe('System Integration — Epic 75', () => {
   test.beforeAll(async ({ request }) => {
     const response = await request.delete(
@@ -37,4 +39,51 @@ test.describe('System Integration — Epic 75', () => {
     const count = await rows.count();
     expect(count).toBeGreaterThan(0);
   });
+
+  test(
+    'universe sync populates distributions_per_year for monthly payers',
+    async ({ page, request }) => {
+      await login(page);
+      await page.goto('/global/universe');
+      await page.waitForLoadState('networkidle');
+
+      const button = page.locator('[data-testid="update-universe-button"]');
+      const overlay = page.locator('[data-testid="loading-overlay"]');
+
+      await expect(button).toBeVisible();
+      await expect(button).toBeEnabled();
+      await button.click();
+
+      // Overlay must appear quickly after click
+      await expect(overlay).toBeVisible({ timeout: 10_000 });
+
+      // Wait for universe sync to complete — can take 60–90 s for a full universe
+      await expect(overlay).toBeHidden({ timeout: 120_000 });
+
+      // Assert at least one row is visible in the universe table
+      const rows = page.locator('tr.mat-mdc-row');
+      await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+
+      // Verify distributions_per_year via the API for known monthly payers
+      const universeResponse = await request.get(
+        'http://localhost:3000/api/universe'
+      );
+      expect(universeResponse.ok()).toBeTruthy();
+      const universes: Array<{
+        symbol: string;
+        distributions_per_year: number;
+      }> = await universeResponse.json();
+
+      const bySymbol = Object.fromEntries(
+        universes.map((u) => [u.symbol, u])
+      );
+      for (const sym of TARGET_SYMBOLS) {
+        expect(bySymbol[sym], `${sym} not found in universe`).toBeDefined();
+        expect(
+          bySymbol[sym].distributions_per_year,
+          `${sym} distributions_per_year`
+        ).toBe(12);
+      }
+    }
+  );
 });

--- a/apps/dms-material-e2e/src/system-integration.spec.ts
+++ b/apps/dms-material-e2e/src/system-integration.spec.ts
@@ -40,50 +40,48 @@ test.describe('System Integration — Epic 75', () => {
     expect(count).toBeGreaterThan(0);
   });
 
-  test(
-    'universe sync populates distributions_per_year for monthly payers',
-    async ({ page, request }) => {
-      await login(page);
-      await page.goto('/global/universe');
-      await page.waitForLoadState('networkidle');
+  test('universe sync populates distributions_per_year for monthly payers', async ({
+    page,
+    request,
+  }) => {
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
 
-      const button = page.locator('[data-testid="update-universe-button"]');
-      const overlay = page.locator('[data-testid="loading-overlay"]');
+    const button = page.locator('[data-testid="update-universe-button"]');
+    const overlay = page.locator('[data-testid="loading-overlay"]');
 
-      await expect(button).toBeVisible();
-      await expect(button).toBeEnabled();
-      await button.click();
+    await expect(button).toBeVisible();
+    await expect(button).toBeEnabled();
+    await button.click();
 
-      // Overlay must appear quickly after click
-      await expect(overlay).toBeVisible({ timeout: 10_000 });
+    // Overlay must appear quickly after click
+    await expect(overlay).toBeVisible({ timeout: 10_000 });
 
-      // Wait for universe sync to complete — can take 60–90 s for a full universe
-      await expect(overlay).toBeHidden({ timeout: 120_000 });
+    // Wait for universe sync to complete — can take 60–90 s for a full universe
+    await expect(overlay).toBeHidden({ timeout: 120_000 });
 
-      // Assert at least one row is visible in the universe table
-      const rows = page.locator('tr.mat-mdc-row');
-      await expect(rows.first()).toBeVisible({ timeout: 5_000 });
+    // Assert at least one row is visible in the universe table
+    const rows = page.locator('tr.mat-mdc-row');
+    await expect(rows.first()).toBeVisible({ timeout: 5_000 });
 
-      // Verify distributions_per_year via the API for known monthly payers
-      const universeResponse = await request.get(
-        'http://localhost:3000/api/universe'
-      );
-      expect(universeResponse.ok()).toBeTruthy();
-      const universes: Array<{
-        symbol: string;
-        distributions_per_year: number;
-      }> = await universeResponse.json();
+    // Verify distributions_per_year via the API for known monthly payers
+    const universeResponse = await request.get(
+      'http://localhost:3000/api/universe'
+    );
+    expect(universeResponse.ok()).toBeTruthy();
+    const universes: Array<{
+      symbol: string;
+      distributions_per_year: number;
+    }> = await universeResponse.json();
 
-      const bySymbol = Object.fromEntries(
-        universes.map((u) => [u.symbol, u])
-      );
-      for (const sym of TARGET_SYMBOLS) {
-        expect(bySymbol[sym], `${sym} not found in universe`).toBeDefined();
-        expect(
-          bySymbol[sym].distributions_per_year,
-          `${sym} distributions_per_year`
-        ).toBe(12);
-      }
+    const bySymbol = Object.fromEntries(universes.map((u) => [u.symbol, u]));
+    for (const sym of TARGET_SYMBOLS) {
+      expect(bySymbol[sym], `${sym} not found in universe`).toBeDefined();
+      expect(
+        bySymbol[sym].distributions_per_year,
+        `${sym} distributions_per_year`
+      ).toBe(12);
     }
-  );
+  });
 });


### PR DESCRIPTION
## Summary

Adds a second test to the Epic 75 system integration suite that verifies end-to-end behaviour of the universe sync pipeline.

**What this PR does:**

- Navigates to `/global/universe` and clicks the `[data-testid="update-universe-button"]` button
- Waits for the loading overlay to appear then disappear (up to 120 s — universe sync calls CefConnect for every symbol)
- Asserts at least one `tr.mat-mdc-row` row is visible in the universe table
- Fetches `GET /api/universe` and asserts that OXLC, NHS, DHY, CIK, and DMB each have `distributions_per_year === 12`

**Testing**

The test lives in the `integration` Playwright project (`--project=integration`) and is excluded from the `chromium` and `firefox` projects via `testIgnore`.

Run the integration suite with:
```
pnpm nx run dms-material-e2e:e2e --project=integration
```

The DB is reset before each run by the existing `beforeAll` hook, so the test is repeatable.

Closes #1066


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added system integration test for universe synchronization workflow, validating overlay behavior and verifying target universe data attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->