### PR TITLE
Story 83.2: Write Electron App Documentation

### DIFF
--- a/_bmad-output/implementation-artifacts/83-2-electron-documentation.md
+++ b/_bmad-output/implementation-artifacts/83-2-electron-documentation.md
@@ -1,6 +1,6 @@
 # Story 83.2: Write Electron App Documentation
 
-Status: Approved
+Status: Review
 
 ## Story
 
@@ -15,6 +15,7 @@ integration without having to reverse-engineer it from the source.
 1. **Given** the `apps/electron` package,
    **When** a new `apps/electron/README.md` file is created,
    **Then** the documentation covers at minimum:
+
    - Prerequisites (Node version, pnpm, Electron version)
    - How to build the Angular app before launching Electron
    - How to run the app in development (`pnpm nx run electron:start`)
@@ -35,35 +36,39 @@ integration without having to reverse-engineer it from the source.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Read all Electron source files to ensure documentation accuracy (AC: #1, #2)
-  - [ ] Read `apps/electron/src/main.ts` — understand BrowserWindow config, server fork,
+- [x] Task 1: Read all Electron source files to ensure documentation accuracy (AC: #1, #2)
+
+  - [x] Read `apps/electron/src/main.ts` — understand BrowserWindow config, server fork,
         link interception, health check, and CSP setup
-  - [ ] Read `apps/electron/src/preload.ts` — understand contextBridge / `electronAPI`
+  - [x] Read `apps/electron/src/preload.ts` — understand contextBridge / `electronAPI`
         exposure
-  - [ ] Read `apps/electron/src/utils/port.ts` — understand dynamic port selection
-  - [ ] Read `apps/electron/project.json` — document `build`, `start`, and `test` targets
-  - [ ] Read `apps/electron/package.json` — note `main` field and `start` script
-  - [ ] Read `apps/electron/tsconfig.json` — note compilation output directory
+  - [x] Read `apps/electron/src/utils/port.ts` — understand dynamic port selection
+  - [x] Read `apps/electron/project.json` — document `build`, `start`, and `test` targets
+  - [x] Read `apps/electron/package.json` — note `main` field and `start` script
+  - [x] Read `apps/electron/tsconfig.json` — note compilation output directory
 
-- [ ] Task 2: Read Epic 77 story files for historical context (AC: #2)
-  - [ ] Read `_bmad-output/implementation-artifacts/77-1-research-electron-setup.md`
-  - [ ] Read `_bmad-output/implementation-artifacts/77-2-launch-fastify-in-electron.md`
-  - [ ] Read `_bmad-output/implementation-artifacts/77-3-configure-electron-window.md`
-  - [ ] Read `_bmad-output/implementation-artifacts/77-4-intercept-api-and-external-links.md`
-  - [ ] Read `_bmad-output/implementation-artifacts/77-5-e2e-electron-launch.md`
-  - [ ] Note any design decisions or known limitations documented in these files
+- [x] Task 2: Read Epic 77 story files for historical context (AC: #2)
 
-- [ ] Task 3: Read Story 83.1 findings to include accurate build information (AC: #1, #2)
-  - [ ] Read `_bmad-output/implementation-artifacts/83-1-audit-electron-build.md` —
+  - [x] Read `_bmad-output/implementation-artifacts/77-1-research-electron-setup.md`
+  - [x] Read `_bmad-output/implementation-artifacts/77-2-launch-fastify-in-electron.md`
+  - [x] Read `_bmad-output/implementation-artifacts/77-3-configure-electron-window.md`
+  - [x] Read `_bmad-output/implementation-artifacts/77-4-intercept-api-and-external-links.md`
+  - [x] Read `_bmad-output/implementation-artifacts/77-5-e2e-electron-launch.md`
+  - [x] Note any design decisions or known limitations documented in these files
+
+- [x] Task 3: Read Story 83.1 findings to include accurate build information (AC: #1, #2)
+
+  - [x] Read `_bmad-output/implementation-artifacts/83-1-audit-electron-build.md` —
         specifically the Dev Agent Record section with build findings
-  - [ ] Ensure the documentation reflects the actual working state of the build, not
+  - [x] Ensure the documentation reflects the actual working state of the build, not
         aspirational state
-  - [ ] If `electron-builder` distributable packaging is not yet set up (per Story 83.1),
+  - [x] If `electron-builder` distributable packaging is not yet set up (per Story 83.1),
         note this limitation clearly in the README
 
-- [ ] Task 4: Create `apps/electron/README.md` (AC: #1)
-  - [ ] Create the file at `apps/electron/README.md`
-  - [ ] Include all sections listed in AC #1:
+- [x] Task 4: Create `apps/electron/README.md` (AC: #1)
+
+  - [x] Create the file at `apps/electron/README.md`
+  - [x] Include all sections listed in AC #1:
     - **Overview**: what the Electron app does (wraps Angular+Fastify in a desktop window)
     - **Architecture**: how main process forks Fastify, finds a free port, opens BrowserWindow
       at `http://localhost:<port>`, and intercepts navigation
@@ -79,25 +84,28 @@ integration without having to reverse-engineer it from the source.
       discovers the dynamic API port
     - **Content Security Policy**: CSP header injection via `onHeadersReceived`
     - **Testing**: `pnpm nx run electron:test` (passWithNoTests currently)
-  - [ ] Use clear headings, code blocks for all commands, and inline references to source
+  - [x] Use clear headings, code blocks for all commands, and inline references to source
         files where relevant
 
-- [ ] Task 5: Review documentation for accuracy against source code (AC: #2)
-  - [ ] Cross-check every stated file path, command, and config value against the actual
-        source code
-  - [ ] Verify the Angular route URL used to launch (`http://localhost:<port>`) matches what
-        `createWindow()` calls
-  - [ ] Verify the preload path in `webPreferences` matches the actual compiled output location
+- [x] Task 5: Review documentation for accuracy against source code (AC: #2)
 
-- [ ] Task 6: Run `pnpm all` to confirm all tests pass (AC: #3)
-  - [ ] Run `pnpm all`
-  - [ ] Confirm no new failures — adding a markdown file should not break anything
+  - [x] Cross-check every stated file path, command, and config value against the actual
+        source code
+  - [x] Verify the Angular route URL used to launch (`http://localhost:<port>`) matches what
+        `createWindow()` calls
+  - [x] Verify the preload path in `webPreferences` matches the actual compiled output location
+
+- [x] Task 6: Run `pnpm all` to confirm all tests pass (AC: #3)
+
+  - [x] Run `pnpm all`
+  - [x] Confirm no new failures — adding a markdown file should not break anything
 
 ## Dev Notes
 
 ### Architecture Summary (for README accuracy)
 
 The Electron app does **not** bundle the Angular frontend. Instead:
+
 1. `main.ts` calls `findAvailablePort()` to claim a free TCP port dynamically
 2. It forks the Fastify server (`dist/apps/server/main.js`) with `PORT=<port>` via `fork()`
 3. It waits for a `'ready'` IPC message from the server, then runs an HTTP health check
@@ -108,6 +116,7 @@ The Electron app does **not** bundle the Angular frontend. Instead:
 ### Navigation Handling (for README accuracy)
 
 Two interception points prevent navigation from breaking the SPA:
+
 - `win.webContents.on('will-navigate', handleWillNavigate)`: cancels any navigation to a
   non-localhost URL and opens it externally; same-origin navigations are allowed through
 - `win.webContents.setWindowOpenHandler(...)`: handles `window.open()` calls; same-origin
@@ -118,22 +127,24 @@ Two interception points prevent navigation from breaking the SPA:
 
 `preload.ts` exposes `window.electronAPI.getApiPort()` which calls
 `ipcRenderer.invoke('get-api-port')`. The main process registers this handler in `init()`:
+
 ```typescript
 ipcMain.handle('get-api-port', function getApiPort(): number | null {
   return resolvedPort;
 });
 ```
+
 The Angular app uses this to build API URLs dynamically (when running under Electron).
 
 ### Key Source Files
 
-| File | Content |
-| ---- | ------- |
-| `apps/electron/src/main.ts` | Full main process logic |
-| `apps/electron/src/preload.ts` | contextBridge API surface |
-| `apps/electron/src/utils/port.ts` | Dynamic port selection |
-| `apps/electron/project.json` | Nx targets: build, start, test |
-| `apps/electron/package.json` | Entry point (`dist/main.js`), start script |
+| File                              | Content                                    |
+| --------------------------------- | ------------------------------------------ |
+| `apps/electron/src/main.ts`       | Full main process logic                    |
+| `apps/electron/src/preload.ts`    | contextBridge API surface                  |
+| `apps/electron/src/utils/port.ts` | Dynamic port selection                     |
+| `apps/electron/project.json`      | Nx targets: build, start, test             |
+| `apps/electron/package.json`      | Entry point (`dist/main.js`), start script |
 
 ### Key Commands
 
@@ -155,3 +166,47 @@ node -e "const p=require('./node_modules/electron/package.json'); console.log(p.
 - [Source: apps/electron/project.json]
 - [Source: _bmad-output/implementation-artifacts/83-1-audit-electron-build.md]
 - [Source: _bmad-output/planning-artifacts/epics-2026-04-23.md#story-832]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GitHub Copilot (GPT-5.4)
+
+### Implementation Plan
+
+- Read the Electron source, Epic 77 story history, and Story 83.1 findings before writing any
+  documentation so the README reflects the actual runtime model.
+- Document the supported developer workflow (`electron:start`) and the current compile-only state
+  of `electron:build`.
+- Validate the workspace after the documentation change with the full quality-validation workflow.
+
+### Debug Log References
+
+- `pnpm i` completed successfully in `/home/dave/code/dms/story-83-2-electron-documentation`
+- `pnpm exec prisma generate` completed successfully in the story worktree
+- `CI=1 NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm all` completed successfully
+- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm e2e:dms-material:chromium` completed successfully
+- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm e2e:dms-material:firefox` completed successfully
+- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm dupcheck` completed successfully
+- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm format` completed successfully
+
+### Completion Notes List
+
+- Added `apps/electron/README.md` covering architecture, development, build behavior, navigation,
+  preload IPC, CSP, and testing.
+- Documented the current limitation that `electron:build` compiles TypeScript only and does not
+  yet package a true distributable.
+- Re-ran the full quality-validation loop and confirmed `pnpm all`, browser E2E, dupcheck, and
+  format all pass in the story worktree.
+
+### File List
+
+- `apps/electron/README.md` (new)
+- `_bmad-output/implementation-artifacts/83-2-electron-documentation.md` (modified)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified)
+
+### Change Log
+
+- 2026-04-23: Added first-party Electron app documentation and recorded the current compile-only
+  build limitation identified in Story 83.1.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -467,7 +467,7 @@ development_status:
   # ── Epic 83: Electron App Documentation and Build Fix ─────────────────────────
   epic-83: in-progress
   83-1-audit-electron-build: review
-  83-2-electron-documentation: ready-for-dev
+  83-2-electron-documentation: review
   83-3-fix-electron-build: ready-for-dev
   epic-83-retrospective: optional
 

--- a/apps/electron/README.md
+++ b/apps/electron/README.md
@@ -1,0 +1,215 @@
+# Electron App
+
+This package wraps the built Angular client and the Fastify server in a desktop Electron shell.
+The Electron main process starts the backend, waits for it to become healthy, and then opens a
+single `BrowserWindow` at `http://localhost:<dynamic-port>`.
+
+## Overview
+
+- `apps/electron/src/main.ts` starts the Fastify server, configures the desktop window, injects
+  the Content Security Policy, and intercepts navigation.
+- `apps/electron/src/preload.ts` exposes `window.electronAPI.getApiPort()` to the renderer.
+- `apps/electron/src/utils/port.ts` finds an unused local TCP port before Fastify starts.
+- `apps/electron/project.json` defines the Nx `build`, `start`, and `test` targets.
+
+The Angular app is not bundled directly into Electron. Instead, the Fastify server serves the
+built Angular browser assets from `dist/apps/dms-material/browser`, and Electron loads that app
+through `http://localhost:<port>`.
+
+## Architecture
+
+At startup, the Electron main process follows this sequence:
+
+1. Call `findAvailablePort()` to reserve an unused local port.
+2. Fork `dist/apps/server/main.js` with `PORT=<port>`.
+3. Wait for the server to send a `ready` IPC message.
+4. Run an HTTP health check against `http://127.0.0.1:<port>/api/health`.
+5. Create a `BrowserWindow` and load `http://localhost:<port>`.
+
+That flow lives in `apps/electron/src/main.ts`. The server-side static file handling lives in
+`apps/server/src/main.ts`, where Fastify serves the Angular build output and falls back to
+`index.html` for non-API routes.
+
+## Prerequisites
+
+- Node.js `^22.0.0` (workspace root `package.json`)
+- pnpm `^10`
+- Electron `^41.0.0` (workspace root `package.json`; current installed version may be newer
+  within that range)
+
+From a clean checkout:
+
+```bash
+pnpm install
+pnpm exec prisma generate
+```
+
+`prisma generate` is recommended before builds and validations because the workspace only runs it
+automatically in CI.
+
+## Development
+
+Use the Nx start target for the normal development workflow:
+
+```bash
+pnpm nx run electron:start
+```
+
+What this target does:
+
+- Builds the Electron main/preload scripts (`electron:build`)
+- Builds the Fastify server (`server:build`)
+- Builds the Angular app (`dms-material:build`)
+- Runs `electron .` from `apps/electron`
+
+You do not need to build Angular manually before `electron:start`; the target already depends on
+the Angular and server build targets.
+
+## Build
+
+Compile the Electron package with:
+
+```bash
+pnpm nx run electron:build
+```
+
+Current behavior of `electron:build`:
+
+- Runs `tsc -p tsconfig.json` from `apps/electron`
+- Writes compiled files to `apps/electron/dist`
+- Produces `apps/electron/dist/main.js` and `apps/electron/dist/preload.js`
+- Does **not** create an installer or packaged desktop distributable yet
+
+If you want to run the compiled Electron entry after building, also build the server and Angular
+outputs first, then launch Electron from the package directory:
+
+```bash
+pnpm nx run server:build
+pnpm nx run dms-material:build
+pnpm nx run electron:build
+pnpm --dir apps/electron start
+```
+
+Important limitation: the repository does not currently include `electron-builder`,
+`electron-packager`, or equivalent packaging configuration. Today, `electron:build` is a
+compile-only build, not a true distributable packaging step.
+
+## BrowserWindow Configuration
+
+`createWindow()` in `apps/electron/src/main.ts` creates a single desktop window with these
+security-relevant settings:
+
+```ts
+const win = new BrowserWindow({
+  width: 1280,
+  height: 800,
+  webPreferences: {
+    preload: path.join(__dirname, 'preload.js'),
+    nodeIntegration: false,
+    contextIsolation: true,
+    sandbox: true,
+  },
+});
+```
+
+- `preload` points to the compiled preload script at `apps/electron/dist/preload.js`
+- `nodeIntegration: false` keeps Node.js APIs out of the renderer
+- `contextIsolation: true` keeps the preload bridge isolated from the web page
+- `sandbox: true` adds another renderer isolation layer
+
+The window loads the Angular app via:
+
+```ts
+win.loadURL(`http://localhost:${port}`);
+```
+
+## Angular Router Handling
+
+Electron uses two navigation hooks to keep the Angular app inside the same window:
+
+- `win.webContents.on('will-navigate', ...)`
+- `win.webContents.setWindowOpenHandler(...)`
+
+Behavior:
+
+- Same-origin URLs matching `http://localhost:<port>` are treated as internal app navigation.
+- External URLs are prevented from navigating inside Electron.
+- `window.open()` calls for same-origin URLs are redirected back into the existing window with
+  `win.loadURL(details.url)`.
+- New window creation is always denied by returning `{ action: 'deny' }`.
+
+Angular Router itself uses the History API for normal SPA navigation, so most route changes do not
+trigger `will-navigate`. The Electron handlers matter for full-page navigations, reloads, and
+`window.open()` behavior.
+
+## Internal vs External Links
+
+The helper `isLocalAppUrl()` in `apps/electron/src/main.ts` treats only
+`http://localhost:<port>` as internal.
+
+- Internal same-origin links stay in the Electron window.
+- External `http:` and `https:` links are opened with `shell.openExternal(url)`.
+- External navigation is prevented inside the `BrowserWindow`.
+
+This keeps the app in a single desktop window while still allowing documentation, auth, or other
+external URLs to open in the system browser.
+
+## IPC / Preload API
+
+The preload script exposes a single renderer API:
+
+```ts
+window.electronAPI.getApiPort(): Promise<number>
+```
+
+Implementation details:
+
+- `apps/electron/src/preload.ts` calls `ipcRenderer.invoke('get-api-port')`
+- `apps/electron/src/main.ts` registers `ipcMain.handle('get-api-port', ...)`
+- The resolved port is stored in the main process after `findAvailablePort()` succeeds
+
+This allows the Angular app to discover the dynamic backend port when running under Electron.
+
+## Content Security Policy
+
+Electron injects the Content Security Policy in `apps/electron/src/main.ts` using
+`session.defaultSession.webRequest.onHeadersReceived(...)`.
+
+The injected policy allows:
+
+- `default-src 'self' http://localhost:<port>`
+- `script-src 'self'`
+- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`
+- `font-src 'self' https://fonts.gstatic.com`
+- `img-src 'self' data: https:`
+- `connect-src 'self' http://localhost:<port>` plus the configured AWS Cognito endpoints
+
+This keeps the Angular app functional while avoiding remote script execution from untrusted
+origins.
+
+## Testing
+
+Electron-specific Nx targets:
+
+```bash
+pnpm nx run electron:test
+pnpm nx run electron:build
+pnpm nx run electron:start
+```
+
+Notes:
+
+- `electron:test` currently uses `passWithNoTests: true`
+- `electron:start` is the supported end-to-end developer workflow
+- `pnpm all` should continue to pass after documentation changes
+
+## Source References
+
+- `apps/electron/src/main.ts`
+- `apps/electron/src/preload.ts`
+- `apps/electron/src/utils/port.ts`
+- `apps/electron/project.json`
+- `apps/electron/package.json`
+- `apps/electron/tsconfig.json`
+- `apps/server/src/main.ts`
+- `apps/dms-material/project.json`


### PR DESCRIPTION
Closes #1123

## Summary

- Added first-party Electron app documentation describing how the Electron main process starts Fastify, serves the built Angular app, and loads it in a single desktop window.
- Documented the supported development workflow around `pnpm nx run electron:start`, including the upstream server and Angular build dependencies.
- Documented the current compile-only state of `pnpm nx run electron:build` and the missing packaging step for a true distributable build.

## Testing

- `CI=1 NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm all`
- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm e2e:dms-material:chromium`
- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm e2e:dms-material:firefox`
- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm dupcheck`
- `NX_DAEMON=false NX_WORKSPACE_ROOT_PATH=/home/dave/code/dms/story-83-2-electron-documentation pnpm format`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Electron app documentation covering process initialization, port management, frontend loading, navigation handling, IPC communication, and security policies.

* **Chores**
  * Updated development documentation and sprint status to reflect work progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->