### PR TITLE
feat(electron): launch Fastify backend from Electron main process

### DIFF
--- a/apps/electron/eslint.config.mjs
+++ b/apps/electron/eslint.config.mjs
@@ -6,6 +6,10 @@ export default [
     files: ['**/*.ts'],
     rules: {
       'import/no-default-export': 'off',
+      // Electron main process is Node.js (not Angular/RxJS) - Observables not applicable
+      'no-restricted-syntax': 'off',
+      // Electron callbacks wrap Node.js APIs that don't support async natively
+      '@typescript-eslint/promise-function-async': 'off',
     },
   },
   {

--- a/apps/electron/project.json
+++ b/apps/electron/project.json
@@ -12,9 +12,16 @@
         "cwd": "apps/electron"
       }
     },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "options": {
+        "passWithNoTests": true,
+        "cwd": "apps/electron"
+      }
+    },
     "start": {
       "executor": "nx:run-commands",
-      "dependsOn": ["build"],
+      "dependsOn": ["build", { "projects": ["server"], "target": "build" }],
       "options": {
         "command": "../../node_modules/.bin/electron .",
         "cwd": "apps/electron"

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -14,11 +14,14 @@ function healthCheck(port: number): Promise<void> {
     reject: (err: Error) => void
   ): void {
     const req = http.get(
-      `http://localhost:${port}/api/health`,
+      `http://127.0.0.1:${port}/api/health`,
+      { timeout: 2000 },
       function onResponse(res): void {
         if (res.statusCode === 200) {
+          res.resume();
           resolve();
         } else {
+          res.resume();
           reject(
             new Error(
               `Health check failed with status: ${res.statusCode ?? 'unknown'}`
@@ -27,6 +30,9 @@ function healthCheck(port: number): Promise<void> {
         }
       }
     );
+    req.on('timeout', function onTimeout(): void {
+      req.destroy(new Error('Health check request timed out'));
+    });
     req.on('error', reject);
   });
 }
@@ -36,6 +42,7 @@ function startServer(port: number): Promise<void> {
     resolve: () => void,
     reject: (err: Error) => void
   ): void {
+    // Note: serverPath must be updated for asar-packaged production builds
     const serverPath = path.join(
       __dirname,
       '../../../dist/apps/server/main.js'
@@ -88,16 +95,19 @@ function createWindow(): void {
 }
 
 function handleQuit(): void {
-  if (serverProcess) {
-    serverProcess.kill('SIGTERM');
-    setTimeout(function killIfStillAlive(): void {
-      if (serverProcess) {
-        serverProcess.kill('SIGTERM');
-        serverProcess = null;
-      }
-    }, 3000);
-    serverProcess = null;
+  if (!serverProcess) {
+    return;
   }
+  const child = serverProcess;
+  child.kill('SIGTERM');
+  setTimeout(function killIfStillAlive(): void {
+    if (!child.killed && child.exitCode === null) {
+      child.kill('SIGKILL');
+    }
+  }, 3000);
+  child.once('exit', function clearRef(): void {
+    serverProcess = null;
+  });
 }
 
 function onWindowAllClosed(): void {
@@ -125,6 +135,10 @@ async function init(): Promise<void> {
     createWindow();
   } catch (error) {
     console.error('[electron] Failed to start server:', error);
+    if (serverProcess?.exitCode === null) {
+      serverProcess.kill('SIGKILL');
+      serverProcess = null;
+    }
     app.exit(1);
   }
 }

--- a/apps/electron/src/main.ts
+++ b/apps/electron/src/main.ts
@@ -1,5 +1,77 @@
-import { app, BrowserWindow } from 'electron';
+import { ChildProcess, fork } from 'child_process';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import http from 'http';
 import path from 'path';
+
+import { findAvailablePort } from './utils/port';
+
+let serverProcess: ChildProcess | null = null;
+let resolvedPort: number | null = null;
+
+function healthCheck(port: number): Promise<void> {
+  return new Promise(function doHealthCheck(
+    resolve: () => void,
+    reject: (err: Error) => void
+  ): void {
+    const req = http.get(
+      `http://localhost:${port}/api/health`,
+      function onResponse(res): void {
+        if (res.statusCode === 200) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `Health check failed with status: ${res.statusCode ?? 'unknown'}`
+            )
+          );
+        }
+      }
+    );
+    req.on('error', reject);
+  });
+}
+
+function startServer(port: number): Promise<void> {
+  return new Promise(function doStartServer(
+    resolve: () => void,
+    reject: (err: Error) => void
+  ): void {
+    const serverPath = path.join(
+      __dirname,
+      '../../../dist/apps/server/main.js'
+    );
+    serverProcess = fork(serverPath, [], {
+      env: { ...process.env, PORT: String(port) },
+      silent: false,
+    });
+
+    const timeout = setTimeout(function onTimeout(): void {
+      reject(new Error('Server start timeout after 10 seconds'));
+    }, 10_000);
+
+    serverProcess.on(
+      'message',
+      function onMessage(msg: Buffer | object | string): void {
+        if (msg === 'ready') {
+          clearTimeout(timeout);
+          resolve();
+        }
+      }
+    );
+
+    serverProcess.on('error', function onError(err: Error): void {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    serverProcess.on('exit', function onExit(code: number | null): void {
+      clearTimeout(timeout);
+      if (code !== 0) {
+        reject(new Error(`Server process exited with code ${code ?? 'null'}`));
+      }
+    });
+  });
+}
 
 function createWindow(): void {
   const win = new BrowserWindow({
@@ -15,12 +87,49 @@ function createWindow(): void {
   void win.loadURL('about:blank');
 }
 
+function handleQuit(): void {
+  if (serverProcess) {
+    serverProcess.kill('SIGTERM');
+    setTimeout(function killIfStillAlive(): void {
+      if (serverProcess) {
+        serverProcess.kill('SIGTERM');
+        serverProcess = null;
+      }
+    }, 3000);
+    serverProcess = null;
+  }
+}
+
 function onWindowAllClosed(): void {
   if (process.platform !== 'darwin') {
     app.quit();
   }
 }
 
-void app.whenReady().then(createWindow);
+async function init(): Promise<void> {
+  try {
+    const port = await findAvailablePort();
+    resolvedPort = port;
 
+    ipcMain.handle('get-api-port', function getApiPort(): number | null {
+      return resolvedPort;
+    });
+
+    await startServer(port);
+    console.log(`[electron] Fastify started on port ${port}`);
+
+    await healthCheck(port);
+    console.log(`[electron] Health check passed on port ${port}`);
+
+    await app.whenReady();
+    createWindow();
+  } catch (error) {
+    console.error('[electron] Failed to start server:', error);
+    app.exit(1);
+  }
+}
+
+app.on('before-quit', handleQuit);
 app.on('window-all-closed', onWindowAllClosed);
+
+void init();

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -1,4 +1,7 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcRenderer } from 'electron';
 
-// Expose IPC surface to renderer in later stories
-contextBridge.exposeInMainWorld('electronAPI', {});
+contextBridge.exposeInMainWorld('electronAPI', {
+  getApiPort: function getApiPort(): Promise<number> {
+    return ipcRenderer.invoke('get-api-port') as Promise<number>;
+  },
+});

--- a/apps/electron/src/utils/port.spec.ts
+++ b/apps/electron/src/utils/port.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import * as net from 'net';
+
+import { findAvailablePort } from './port';
+
+describe('findAvailablePort', () => {
+  it('returns a valid port number above 1023', async () => {
+    const port = await findAvailablePort();
+    expect(typeof port).toBe('number');
+    expect(port).toBeGreaterThan(1023);
+    expect(port).toBeLessThanOrEqual(65535);
+  });
+
+  it('returns a port that is actually available (not in use)', async () => {
+    const port = await findAvailablePort();
+    expect(port).toBeGreaterThan(1023);
+    await new Promise<void>(function verifyPortFree(resolve, reject) {
+      const server = net.createServer();
+      server.listen(port, '127.0.0.1', function onListening() {
+        server.close(function onClosed() {
+          resolve();
+        });
+      });
+      server.on('error', function onError(err: Error) {
+        reject(new Error(`Port ${port} was not free: ${err.message}`));
+      });
+    });
+  });
+
+  it('returns different ports on successive calls', async () => {
+    const [port1, port2] = await Promise.all([
+      findAvailablePort(),
+      findAvailablePort(),
+    ]);
+    // Both should be valid ports; they may be different values
+    expect(port1).toBeGreaterThan(1023);
+    expect(port2).toBeGreaterThan(1023);
+  });
+});

--- a/apps/electron/src/utils/port.spec.ts
+++ b/apps/electron/src/utils/port.spec.ts
@@ -27,7 +27,7 @@ describe('findAvailablePort', () => {
     });
   });
 
-  it('returns different ports on successive calls', async () => {
+  it('handles concurrent calls and returns valid ports', async () => {
     const [port1, port2] = await Promise.all([
       findAvailablePort(),
       findAvailablePort(),

--- a/apps/electron/src/utils/port.ts
+++ b/apps/electron/src/utils/port.ts
@@ -1,0 +1,26 @@
+import * as net from 'net';
+
+export function findAvailablePort(): Promise<number> {
+  return new Promise(function resolvePort(
+    resolve: (port: number) => void,
+    reject: (err: Error) => void
+  ): void {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', function onListening(): void {
+      const address = server.address();
+      if (
+        address === null ||
+        address === undefined ||
+        typeof address === 'string'
+      ) {
+        reject(new Error('Could not determine port'));
+        return;
+      }
+      const port = address.port;
+      server.close(function onClosed(): void {
+        resolve(port);
+      });
+    });
+    server.on('error', reject);
+  });
+}

--- a/apps/electron/vitest.config.ts
+++ b/apps/electron/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/apps/electron',
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.spec.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/apps/electron',
+      provider: 'v8' as const,
+    },
+  },
+});

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -68,6 +68,10 @@ async function startServer(): Promise<void> {
     console.log(server.printRoutes());
     console.log(`🚀 Server ready at http://${host}:${port}`);
     console.log(`💚 Health check available at http://${host}:${port}/health`);
+    // Notify parent process (e.g. Electron main) that the server is ready
+    if (process.send) {
+      process.send('ready');
+    }
   } catch (error) {
     server.log.error(error);
     process.exit(1);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,4 @@
-export default ['apps/server/vitest.config.ts'];
+export default [
+  'apps/server/vitest.config.ts',
+  'apps/electron/vitest.config.ts',
+];


### PR DESCRIPTION
## Summary

Implements story 77.2: Launch Fastify Backend from Electron Main Process.

The Electron main process now automatically starts the Fastify backend server on a dynamically allocated port before creating the browser window.

## Changes

### New Files
- `apps/electron/src/utils/port.ts` — `findAvailablePort()` helper using `net.createServer` with port 0 for dynamic OS-allocated port selection
- `apps/electron/src/utils/port.spec.ts` — 3 unit tests for `findAvailablePort()`
- `apps/electron/vitest.config.ts` — Vitest configuration for electron app tests

### Modified Files
- `apps/electron/src/main.ts` — Full implementation: dynamic port allocation → fork server → health check → create window; IPC `get-api-port` handler; graceful shutdown with SIGTERM + 3s force-kill fallback
- `apps/electron/src/preload.ts` — Exposes `getApiPort()` via `contextBridge` for renderer access
- `apps/server/src/main.ts` — Sends `process.send('ready')` after successful listen for IPC coordination
- `apps/electron/project.json` — Adds `test` target and `server:build` dependency to `start` target
- `apps/electron/eslint.config.mjs` — Disables Angular-specific rules (Observables, promise-function-async) for Node.js/Electron context
- `vitest.workspace.ts` — Registers electron vitest config

## Tests
- 3 unit tests: all passing
- Chromium e2e: 653 passed (5 pre-existing failures unrelated to this story)
- Firefox e2e: 664 passed, 0 failures

Closes #1081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Electron app now automatically manages server startup with dynamic port discovery and health verification
  * Added inter-process communication enabling renderer processes to access the API port

* **Chores**
  * Added test framework configuration for Electron application testing
  * Updated project configuration to ensure server builds alongside Electron

<!-- end of auto-generated comment: release notes by coderabbit.ai -->