### PR TITLE
feat(story-80.2): Restore Error Log File-Viewer Component and Fix Route

### DIFF
--- a/_bmad-output/implementation-artifacts/80-2-restore-error-log-viewer.md
+++ b/_bmad-output/implementation-artifacts/80-2-restore-error-log-viewer.md
@@ -33,11 +33,13 @@ so that I can review and manage error logs the same way I could before the refac
 ## Tasks / Subtasks
 
 - [x] Task 1: Review Story 80.1 findings (AC: #1)
+
   - [x] Read `80-1-locate-error-log-component-git.md` Dev Notes — "Investigation Findings" section
   - [x] Confirm recovered component source, component class name, and correct route target are available
   - [x] If component not recoverable from git, reconstruct from scratch (see Dev Notes for expected shape)
 
 - [x] Task 2: Restore or reconstruct the file-viewer component (AC: #1, #3)
+
   - [x] Create component file(s) at original path (or equivalent) in `apps/dms-material/src/app/`
   - [x] Adapt component to use `inject()` instead of constructor injection
   - [x] Apply `ChangeDetectionStrategy.OnPush`
@@ -48,6 +50,7 @@ so that I can review and manage error logs the same way I could before the refac
   - [x] Named functions for all callbacks — no anonymous arrow functions
 
 - [x] Task 3: Check and create backend endpoints if missing (AC: #3, #4)
+
   - [x] Check `apps/server/src/app/routes/` for existing `GET /api/error-logs` and `DELETE /api/error-logs/:filename`
   - [x] If missing, create the route file with Fastify handlers:
     - `GET /api/logs/files` — reads `logs/` directory, returns array of `LogFileInfo` objects (uses existing autoloaded route)
@@ -56,6 +59,7 @@ so that I can review and manage error logs the same way I could before the refac
   - [x] Security: validate filename param — reject any value containing `/`, `..`, or path separators
 
 - [x] Task 4: Update Angular router (AC: #2)
+
   - [x] Open `apps/dms-material/src/app/app.routes.ts`
   - [x] Find the Error Logs route entry (identified in Story 80.1)
   - [x] Update `component:` reference to point at the restored file-viewer component class
@@ -100,18 +104,24 @@ export class ErrorLogComponent {
   }
 
   loadFiles(): void {
-    this.http.get<string[]>('/api/error-logs').subscribe(function handleFiles(files) {
-      // named function — no anonymous arrow function
-      this.errorLogFiles.set(files);
-    }.bind(this)); // or use rxjs take(1) pattern
+    this.http.get<string[]>('/api/error-logs').subscribe(
+      function handleFiles(files) {
+        // named function — no anonymous arrow function
+        this.errorLogFiles.set(files);
+      }.bind(this)
+    ); // or use rxjs take(1) pattern
   }
 
   deleteFile(filename: string): void {
-    this.http.delete(`/api/error-logs/${encodeURIComponent(filename)}`).subscribe(function handleDelete() {
-      this.errorLogFiles.update(function removeFile(files) {
-        return files.filter(function isNotDeleted(f) { return f !== filename; });
-      });
-    }.bind(this));
+    this.http.delete(`/api/error-logs/${encodeURIComponent(filename)}`).subscribe(
+      function handleDelete() {
+        this.errorLogFiles.update(function removeFile(files) {
+          return files.filter(function isNotDeleted(f) {
+            return f !== filename;
+          });
+        });
+      }.bind(this)
+    );
   }
 }
 ```
@@ -159,24 +169,24 @@ The `DELETE /api/error-logs/:filename` endpoint **must** validate the filename p
 
 ### Key Commands
 
-| Purpose | Command |
-|---------|---------|
-| Run all tests | `pnpm all` |
-| Run Chromium E2E | `pnpm e2e:dms-material:chromium` |
-| List server routes | `ls apps/server/src/app/routes/` |
-| Find Angular router | `cat apps/dms-material/src/app/app.routes.ts` |
+| Purpose                | Command                                            |
+| ---------------------- | -------------------------------------------------- |
+| Run all tests          | `pnpm all`                                         |
+| Run Chromium E2E       | `pnpm e2e:dms-material:chromium`                   |
+| List server routes     | `ls apps/server/src/app/routes/`                   |
+| Find Angular router    | `cat apps/dms-material/src/app/app.routes.ts`      |
 | Find existing services | `ls apps/dms-material/src/app/services/` (or api/) |
-| Check logs directory | `ls logs/` |
+| Check logs directory   | `ls logs/`                                         |
 
 ### Key Files
 
-| File | Purpose |
-|------|---------|
-| `80-1-locate-error-log-component-git.md` | Investigation findings — component source and route target |
-| `apps/dms-material/src/app/app.routes.ts` | Angular router — update Error Logs route |
-| `apps/dms-material/src/app/` | Restore component here (confirm path from 80.1) |
-| `apps/server/src/app/routes/` | Add `GET`/`DELETE` error-logs endpoints if missing |
-| `logs/` | Project logs directory — files listed and deleted by this feature |
+| File                                      | Purpose                                                           |
+| ----------------------------------------- | ----------------------------------------------------------------- |
+| `80-1-locate-error-log-component-git.md`  | Investigation findings — component source and route target        |
+| `apps/dms-material/src/app/app.routes.ts` | Angular router — update Error Logs route                          |
+| `apps/dms-material/src/app/`              | Restore component here (confirm path from 80.1)                   |
+| `apps/server/src/app/routes/`             | Add `GET`/`DELETE` error-logs endpoints if missing                |
+| `logs/`                                   | Project logs directory — files listed and deleted by this feature |
 
 ### Constraints
 

--- a/_bmad-output/implementation-artifacts/80-2-restore-error-log-viewer.md
+++ b/_bmad-output/implementation-artifacts/80-2-restore-error-log-viewer.md
@@ -1,6 +1,6 @@
 # Story 80.2: Restore Error Log File-Viewer Component and Fix Route
 
-Status: Approved
+Status: Done
 
 ## Story
 
@@ -32,39 +32,39 @@ so that I can review and manage error logs the same way I could before the refac
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Review Story 80.1 findings (AC: #1)
-  - [ ] Read `80-1-locate-error-log-component-git.md` Dev Notes — "Investigation Findings" section
-  - [ ] Confirm recovered component source, component class name, and correct route target are available
-  - [ ] If component not recoverable from git, reconstruct from scratch (see Dev Notes for expected shape)
+- [x] Task 1: Review Story 80.1 findings (AC: #1)
+  - [x] Read `80-1-locate-error-log-component-git.md` Dev Notes — "Investigation Findings" section
+  - [x] Confirm recovered component source, component class name, and correct route target are available
+  - [x] If component not recoverable from git, reconstruct from scratch (see Dev Notes for expected shape)
 
-- [ ] Task 2: Restore or reconstruct the file-viewer component (AC: #1, #3)
-  - [ ] Create component file(s) at original path (or equivalent) in `apps/dms-material/src/app/`
-  - [ ] Adapt component to use `inject()` instead of constructor injection
-  - [ ] Apply `ChangeDetectionStrategy.OnPush`
-  - [ ] Use signals (`signal()`, `computed()`) for the file list state
-  - [ ] Component must list files from backend API (`GET /api/error-logs`)
-  - [ ] Each file row must show: filename + "Delete" button
-  - [ ] Delete button calls `DELETE /api/error-logs/:filename` and removes row from signal-based list
-  - [ ] Named functions for all callbacks — no anonymous arrow functions
+- [x] Task 2: Restore or reconstruct the file-viewer component (AC: #1, #3)
+  - [x] Create component file(s) at original path (or equivalent) in `apps/dms-material/src/app/`
+  - [x] Adapt component to use `inject()` instead of constructor injection
+  - [x] Apply `ChangeDetectionStrategy.OnPush`
+  - [x] Use signals (`signal()`, `computed()`) for the file list state
+  - [x] Component must list files from backend API (`GET /api/error-logs`)
+  - [x] Each file row must show: filename + "Delete" button
+  - [x] Delete button calls `DELETE /api/error-logs/:filename` and removes row from signal-based list
+  - [x] Named functions for all callbacks — no anonymous arrow functions
 
-- [ ] Task 3: Check and create backend endpoints if missing (AC: #3, #4)
-  - [ ] Check `apps/server/src/app/routes/` for existing `GET /api/error-logs` and `DELETE /api/error-logs/:filename`
-  - [ ] If missing, create the route file with Fastify handlers:
-    - `GET /api/error-logs` — reads `logs/` directory, returns array of filenames
-    - `DELETE /api/error-logs/:filename` — validates filename (no path traversal), deletes file from `logs/`
-  - [ ] Logs directory: `logs/` at project root (confirm location by checking where the server writes logs)
-  - [ ] Security: validate filename param — reject any value containing `/`, `..`, or path separators
+- [x] Task 3: Check and create backend endpoints if missing (AC: #3, #4)
+  - [x] Check `apps/server/src/app/routes/` for existing `GET /api/error-logs` and `DELETE /api/error-logs/:filename`
+  - [x] If missing, create the route file with Fastify handlers:
+    - `GET /api/logs/files` — reads `logs/` directory, returns array of `LogFileInfo` objects (uses existing autoloaded route)
+    - `DELETE /api/logs/files/:filename` — validates filename (no path traversal), deletes file from `logs/`
+  - [x] Logs directory: `logs/` at project root (confirm location by checking where the server writes logs)
+  - [x] Security: validate filename param — reject any value containing `/`, `..`, or path separators
 
-- [ ] Task 4: Update Angular router (AC: #2)
-  - [ ] Open `apps/dms-material/src/app/app.routes.ts`
-  - [ ] Find the Error Logs route entry (identified in Story 80.1)
-  - [ ] Update `component:` reference to point at the restored file-viewer component class
-  - [ ] Verify lazy-loading import path is correct if route uses `loadComponent`
+- [x] Task 4: Update Angular router (AC: #2)
+  - [x] Open `apps/dms-material/src/app/app.routes.ts`
+  - [x] Find the Error Logs route entry (identified in Story 80.1)
+  - [x] Update `component:` reference to point at the restored file-viewer component class
+  - [x] Verify lazy-loading import path is correct if route uses `loadComponent`
 
-- [ ] Task 5: Run full test suite (AC: #5)
-  - [ ] Run `pnpm all` and confirm all tests pass
-  - [ ] Run `pnpm e2e:dms-material:chromium` to confirm E2E passes (Story 80.3 will add more tests)
-  - [ ] Do not modify pre-existing tests
+- [x] Task 5: Run full test suite (AC: #5)
+  - [x] Run `pnpm all` and confirm all tests pass
+  - [x] Run `pnpm e2e:dms-material:chromium` to confirm E2E passes (Story 80.3 will add more tests)
+  - [x] Do not modify pre-existing tests
 
 ## Dev Notes
 
@@ -191,10 +191,34 @@ The `DELETE /api/error-logs/:filename` endpoint **must** validate the filename p
 
 ### Agent Model Used
 
-_TBD_
+Claude Sonnet 4.6 (GitHub Copilot)
 
 ### Debug Log References
 
+- Read full 80-1 findings — confirmed `GlobalErrorLogs` original class name and `48fec6ab~1` recovery path
+- Previous session had committed implementation with class named `GlobalErrorLogs` (no Component suffix)
+- Ran `pnpm all` with `NX_WORKSPACE_ROOT_PATH` override — caught `@angular-eslint/component-class-suffix` error
+- Renamed `GlobalErrorLogs` → `GlobalErrorLogsComponent` and updated route; re-ran lint to confirm clean
+- `pnpm all` passed; dupcheck showed 0 clones; format applied to html+ts
+- E2E chromium + firefox both passed (1 test each in `error-logs.spec.ts`)
+
 ### Completion Notes List
 
+- All 5 ACs satisfied
+- Component uses `inject()`, `OnPush`, signals, named functions — adheres to Angular conventions
+- Backend endpoints use existing `/api/logs/files` autoloaded route (fits project structure better than new `/api/error-logs`)
+- `isValidFilename()` security guard added to DELETE handler — strict alphanumeric regex + `..` check
+- Class renamed to `GlobalErrorLogsComponent` to comply with `@angular-eslint/component-class-suffix` ESLint rule
+
 ### File List
+
+- `apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts` (replaced stub with file-viewer)
+- `apps/dms-material/src/app/global/global-error-logs/global-error-logs.html` (replaced table with mat-list + delete buttons)
+- `apps/dms-material/src/app/app.routes.ts` (updated route to `GlobalErrorLogsComponent`)
+- `apps/server/src/app/routes/logs/index.ts` (added `isValidFilename` guard + `/files` and `/files/:filename` handlers)
+
+### Change Log
+
+- 2026-04-21: Implementation complete. All tasks done, all tests pass, story Status → Done.
+
+## Status: Done

--- a/apps/dms-material/src/app/app.routes.ts
+++ b/apps/dms-material/src/app/app.routes.ts
@@ -85,7 +85,7 @@ export const appRoutes: Route[] = [
         path: 'global/error-logs',
         loadComponent: async () =>
           import('./global/global-error-logs/global-error-logs').then(
-            (m) => m.GlobalErrorLogsComponent
+            (m) => m.GlobalErrorLogs
           ),
       },
       {

--- a/apps/dms-material/src/app/app.routes.ts
+++ b/apps/dms-material/src/app/app.routes.ts
@@ -85,7 +85,7 @@ export const appRoutes: Route[] = [
         path: 'global/error-logs',
         loadComponent: async () =>
           import('./global/global-error-logs/global-error-logs').then(
-            (m) => m.GlobalErrorLogs
+            (m) => m.GlobalErrorLogsComponent
           ),
       },
       {

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -4,7 +4,10 @@
 <mat-card>
   @if (loading$()) {
   <mat-card-content>
-    <mat-spinner diameter="40" aria-label="Loading error log files"></mat-spinner>
+    <mat-spinner
+      diameter="40"
+      aria-label="Loading error log files"
+    ></mat-spinner>
   </mat-card-content>
   } @else if (errorMessage$()) {
   <mat-card-content>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -4,32 +4,35 @@
 <mat-card>
   @if (loading$()) {
   <mat-card-content>
-    <mat-spinner diameter="40" aria-label="Loading error logs"></mat-spinner>
+    <mat-spinner diameter="40" aria-label="Loading error log files"></mat-spinner>
   </mat-card-content>
   } @else if (errorMessage$()) {
   <mat-card-content>
     <p role="alert" aria-live="polite">{{ errorMessage$() }}</p>
   </mat-card-content>
+  } @else if (files$().length === 0) {
+  <mat-card-content>
+    <p>No error log files found.</p>
+  </mat-card-content>
   } @else {
   <mat-card-content>
-    <table mat-table [dataSource]="logs$()">
-      <ng-container matColumnDef="timestamp">
-        <th mat-header-cell *matHeaderCellDef>Timestamp</th>
-        <td mat-cell *matCellDef="let log">
-          {{ log.timestamp | date: 'short' }}
-        </td>
-      </ng-container>
-      <ng-container matColumnDef="level">
-        <th mat-header-cell *matHeaderCellDef>Level</th>
-        <td mat-cell *matCellDef="let log">{{ log.level }}</td>
-      </ng-container>
-      <ng-container matColumnDef="message">
-        <th mat-header-cell *matHeaderCellDef>Message</th>
-        <td mat-cell *matCellDef="let log">{{ log.message }}</td>
-      </ng-container>
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-    </table>
+    <mat-list>
+      @for (file of files$(); track file.filename) {
+      <mat-list-item>
+        <span matListItemTitle>{{ file.displayName }}</span>
+        <span matListItemLine>{{ file.filename }}</span>
+        <button
+          mat-icon-button
+          color="warn"
+          matListItemMeta
+          (click)="deleteFile(file.filename)"
+          [attr.aria-label]="'Delete ' + file.displayName"
+        >
+          <mat-icon>delete</mat-icon>
+        </button>
+      </mat-list-item>
+      }
+    </mat-list>
   </mat-card-content>
   }
 </mat-card>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.html
@@ -9,16 +9,11 @@
       aria-label="Loading error log files"
     ></mat-spinner>
   </mat-card-content>
-  } @else if (errorMessage$()) {
-  <mat-card-content>
-    <p role="alert" aria-live="polite">{{ errorMessage$() }}</p>
-  </mat-card-content>
-  } @else if (files$().length === 0) {
-  <mat-card-content>
-    <p>No error log files found.</p>
-  </mat-card-content>
   } @else {
   <mat-card-content>
+    @if (errorMessage$()) {
+    <p role="alert" aria-live="polite">{{ errorMessage$() }}</p>
+    } @if (files$().length > 0) {
     <mat-list>
       @for (file of files$(); track file.filename) {
       <mat-list-item>
@@ -36,6 +31,9 @@
       </mat-list-item>
       }
     </mat-list>
+    } @else if (!errorMessage$()) {
+    <p>No error log files found.</p>
+    }
   </mat-card-content>
   }
 </mat-card>

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
@@ -33,7 +33,7 @@ interface LogFileInfo {
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './global-error-logs.html',
 })
-export class GlobalErrorLogs {
+export class GlobalErrorLogsComponent {
   private readonly http = inject(HttpClient);
 
   readonly loading$ = signal(true);
@@ -48,18 +48,16 @@ export class GlobalErrorLogs {
     const self = this;
     self.loading$.set(true);
     self.errorMessage$.set('');
-    this.http
-      .get<{ files: LogFileInfo[] }>('/api/logs/files')
-      .subscribe({
-        next: function onFilesSuccess(response) {
-          self.files$.set(response.files);
-          self.loading$.set(false);
-        },
-        error: function onFilesError() {
-          self.errorMessage$.set('Failed to load error log files.');
-          self.loading$.set(false);
-        },
-      });
+    this.http.get<{ files: LogFileInfo[] }>('/api/logs/files').subscribe({
+      next: function onFilesSuccess(response) {
+        self.files$.set(response.files);
+        self.loading$.set(false);
+      },
+      error: function onFilesError() {
+        self.errorMessage$.set('Failed to load error log files.');
+        self.loading$.set(false);
+      },
+    });
   }
 
   deleteFile(filename: string): void {

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
@@ -1,64 +1,84 @@
-import { DatePipe } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
   inject,
-  OnInit,
   signal,
 } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatListModule } from '@angular/material/list';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTableModule } from '@angular/material/table';
 import { MatToolbarModule } from '@angular/material/toolbar';
 
-interface ErrorLogEntry {
-  id: string;
-  timestamp: string;
-  level: string;
-  message: string;
-  requestId?: string;
-}
-
-interface ErrorLogResponse {
-  logs: ErrorLogEntry[];
-  totalCount: number;
-  currentPage: number;
-  totalPages: number;
+interface LogFileInfo {
+  filename: string;
+  displayName: string;
+  size: number;
+  lastModified: string;
 }
 
 @Component({
   selector: 'dms-global-error-logs',
   standalone: true,
   imports: [
-    DatePipe,
+    MatButtonModule,
     MatCardModule,
+    MatIconModule,
+    MatListModule,
     MatProgressSpinnerModule,
-    MatTableModule,
     MatToolbarModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './global-error-logs.html',
 })
-export class GlobalErrorLogsComponent implements OnInit {
+export class GlobalErrorLogs {
   private readonly http = inject(HttpClient);
 
   readonly loading$ = signal(true);
   readonly errorMessage$ = signal('');
-  readonly logs$ = signal<ErrorLogEntry[]>([]);
-  readonly displayedColumns = ['timestamp', 'level', 'message'];
+  readonly files$ = signal<LogFileInfo[]>([]);
 
-  ngOnInit(): void {
+  constructor() {
+    this.loadFiles();
+  }
+
+  loadFiles(): void {
     const self = this;
-    this.http.get<ErrorLogResponse>('/api/logs/errors').subscribe({
-      next: function onLogsSuccess(response) {
-        self.logs$.set(response.logs);
-        self.loading$.set(false);
-      },
-      error: function onLogsError() {
-        self.errorMessage$.set('Failed to load error logs.');
-        self.loading$.set(false);
-      },
-    });
+    self.loading$.set(true);
+    self.errorMessage$.set('');
+    this.http
+      .get<{ files: LogFileInfo[] }>('/api/logs/files')
+      .subscribe({
+        next: function onFilesSuccess(response) {
+          self.files$.set(response.files);
+          self.loading$.set(false);
+        },
+        error: function onFilesError() {
+          self.errorMessage$.set('Failed to load error log files.');
+          self.loading$.set(false);
+        },
+      });
+  }
+
+  deleteFile(filename: string): void {
+    const self = this;
+    this.http
+      .delete<{ success: boolean; message: string }>(
+        `/api/logs/files/${encodeURIComponent(filename)}`
+      )
+      .subscribe({
+        next: function onDeleteSuccess() {
+          self.files$.update(function removeDeleted(files) {
+            return files.filter(function isNotDeleted(f) {
+              return f.filename !== filename;
+            });
+          });
+        },
+        error: function onDeleteError() {
+          self.errorMessage$.set(`Failed to delete file: ${filename}`);
+        },
+      });
   }
 }

--- a/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
+++ b/apps/dms-material/src/app/global/global-error-logs/global-error-logs.ts
@@ -2,9 +2,11 @@ import { HttpClient } from '@angular/common/http';
 import {
   ChangeDetectionStrategy,
   Component,
+  DestroyRef,
   inject,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
@@ -35,6 +37,7 @@ interface LogFileInfo {
 })
 export class GlobalErrorLogsComponent {
   private readonly http = inject(HttpClient);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly loading$ = signal(true);
   readonly errorMessage$ = signal('');
@@ -48,16 +51,19 @@ export class GlobalErrorLogsComponent {
     const self = this;
     self.loading$.set(true);
     self.errorMessage$.set('');
-    this.http.get<{ files: LogFileInfo[] }>('/api/logs/files').subscribe({
-      next: function onFilesSuccess(response) {
-        self.files$.set(response.files);
-        self.loading$.set(false);
-      },
-      error: function onFilesError() {
-        self.errorMessage$.set('Failed to load error log files.');
-        self.loading$.set(false);
-      },
-    });
+    this.http
+      .get<{ files: LogFileInfo[] }>('/api/logs/files')
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: function onFilesSuccess(response) {
+          self.files$.set(response.files);
+          self.loading$.set(false);
+        },
+        error: function onFilesError() {
+          self.errorMessage$.set('Failed to load error log files.');
+          self.loading$.set(false);
+        },
+      });
   }
 
   deleteFile(filename: string): void {
@@ -66,6 +72,7 @@ export class GlobalErrorLogsComponent {
       .delete<{ success: boolean; message: string }>(
         `/api/logs/files/${encodeURIComponent(filename)}`
       )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: function onDeleteSuccess() {
           self.files$.update(function removeDeleted(files) {

--- a/apps/server/src/app/routes/logs/index.ts
+++ b/apps/server/src/app/routes/logs/index.ts
@@ -98,6 +98,12 @@ function handleLogFilesRequest(
   }
 }
 
+function isValidFilename(filename: string): boolean {
+  // Security: reject path traversal, null bytes, and path separators
+  // Only allow alphanumeric, hyphens, underscores, and dots
+  return /^[a-zA-Z0-9_.-]+$/.test(filename) && !filename.includes('..');
+}
+
 function handleDeleteLogFile(
   request: FastifyRequest<{
     Params: { filename: string };
@@ -106,6 +112,12 @@ function handleDeleteLogFile(
 ): { error: string; message: string } | { success: boolean; message: string } {
   try {
     const { filename } = request.params;
+
+    if (!isValidFilename(filename)) {
+      void reply.status(400);
+      return { error: 'Invalid filename', message: 'Filename contains invalid characters' };
+    }
+
     const result = deleteLogFile(filename);
 
     if (result.success) {


### PR DESCRIPTION
## Summary

Restores the GlobalErrorLogs error log file-viewer component that was deleted in Epic 1 (commit 48fec6ab).

## Changes

- **Replaces stub** `GlobalErrorLogsComponent` (64-line Epic 70 stub) with full file-viewer component
- **Component** (`GlobalErrorLogsComponent`): lists log files from `GET /api/logs/files`, each with a Delete button calling `DELETE /api/logs/files/:filename`
- **Angular conventions**: `inject()`, `ChangeDetectionStrategy.OnPush`, signals, named functions, standalone
- **Backend security**: Added `isValidFilename()` guard to DELETE handler — strict alphanumeric regex + `...` check (OWASP A01 path traversal prevention)
- **Route**: Updated `app.routes.ts` to export `GlobalErrorLogsComponent`

## Tests

- `pnpm all` passes (lint, build, unit tests)
- E2E tests pass (chromium + firefox): navigates to error-logs page, verifies mat-toolbar with 'Error Logs' visible

Closes #1102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Restored error log file viewer with enhanced file management capabilities
  * Users can now delete individual log files directly from the interface
  * Improved empty state messaging when no log files are available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->