### PR TITLE
feat(story-81.3): E2E Tests for Vol Column on Universe Screen

### DIFF
--- a/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
+++ b/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
@@ -29,18 +29,21 @@ so that regressions to the column are caught in CI.
 ## Tasks / Subtasks
 
 - [x] Task 1: Explore existing Universe E2E specs and understand seeding patterns (AC: #1–3)
+
   - [x] List `apps/dms-material-e2e/src/` to find existing universe-related specs
   - [x] Read any `universe*.spec.ts` files to understand how they seed data and assert table structure
   - [x] Identify how table headers are selected (CSS selectors, role-based, `data-testid`, etc.)
   - [x] Find the login helper: `apps/dms-material-e2e/src/helpers/login.helper.ts`
 
 - [x] Task 2: Identify seeding mechanism for symbol with 12+ months distribution history (AC: #3)
+
   - [x] Check how existing E2E tests seed distribution/dividend data (look for `beforeAll` patterns in existing specs)
   - [x] Find the distribution import endpoint or seed endpoint in server routes
   - [x] Create a fixture with at least 12 monthly distribution records for a test symbol (e.g., `TEST-VOL`)
   - [x] Seed this fixture in `beforeAll` before Universe screen tests
 
 - [x] Task 3: Write E2E spec (AC: #1, #2, #3)
+
   - [x] Create `apps/dms-material-e2e/src/vol-column.spec.ts`
   - [x] `beforeAll`: login and seed at least one symbol with 12+ months of consistent distribution data
   - [x] Test 1: assert first `mat-header-cell` has text "Vol" (first column check)
@@ -49,6 +52,7 @@ so that regressions to the column are caught in CI.
   - [x] Named functions for all callbacks
 
 - [x] Task 4: Verify with Playwright MCP server (AC: #1, #2, #3)
+
   - [x] Use Playwright MCP server to visually confirm:
     - "Vol" is the first column visible
     - Tooltip appears on hover
@@ -141,6 +145,7 @@ Use the Playwright MCP server to inspect the rendered DOM and confirm the correc
 ### Tooltip Assertion
 
 Angular Material tooltips appear as an overlay element. The selector depends on Angular Material version:
+
 - Newer (`mat-mdc-tooltip`): `.mat-mdc-tooltip`
 - Older (`mat-tooltip`): `.mat-tooltip`
 
@@ -161,6 +166,7 @@ Adjust the locator based on actual DOM structure confirmed via Playwright MCP se
 ### Seeding 12+ Months of Data
 
 For AC #3 to pass, at least one symbol in the test database must have 12+ months of distribution records. Options:
+
 1. Look for an existing E2E seed endpoint (check `POST /api/test/seed` or similar in server routes)
 2. Use a test fixture with pre-existing data if the E2E database is seeded before tests
 3. Insert records via Prisma client in a `globalSetup` file if available
@@ -169,24 +175,24 @@ Look at existing universe E2E specs to see how they handle seeding.
 
 ### Key Commands
 
-| Purpose | Command |
-|---------|---------|
-| Run all tests | `pnpm all` |
-| Run Chromium E2E | `pnpm e2e:dms-material:chromium` |
-| List E2E specs | `ls apps/dms-material-e2e/src/` |
-| Find universe E2E specs | `find apps/dms-material-e2e/src/ -name "*universe*"` |
+| Purpose                     | Command                                                      |
+| --------------------------- | ------------------------------------------------------------ |
+| Run all tests               | `pnpm all`                                                   |
+| Run Chromium E2E            | `pnpm e2e:dms-material:chromium`                             |
+| List E2E specs              | `ls apps/dms-material-e2e/src/`                              |
+| Find universe E2E specs     | `find apps/dms-material-e2e/src/ -name "*universe*"`         |
 | Find Angular Universe route | `grep -r "universe" apps/dms-material/src/app/app.routes.ts` |
-| Find login helper | `find apps/dms-material-e2e/src/ -name "*.helper.ts"` |
+| Find login helper           | `find apps/dms-material-e2e/src/ -name "*.helper.ts"`        |
 
 ### Key Files
 
-| File | Purpose |
-|------|---------|
-| `81-2-frontend-vol-column.md` | Prerequisite — Vol column must be implemented first |
-| `apps/dms-material-e2e/src/vol-column.spec.ts` | New E2E spec to create |
-| `apps/dms-material-e2e/src/helpers/login.helper.ts` | Login helper for E2E tests |
-| `apps/dms-material-e2e/src/` | Existing specs — find universe seeding patterns here |
-| `apps/dms-material/src/app/app.routes.ts` | Angular router — find Universe route URL |
+| File                                                | Purpose                                              |
+| --------------------------------------------------- | ---------------------------------------------------- |
+| `81-2-frontend-vol-column.md`                       | Prerequisite — Vol column must be implemented first  |
+| `apps/dms-material-e2e/src/vol-column.spec.ts`      | New E2E spec to create                               |
+| `apps/dms-material-e2e/src/helpers/login.helper.ts` | Login helper for E2E tests                           |
+| `apps/dms-material-e2e/src/`                        | Existing specs — find universe seeding patterns here |
+| `apps/dms-material/src/app/app.routes.ts`           | Angular router — find Universe route URL             |
 
 ### Constraints
 

--- a/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
+++ b/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
@@ -28,45 +28,45 @@ so that regressions to the column are caught in CI.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Explore existing Universe E2E specs and understand seeding patterns (AC: #1–3)
-  - [ ] List `apps/dms-material-e2e/src/` to find existing universe-related specs
-  - [ ] Read any `universe*.spec.ts` files to understand how they seed data and assert table structure
-  - [ ] Identify how table headers are selected (CSS selectors, role-based, `data-testid`, etc.)
-  - [ ] Find the login helper: `apps/dms-material-e2e/src/helpers/login.helper.ts`
+- [x] Task 1: Explore existing Universe E2E specs and understand seeding patterns (AC: #1–3)
+  - [x] List `apps/dms-material-e2e/src/` to find existing universe-related specs
+  - [x] Read any `universe*.spec.ts` files to understand how they seed data and assert table structure
+  - [x] Identify how table headers are selected (CSS selectors, role-based, `data-testid`, etc.)
+  - [x] Find the login helper: `apps/dms-material-e2e/src/helpers/login.helper.ts`
 
-- [ ] Task 2: Identify seeding mechanism for symbol with 12+ months distribution history (AC: #3)
-  - [ ] Check how existing E2E tests seed distribution/dividend data (look for `beforeAll` patterns in existing specs)
-  - [ ] Find the distribution import endpoint or seed endpoint in server routes
-  - [ ] Create a fixture with at least 12 monthly distribution records for a test symbol (e.g., `TEST-VOL`)
-  - [ ] Seed this fixture in `beforeAll` before Universe screen tests
+- [x] Task 2: Identify seeding mechanism for symbol with 12+ months distribution history (AC: #3)
+  - [x] Check how existing E2E tests seed distribution/dividend data (look for `beforeAll` patterns in existing specs)
+  - [x] Find the distribution import endpoint or seed endpoint in server routes
+  - [x] Create a fixture with at least 12 monthly distribution records for a test symbol (e.g., `TEST-VOL`)
+  - [x] Seed this fixture in `beforeAll` before Universe screen tests
 
-- [ ] Task 3: Write E2E spec (AC: #1, #2, #3)
-  - [ ] Create `apps/dms-material-e2e/src/vol-column.spec.ts`
-  - [ ] `beforeAll`: login and seed at least one symbol with 12+ months of consistent distribution data
-  - [ ] Test 1: assert first `mat-header-cell` has text "Vol" (first column check)
-  - [ ] Test 2: hover over "Vol" header → assert Angular Material tooltip contains "Volatility"
-  - [ ] Test 3: locate the "Vol" column cells → assert at least one cell contains a `mat-icon` element with a non-empty icon name
-  - [ ] Named functions for all callbacks
+- [x] Task 3: Write E2E spec (AC: #1, #2, #3)
+  - [x] Create `apps/dms-material-e2e/src/vol-column.spec.ts`
+  - [x] `beforeAll`: login and seed at least one symbol with 12+ months of consistent distribution data
+  - [x] Test 1: assert first `mat-header-cell` has text "Vol" (first column check)
+  - [x] Test 2: hover over "Vol" header → assert Angular Material tooltip contains "Volatility"
+  - [x] Test 3: locate the "Vol" column cells → assert at least one cell contains a `mat-icon` element with a non-empty icon name
+  - [x] Named functions for all callbacks
 
-- [ ] Task 4: Verify with Playwright MCP server (AC: #1, #2, #3)
-  - [ ] Use Playwright MCP server to visually confirm:
+- [x] Task 4: Verify with Playwright MCP server (AC: #1, #2, #3)
+  - [x] Use Playwright MCP server to visually confirm:
     - "Vol" is the first column visible
     - Tooltip appears on hover
     - Icons are visible for seeded symbols
-  - [ ] Adjust selectors in spec based on visual inspection if needed
+  - [x] Adjust selectors in spec based on visual inspection if needed
 
-- [ ] Task 5: Run full test suite (AC: #4)
-  - [ ] Run `pnpm all` and confirm all tests pass
-  - [ ] Run `pnpm e2e:dms-material:chromium`
-  - [ ] Do not modify pre-existing tests
+- [x] Task 5: Run full test suite (AC: #4)
+  - [x] Run `pnpm all` and confirm all tests pass
+  - [x] Run `pnpm e2e:dms-material:chromium`
+  - [x] Do not modify pre-existing tests
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Explore existing Universe E2E specs and understand seeding patterns (AC: #1–3)
-- [ ] Task 2: Identify seeding mechanism for symbol with 12+ months distribution history (AC: #3)
-- [ ] Task 3: Write E2E spec (AC: #1, #2, #3)
-- [ ] Task 4: Verify with Playwright MCP server (AC: #1, #2, #3)
-- [ ] Task 5: Run full test suite (AC: #4)
+- [x] Task 1: Explore existing Universe E2E specs and understand seeding patterns (AC: #1–3)
+- [x] Task 2: Identify seeding mechanism for symbol with 12+ months distribution history (AC: #3)
+- [x] Task 3: Write E2E spec (AC: #1, #2, #3)
+- [x] Task 4: Verify with Playwright MCP server (AC: #1, #2, #3)
+- [x] Task 5: Run full test suite (AC: #4)
 
 ## Dev Notes
 
@@ -200,10 +200,22 @@ Look at existing universe E2E specs to see how they handle seeding.
 
 ### Agent Model Used
 
-_TBD_
+GitHub Copilot (Claude Sonnet 4.6)
 
 ### Debug Log References
 
+None — all issues resolved without debug log review.
+
 ### Completion Notes List
 
+- All 3 E2E tests pass in both Chromium and Firefox
+- Root cause of `VolatilityDataService` not in bundle: `NX_WORKSPACE_ROOT_PATH` must be set to the worktree when starting the dev server from a git worktree
+- `buildMonthlyDates` date-order bug fixed: `setDate(1)` now runs before `setMonth()` to avoid month-overflow on day 29–31
+- Seed helper catch block now cleans up any partially-created rows before rethrowing
+
 ### File List
+
+- `apps/dms-material-e2e/src/vol-column.spec.ts` (new)
+- `apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts` (new)
+- `apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts` (new)
+- `apps/dms-material/src/app/global/global-universe/global-universe.component.ts` (modified)

--- a/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
+++ b/_bmad-output/implementation-artifacts/81-3-e2e-vol-column.md
@@ -1,6 +1,6 @@
 # Story 81.3: E2E Tests — Vol Column Renders Correctly on Universe Screen
 
-Status: Approved
+Status: Done
 
 ## Story
 

--- a/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
@@ -38,11 +38,7 @@ async function getOrCreateDivDepositTypeId(
 function buildMonthlyDates(): Date[] {
   const dates: Date[] = [];
   const now = new Date();
-  for (
-    let monthOffset = MONTHS_TO_SEED - 1;
-    monthOffset >= 0;
-    monthOffset--
-  ) {
+  for (let monthOffset = MONTHS_TO_SEED - 1; monthOffset >= 0; monthOffset--) {
     const d = new Date(now);
     d.setMonth(d.getMonth() - monthOffset);
     d.setDate(1);

--- a/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
@@ -40,8 +40,8 @@ function buildMonthlyDates(): Date[] {
   const now = new Date();
   for (let monthOffset = MONTHS_TO_SEED - 1; monthOffset >= 0; monthOffset--) {
     const d = new Date(now);
-    d.setMonth(d.getMonth() - monthOffset);
     d.setDate(1);
+    d.setMonth(d.getMonth() - monthOffset);
     dates.push(d);
   }
   return dates;
@@ -100,6 +100,19 @@ export async function seedVolColumnE2eData(): Promise<VolColumnSeederResult> {
       }),
     });
   } catch (error) {
+    if (universeId !== '') {
+      await prisma.divDeposits
+        .deleteMany({ where: { universeId } })
+        .catch(() => undefined);
+      await prisma.universe
+        .delete({ where: { id: universeId } })
+        .catch(() => undefined);
+    }
+    if (accountId !== '') {
+      await prisma.accounts
+        .delete({ where: { id: accountId } })
+        .catch(() => undefined);
+    }
     await prisma.$disconnect();
     throw error;
   }

--- a/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
@@ -1,0 +1,124 @@
+import type { PrismaClient } from '@prisma/client';
+
+import { generateUniqueId } from './generate-unique-id.helper';
+import type { SeederResultBase } from './seeder-result-base.types';
+import { initializePrismaClient } from './shared-prisma-client.helper';
+
+const STEADY_AMOUNT = 1.0;
+const MONTHS_TO_SEED = 12;
+
+interface VolColumnSeederResult extends SeederResultBase {
+  symbol: string;
+}
+
+async function getOrCreateRiskGroupId(prisma: PrismaClient): Promise<string> {
+  const rg = await prisma.risk_group.upsert({
+    where: { name: 'Equities' },
+    update: {},
+    create: { name: 'Equities' },
+  });
+  return rg.id;
+}
+
+async function getOrCreateDivDepositTypeId(
+  prisma: PrismaClient
+): Promise<string> {
+  const existing = await prisma.divDepositType.findFirst({
+    where: { name: 'Dividend' },
+  });
+  if (existing !== null) {
+    return existing.id;
+  }
+  const created = await prisma.divDepositType.create({
+    data: { name: 'Dividend' },
+  });
+  return created.id;
+}
+
+function buildMonthlyDates(): Date[] {
+  const dates: Date[] = [];
+  const now = new Date();
+  for (
+    let monthOffset = MONTHS_TO_SEED - 1;
+    monthOffset >= 0;
+    monthOffset--
+  ) {
+    const d = new Date(now);
+    d.setMonth(d.getMonth() - monthOffset);
+    d.setDate(1);
+    dates.push(d);
+  }
+  return dates;
+}
+
+export async function seedVolColumnE2eData(): Promise<VolColumnSeederResult> {
+  const prisma = await initializePrismaClient();
+  const uniqueId = generateUniqueId();
+  const symbol = `E2EVOL${uniqueId}`;
+  const accountName = `E2E-VOL-Acct-${uniqueId}`;
+  let universeId = '';
+  let accountId = '';
+
+  try {
+    const riskGroupId = await getOrCreateRiskGroupId(prisma);
+    const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
+
+    const universe = await prisma.universe.create({
+      data: {
+        symbol,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        risk_group_id: riskGroupId,
+        distribution: 1.0,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        distributions_per_year: 12,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        last_price: 10.0,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        ex_date: null,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        most_recent_sell_date: null,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        most_recent_sell_price: null,
+        expired: false,
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+        is_closed_end_fund: true,
+      },
+    });
+    universeId = universe.id;
+
+    const account = await prisma.accounts.create({
+      data: { name: accountName },
+    });
+    accountId = account.id;
+
+    const dates = buildMonthlyDates();
+    await prisma.divDeposits.createMany({
+      data: dates.map(function buildDepositRecord(date: Date) {
+        return {
+          date,
+          amount: STEADY_AMOUNT,
+          accountId,
+          divDepositTypeId,
+          universeId,
+        };
+      }),
+    });
+  } catch (error) {
+    await prisma.$disconnect();
+    throw error;
+  }
+
+  return {
+    symbol,
+    symbols: [symbol],
+    cleanup: async function cleanupVolColumnData(): Promise<void> {
+      try {
+        await prisma.divDeposits.deleteMany({ where: { universeId } });
+        await prisma.universe.deleteMany({ where: { symbol } });
+        await prisma.accounts.deleteMany({ where: { name: accountName } });
+      } finally {
+        await prisma.$disconnect();
+      }
+    },
+  };
+}

--- a/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
@@ -47,6 +47,54 @@ function buildMonthlyDates(): Date[] {
   return dates;
 }
 
+function buildUniverseCreateData(
+  symbol: string,
+  riskGroupId: string
+): Record<string, unknown> {
+  return {
+    symbol,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    risk_group_id: riskGroupId,
+    distribution: 1.0,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    distributions_per_year: 12,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    last_price: 10.0,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    ex_date: null,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    most_recent_sell_date: null,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    most_recent_sell_price: null,
+    expired: false,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
+    is_closed_end_fund: true,
+  };
+}
+
+async function cleanupOnError(
+  prisma: PrismaClient,
+  universeId: string,
+  accountId: string
+): Promise<void> {
+  function suppressError(): undefined {
+    return undefined;
+  }
+  if (universeId !== '') {
+    await prisma.divDeposits
+      .deleteMany({ where: { universeId } })
+      .catch(suppressError);
+    await prisma.universe
+      .delete({ where: { id: universeId } })
+      .catch(suppressError);
+  }
+  if (accountId !== '') {
+    await prisma.accounts
+      .delete({ where: { id: accountId } })
+      .catch(suppressError);
+  }
+}
+
 export async function seedVolColumnE2eData(): Promise<VolColumnSeederResult> {
   const prisma = await initializePrismaClient();
   const uniqueId = generateUniqueId();
@@ -58,35 +106,14 @@ export async function seedVolColumnE2eData(): Promise<VolColumnSeederResult> {
   try {
     const riskGroupId = await getOrCreateRiskGroupId(prisma);
     const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
-
     const universe = await prisma.universe.create({
-      data: {
-        symbol,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        risk_group_id: riskGroupId,
-        distribution: 1.0,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        distributions_per_year: 12,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        last_price: 10.0,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        ex_date: null,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        most_recent_sell_date: null,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        most_recent_sell_price: null,
-        expired: false,
-        // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
-        is_closed_end_fund: true,
-      },
+      data: buildUniverseCreateData(symbol, riskGroupId),
     });
     universeId = universe.id;
-
     const account = await prisma.accounts.create({
       data: { name: accountName },
     });
     accountId = account.id;
-
     const dates = buildMonthlyDates();
     await prisma.divDeposits.createMany({
       data: dates.map(function buildDepositRecord(date: Date) {
@@ -100,19 +127,7 @@ export async function seedVolColumnE2eData(): Promise<VolColumnSeederResult> {
       }),
     });
   } catch (error) {
-    if (universeId !== '') {
-      await prisma.divDeposits
-        .deleteMany({ where: { universeId } })
-        .catch(() => undefined);
-      await prisma.universe
-        .delete({ where: { id: universeId } })
-        .catch(() => undefined);
-    }
-    if (accountId !== '') {
-      await prisma.accounts
-        .delete({ where: { id: accountId } })
-        .catch(() => undefined);
-    }
+    await cleanupOnError(prisma, universeId, accountId);
     await prisma.$disconnect();
     throw error;
   }

--- a/apps/dms-material-e2e/src/vol-column.spec.ts
+++ b/apps/dms-material-e2e/src/vol-column.spec.ts
@@ -28,30 +28,28 @@ test.describe('Volatility Column', function describeVolColumn() {
   test('first column header has text Vol', async function firstColumnIsVol({
     page,
   }) {
-    await expect(page.locator('[role="columnheader"]').first()).toContainText(
-      'Vol'
-    );
+    await expect(
+      page
+        .locator('tr.mat-mdc-header-row:not(.filter-row) [role="columnheader"]')
+        .first()
+    ).toContainText('Vol');
   });
 
-  test(
-    'hovering Vol header shows tooltip Volatility',
-    async function volTooltipShowsVolatility({ page }) {
-      const volHeader = page.getByRole('columnheader', { name: 'Vol' });
-      await volHeader.hover();
-      await expect(
-        page.locator('.mat-mdc-tooltip')
-      ).toContainText('Volatility');
-    }
-  );
+  test('hovering Vol header shows tooltip Volatility', async function volTooltipShowsVolatility({
+    page,
+  }) {
+    const volHeader = page.getByRole('columnheader', { name: 'Vol' });
+    await volHeader.hover();
+    await expect(page.locator('.mat-mdc-tooltip')).toContainText('Volatility');
+  });
 
-  test(
-    'at least one row in Vol column shows an icon',
-    async function volColumnShowsIcon({ page }) {
-      const searchInput = page.locator('input[placeholder="Search Symbol"]');
-      await searchInput.fill(symbol);
-      await expect(
-        page.locator('td.mat-column-vol mat-icon').first()
-      ).toBeVisible({ timeout: 10000 });
-    }
-  );
+  test('at least one row in Vol column shows an icon', async function volColumnShowsIcon({
+    page,
+  }) {
+    const searchInput = page.locator('input[placeholder="Search Symbol"]');
+    await searchInput.fill(symbol);
+    await expect(
+      page.locator('td.mat-column-vol mat-icon').first()
+    ).toBeVisible({ timeout: 10000 });
+  });
 });

--- a/apps/dms-material-e2e/src/vol-column.spec.ts
+++ b/apps/dms-material-e2e/src/vol-column.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedVolColumnE2eData } from './helpers/seed-vol-column-e2e-data.helper';
+
+test.describe('Volatility Column', function describeVolColumn() {
+  let cleanup: (() => Promise<void>) | undefined;
+  let symbol: string;
+
+  test.beforeAll(async function seedData() {
+    const result = await seedVolColumnE2eData();
+    cleanup = result.cleanup;
+    symbol = result.symbol;
+  });
+
+  test.afterAll(async function teardown() {
+    if (cleanup !== undefined) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async function navigateToUniverse({ page }) {
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('first column header has text Vol', async function firstColumnIsVol({
+    page,
+  }) {
+    await expect(page.locator('[role="columnheader"]').first()).toContainText(
+      'Vol'
+    );
+  });
+
+  test(
+    'hovering Vol header shows tooltip Volatility',
+    async function volTooltipShowsVolatility({ page }) {
+      const volHeader = page.getByRole('columnheader', { name: 'Vol' });
+      await volHeader.hover();
+      await expect(
+        page.locator('.mat-mdc-tooltip')
+      ).toContainText('Volatility');
+    }
+  );
+
+  test(
+    'at least one row in Vol column shows an icon',
+    async function volColumnShowsIcon({ page }) {
+      const searchInput = page.locator('input[placeholder="Search Symbol"]');
+      await searchInput.fill(symbol);
+      await expect(
+        page.locator('td.mat-column-vol mat-icon').first()
+      ).toBeVisible({ timeout: 10000 });
+    }
+  );
+});

--- a/apps/dms-material/src/app/global/global-universe/apply-volatility.function.ts
+++ b/apps/dms-material/src/app/global/global-universe/apply-volatility.function.ts
@@ -1,5 +1,5 @@
-import type { VolatilityResult } from './services/volatility-result.interface';
 import type { Universe } from '../../store/universe/universe.interface';
+import type { VolatilityResult } from './services/volatility-result.interface';
 
 export function applyVolatility(
   rows: Universe[],

--- a/apps/dms-material/src/app/global/global-universe/apply-volatility.function.ts
+++ b/apps/dms-material/src/app/global/global-universe/apply-volatility.function.ts
@@ -1,0 +1,15 @@
+import type { VolatilityResult } from './services/volatility-result.interface';
+import type { Universe } from '../../store/universe/universe.interface';
+
+export function applyVolatility(
+  rows: Universe[],
+  volMap: Map<string, VolatilityResult>
+): void {
+  for (const row of rows) {
+    const vol = volMap.get(row.symbol);
+    if (vol !== undefined) {
+      row.volatility1yr = vol.volatility1yr;
+      row.volatility5yr = vol.volatility5yr;
+    }
+  }
+}

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -57,6 +57,7 @@ import { restoreUniverseFilters } from './restore-universe-filters.function';
 import { saveUniverseFiltersAndNotify } from './save-universe-filters-and-notify.function';
 import { UniverseService } from './services/universe.service';
 import { UniverseValidationService } from './services/universe-validation.service';
+import { VolatilityDataService } from './services/volatility-data.service';
 import { updatePendingEdits } from './update-pending-edits.function';
 
 @Component({
@@ -93,6 +94,7 @@ export class GlobalUniverseComponent implements OnDestroy {
   private readonly updateFieldsService = inject(UpdateUniverseFieldsService);
   private readonly errorHandling = inject(ErrorHandlingService);
   private readonly sortFilterStateService = inject(SortFilterStateService);
+  private readonly volatilityDataService = inject(VolatilityDataService);
   readonly cellEdit = output<CellEditEvent>();
   readonly symbolDeleted = output<Universe>();
   readonly today = new Date();
@@ -166,6 +168,15 @@ export class GlobalUniverseComponent implements OnDestroy {
     const riskGroups = selectRiskGroup();
     const vr = this.visibleRange();
     const enrichedData = enrichUniverseWithRiskGroups(rawData, riskGroups, vr);
+
+    const volMap = this.volatilityDataService.volatilityMap();
+    for (const row of enrichedData) {
+      const vol = volMap.get(row.symbol);
+      if (vol !== undefined) {
+        row.volatility1yr = vol.volatility1yr;
+        row.volatility5yr = vol.volatility5yr;
+      }
+    }
 
     applyPendingEdits(enrichedData, this.pendingEdits$());
     return filterUniverses(enrichedData, {

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.ts
@@ -41,6 +41,7 @@ import { ScreenerService } from '../global-screener/services/screener.service';
 import { ImportDialogComponent } from '../import-dialog/import-dialog.component';
 import { ImportDialogResult } from '../import-dialog/import-dialog-result.interface';
 import { applyPendingEdits } from './apply-pending-edits.function';
+import { applyVolatility } from './apply-volatility.function';
 import { buildAccountOptions } from './build-account-options.function';
 import { buildRiskGroupOptions } from './build-risk-group-options.function';
 import { buildShiftSortColumns } from './build-shift-sort-columns.function';
@@ -170,14 +171,7 @@ export class GlobalUniverseComponent implements OnDestroy {
     const enrichedData = enrichUniverseWithRiskGroups(rawData, riskGroups, vr);
 
     const volMap = this.volatilityDataService.volatilityMap();
-    for (const row of enrichedData) {
-      const vol = volMap.get(row.symbol);
-      if (vol !== undefined) {
-        row.volatility1yr = vol.volatility1yr;
-        row.volatility5yr = vol.volatility5yr;
-      }
-    }
-
+    applyVolatility(enrichedData, volMap);
     applyPendingEdits(enrichedData, this.pendingEdits$());
     return filterUniverses(enrichedData, {
       symbolFilter: this.symbolFilter$(),

--- a/apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts
+++ b/apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts
@@ -1,19 +1,17 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 
-export interface VolatilityResult {
-  symbol: string;
-  volatility1yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
-  volatility5yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
-}
+import { VolatilityResult } from './volatility-result.interface';
 
 @Injectable({ providedIn: 'root' })
 export class VolatilityDataService {
   private readonly http = inject(HttpClient);
-  private readonly _volatilityMap = signal<Map<string, VolatilityResult>>(
+
+  private readonly volatilityMapSignal = signal<Map<string, VolatilityResult>>(
     new Map()
   );
-  readonly volatilityMap = this._volatilityMap.asReadonly();
+
+  readonly volatilityMap = this.volatilityMapSignal.asReadonly();
 
   constructor() {
     this.loadVolatilityData();
@@ -27,7 +25,7 @@ export class VolatilityDataService {
         for (const result of results) {
           map.set(result.symbol, result);
         }
-        service._volatilityMap.set(map);
+        service.volatilityMapSignal.set(map);
       },
       // eslint-disable-next-line @typescript-eslint/no-empty-function -- silently handle unavailability; vol cells remain empty
       error: function onVolatilityLoadError(): void {},

--- a/apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts
+++ b/apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable, signal } from '@angular/core';
+
+export interface VolatilityResult {
+  symbol: string;
+  volatility1yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
+  volatility5yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
+}
+
+@Injectable({ providedIn: 'root' })
+export class VolatilityDataService {
+  private readonly http = inject(HttpClient);
+  private readonly _volatilityMap = signal<Map<string, VolatilityResult>>(
+    new Map()
+  );
+  readonly volatilityMap = this._volatilityMap.asReadonly();
+
+  constructor() {
+    this.loadVolatilityData();
+  }
+
+  private loadVolatilityData(): void {
+    const service = this;
+    this.http.get<VolatilityResult[]>('/api/universe/volatility').subscribe({
+      next: function onVolatilityLoaded(results: VolatilityResult[]): void {
+        const map = new Map<string, VolatilityResult>();
+        for (const result of results) {
+          map.set(result.symbol, result);
+        }
+        service._volatilityMap.set(map);
+      },
+      // eslint-disable-next-line @typescript-eslint/no-empty-function -- silently handle unavailability; vol cells remain empty
+      error: function onVolatilityLoadError(): void {},
+    });
+  }
+}

--- a/apps/dms-material/src/app/global/global-universe/services/volatility-result.interface.ts
+++ b/apps/dms-material/src/app/global/global-universe/services/volatility-result.interface.ts
@@ -1,0 +1,5 @@
+export interface VolatilityResult {
+  symbol: string;
+  volatility1yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
+  volatility5yr: 'decreasing' | 'increasing' | 'steady' | 'volatile' | null;
+}


### PR DESCRIPTION
## Summary

Adds Playwright E2E tests for the Vol column on the Universe screen, which was introduced in stories 81.1 and 81.2.

## Changes

- **`apps/dms-material-e2e/src/vol-column.spec.ts`** — 3 E2E tests:
  1. First column header has text "Vol"
  2. Hovering "Vol" header shows tooltip "Volatility"
  3. At least one row in the Vol column shows a volatility icon

- **`apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts`** — Seeds 12 monthly dividend deposits for a test symbol to produce a 'steady' volatility reading

- **`apps/dms-material/src/app/global/global-universe/services/volatility-data.service.ts`** — Angular service that fetches `GET /api/universe/volatility` and maintains a signal map keyed by symbol

- **`apps/dms-material/src/app/global/global-universe/global-universe.component.ts`** — Wires `VolatilityDataService` into the `filteredData$` computed signal to enrich each row with `volatility1yr`/`volatility5yr` values

## Test Results

All 3 tests pass in both Chromium and Firefox. No duplicate code found (jscpd: 0 clones).

Closes #1111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Volatility column to the universe view, displaying volatility indicators for securities to help users assess market performance trends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->