### PR TITLE
Story 84.4: Add E2E Coverage for New Volatility Icons

### DIFF
--- a/_bmad-output/implementation-artifacts/84-4-e2e-volatility-icons.md
+++ b/_bmad-output/implementation-artifacts/84-4-e2e-volatility-icons.md
@@ -1,6 +1,6 @@
 # Story 84.4: E2E Tests — Volatility Icons on Universe Screen
 
-Status: Approved
+Status: Review
 
 ## Story
 
@@ -28,61 +28,66 @@ so that future regressions to either fix are caught automatically in CI.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Confirm the Story 84.1 test now covers AC #1 (AC: #1)
-  - [ ] Read `apps/dms-material-e2e/src/volatility-visibility.spec.ts` — this was created
+- [x] Task 1: Confirm the Story 84.1 test now covers AC #1 (AC: #1)
+
+  - [x] Read `apps/dms-material-e2e/src/volatility-visibility.spec.ts` — this was created
         in Story 84.1 and updated to pass in Story 84.2
-  - [ ] Confirm the test seeds a symbol with no positions and asserts the Vol icon is visible
-  - [ ] If the test is already passing and covers AC #1 completely, no additional test is
+  - [x] Confirm the test seeds a symbol with no positions and asserts the Vol icon is visible
+  - [x] If the test is already passing and covers AC #1 completely, no additional test is
         needed for this AC — document this decision in Dev Agent Record
 
-- [ ] Task 2: Extend the E2E seed helper for new categories (AC: #2)
-  - [ ] Read `apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts` (from
+- [x] Task 2: Extend the E2E seed helper for new categories (AC: #2)
+
+  - [x] Read `apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts` (from
         Story 81.3) for the seeding pattern
-  - [ ] Create or extend a seed helper that inserts distribution records qualifying for each
+  - [x] Create or extend a seed helper that inserts distribution records qualifying for each
         of the three new categories:
     - `flat`: insert 24 months of nearly identical amounts (e.g., all `1.00`)
     - `up-then-down`: insert 24 months — first 12 at `2.00`, second 12 at `1.00`
     - `down-then-up`: insert 24 months — first 12 at `1.00`, second 12 at `2.00`
-  - [ ] Each seeded symbol must have no open trades (to also satisfy AC #1 coverage)
-  - [ ] Include a `cleanup` function to remove seeded data in `afterAll`
-  - [ ] Follow the same helper pattern as `seed-vol-column-e2e-data.helper.ts`
+  - [x] Each seeded symbol must have no open trades (to also satisfy AC #1 coverage)
+  - [x] Include a `cleanup` function to remove seeded data in `afterAll`
+  - [x] Follow the same helper pattern as `seed-vol-column-e2e-data.helper.ts`
 
-- [ ] Task 3: Write E2E tests for the three new icon categories (AC: #2)
-  - [ ] Create `apps/dms-material-e2e/src/volatility-new-categories.spec.ts`
-  - [ ] Structure: `beforeAll` seeds data via the helper from Task 2; `afterAll` cleans up;
+- [x] Task 3: Write E2E tests for the three new icon categories (AC: #2)
+
+  - [x] Create `apps/dms-material-e2e/src/volatility-new-categories.spec.ts`
+  - [x] Structure: `beforeAll` seeds data via the helper from Task 2; `afterAll` cleans up;
         `beforeEach` navigates to Universe screen
-  - [ ] Test 1 — `flat` icon:
+  - [x] Test 1 — `flat` icon:
     - Search for the seeded `flat` symbol
     - Assert `page.locator('[aria-label="Volatility: flat"]').first()` is visible
-  - [ ] Test 2 — `up-then-down` icon:
+  - [x] Test 2 — `up-then-down` icon:
     - Search for the seeded `up-then-down` symbol
     - Assert `page.locator('[aria-label="Volatility: up-then-down"]').first()` is visible
-  - [ ] Test 3 — `down-then-up` icon:
+  - [x] Test 3 — `down-then-up` icon:
     - Search for the seeded `down-then-up` symbol
     - Assert `page.locator('[aria-label="Volatility: down-then-up"]').first()` is visible
-  - [ ] Use `{ timeout: 10_000 }` on visibility assertions to allow for API latency
-  - [ ] All test functions must be named (no anonymous arrow functions)
-  - [ ] No `test.skip()` calls
+  - [x] Use `{ timeout: 10_000 }` on visibility assertions to allow for API latency
+  - [x] All test functions must be named (no anonymous arrow functions)
+  - [x] No `test.skip()` calls
 
-- [ ] Task 4: Verify icons have correct `aria-label` attributes (AC: #2)
-  - [ ] Read `apps/dms-material/src/app/global/global-universe/global-universe.component.html`
-  - [ ] Confirm that the `<mat-icon>` elements for `flat`, `up-then-down`, and `down-then-up`
+- [x] Task 4: Verify icons have correct `aria-label` attributes (AC: #2)
+
+  - [x] Read `apps/dms-material/src/app/global/global-universe/global-universe.component.html`
+  - [x] Confirm that the `<mat-icon>` elements for `flat`, `up-then-down`, and `down-then-up`
         have the exact `aria-label` values expected by the E2E tests:
     - `aria-label="Volatility: flat"`
     - `aria-label="Volatility: up-then-down"`
     - `aria-label="Volatility: down-then-up"`
-  - [ ] If `aria-label` values differ between the template and the tests, update the tests to
+  - [x] If `aria-label` values differ between the template and the tests, update the tests to
         match the template (the template from Story 84.3 is the source of truth)
 
-- [ ] Task 5: Verify no regression to existing vol-column E2E tests (AC: #3)
-  - [ ] Run `apps/dms-material-e2e/src/vol-column.spec.ts` tests — confirm all still pass
-  - [ ] Run `apps/dms-material-e2e/src/volatility-visibility.spec.ts` tests — confirm pass
-  - [ ] Run new `apps/dms-material-e2e/src/volatility-new-categories.spec.ts` tests
+- [x] Task 5: Verify no regression to existing vol-column E2E tests (AC: #3)
 
-- [ ] Task 6: Run `pnpm all` and confirm all tests pass (AC: #3)
-  - [ ] Run `pnpm all` from workspace root
-  - [ ] All new and existing tests must pass
-  - [ ] No skipped tests introduced by this story
+  - [x] Run `apps/dms-material-e2e/src/vol-column.spec.ts` tests — confirm all still pass
+  - [x] Run `apps/dms-material-e2e/src/volatility-visibility.spec.ts` tests — confirm pass
+  - [x] Run new `apps/dms-material-e2e/src/volatility-new-categories.spec.ts` tests
+
+- [x] Task 6: Run `pnpm all` and confirm all tests pass (AC: #3)
+  - [x] Run `pnpm all` from workspace root
+  - [x] All new and existing tests must pass
+  - [x] No skipped tests introduced by this story
 
 ## Dev Notes
 
@@ -123,6 +128,7 @@ Follow this pattern exactly in the new spec file.
 
 The `aria-label` values are set by Story 84.3 in `global-universe.component.html`. The E2E
 tests must use the exact same strings. The expected mapping (set in Story 84.3) is:
+
 - `flat` → `aria-label="Volatility: flat"`
 - `up-then-down` → `aria-label="Volatility: up-then-down"`
 - `down-then-up` → `aria-label="Volatility: down-then-up"`
@@ -135,6 +141,7 @@ The seed data must trigger the calculation thresholds defined in Story 84.3. Use
 amounts from the Story 84.3 unit tests as a reference for what data produces each category.
 
 Example distribution record structure (check the actual API endpoint used by existing seed helpers):
+
 ```typescript
 // POST to whatever endpoint seed-vol-column-e2e-data.helper.ts uses
 // Each record: { symbol, amount, date, universeId }
@@ -178,9 +185,7 @@ test.describe('Volatility — new icon categories', function describeNewCategori
   test('flat symbol shows flat icon', async function flatSymbolShowsFlatIcon({ page }) {
     const searchInput = page.locator('input[placeholder="Search Symbol"]');
     await searchInput.fill(flatSymbol);
-    await expect(
-      page.locator('[aria-label="Volatility: flat"]').first()
-    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('[aria-label="Volatility: flat"]').first()).toBeVisible({ timeout: 10_000 });
   });
 
   // ... similar for upThenDownSymbol and downThenUpSymbol
@@ -210,3 +215,71 @@ pnpm all
 - [Source: _bmad-output/implementation-artifacts/84-2-fix-volatility-data-filtering.md]
 - [Source: _bmad-output/implementation-artifacts/84-3-add-new-volatility-icons.md]
 - [Source: _bmad-output/planning-artifacts/epics-2026-04-23.md#story-844]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+GPT-5.4
+
+### Implementation Summary
+
+- Added `apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts` to seed
+  three no-position symbols with deterministic dividend histories for `flat`, `up-then-down`,
+  and `down-then-up`, plus cleanup for seeded rows and the temporary account.
+- Added `apps/dms-material-e2e/src/volatility-new-categories.spec.ts` using the existing
+  beforeAll/afterAll/beforeEach E2E pattern, row-scoped search helpers, exact `aria-label`
+  assertions, and explicit `0.00` position assertions so the new tests also prove zero-position
+  rows still render a Vol icon.
+- Kept AC #1 covered in two ways: the existing live `volatility-visibility.spec.ts` still passes,
+  and the new seeded spec verifies the same no-position behavior deterministically for the new
+  category fixtures.
+- Used the exact classifier-triggering monthly sequences from Story 84.3's unit tests rather than
+  the earlier 24-month sketch in the task notes, because those fixtures were already proven to
+  resolve to the intended categories.
+
+### Validation Notes
+
+- `pnpm exec prisma generate` passed in the 84.4 worktree before test execution.
+- `pnpm exec playwright test src/volatility-new-categories.spec.ts --project=chromium --config=apps/dms-material-e2e/playwright.config.ts`
+  passed with 3 tests.
+- `pnpm exec playwright test src/vol-column.spec.ts --project=chromium --config=apps/dms-material-e2e/playwright.config.ts`
+  passed with 3 tests.
+- `pnpm exec playwright test src/volatility-visibility.spec.ts --project=integration --config=apps/dms-material-e2e/playwright.config.ts`
+  passed with 2 tests.
+- `pnpm nx affected -t lint build --parallel=16 --uncommitted` ran no tasks because this story
+  only changed `dms-material-e2e`, and the affected set for this workspace exposes E2E execution
+  targets rather than `lint`, `build`, or `test` targets for that slice.
+- `pnpm nx affected -t test --coverage --parallel=16 --uncommitted` also ran no tasks for the
+  same reason.
+- `pnpm all` passed from the committed story branch after the lint-rule refactor commit. The only
+  remaining lint output was the pre-existing warning set in
+  `apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts` about unused
+  `eslint-disable` directives; there were no new lint errors, build failures, or test failures.
+
+### Completion Notes List
+
+- The new spec uses row-scoped locators instead of page-global icon lookups, so a wrong icon in
+  another row cannot produce a false green.
+- The helper keeps the no-trade setup from the existing volatility column seed pattern, which
+  makes the icon assertions meaningful for the exact zero-position case that originally regressed.
+- The lint refactor on the new helper reduced parameter count and function length to satisfy the
+  repository's `max-params-no-constructor` and `max-lines-per-function` rules without changing the
+  seeded behavior.
+
+## File List
+
+- `apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts` - added seeded
+  volatility category fixtures and cleanup for new E2E coverage
+- `apps/dms-material-e2e/src/volatility-new-categories.spec.ts` - added deterministic Playwright
+  coverage for `flat`, `up-then-down`, and `down-then-up` icons
+- `_bmad-output/implementation-artifacts/84-4-e2e-volatility-icons.md` - updated task state and
+  recorded Story 84.4 implementation and validation details
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` - moved Story 84.4 to `review`
+
+## Change Log
+
+| Date       | Change                                                                                                                 | Author |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- | ------ |
+| 2026-04-26 | Added deterministic E2E seeding and Playwright coverage for the new volatility icon categories                         | Agent  |
+| 2026-04-26 | Revalidated the existing visibility and Vol-column regressions, fixed helper lint violations, and ran `pnpm all` green | Agent  |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -476,7 +476,7 @@ development_status:
   84-1-investigate-volatility-visibility-bug: ready-for-dev
   84-2-fix-volatility-data-filtering: review
   84-3-add-new-volatility-icons: review
-  84-4-e2e-volatility-icons: ready-for-dev
+  84-4-e2e-volatility-icons: review
   epic-84-retrospective: optional
 
   # ── Epic 85: Store Volatility in Universe Table ───────────────────────────────

--- a/apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts
@@ -1,0 +1,225 @@
+import type { Prisma, PrismaClient } from '@prisma/client';
+
+import { generateUniqueId } from './generate-unique-id.helper';
+import type { SeederResultBase } from './seeder-result-base.types';
+import { initializePrismaClient } from './shared-prisma-client.helper';
+
+const DISTRIBUTIONS_PER_YEAR = 12;
+const LAST_PRICE = 10.0;
+const FLAT_AMOUNTS = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+const UP_THEN_DOWN_AMOUNTS = [1, 2, 3, 4, 5, 6, 6, 5, 4, 3, 2, 1];
+const DOWN_THEN_UP_AMOUNTS = [6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6];
+
+interface VolatilityNewCategoriesSeederResult extends SeederResultBase {
+  flatSymbol: string;
+  upThenDownSymbol: string;
+  downThenUpSymbol: string;
+}
+
+interface SeedCategoryPlan {
+  symbol: string;
+  amounts: number[];
+}
+
+async function getOrCreateRiskGroupId(prisma: PrismaClient): Promise<string> {
+  const riskGroup = await prisma.risk_group.upsert({
+    where: { name: 'Equities' },
+    update: {},
+    create: { name: 'Equities' },
+  });
+  return riskGroup.id;
+}
+
+async function getOrCreateDivDepositTypeId(
+  prisma: PrismaClient
+): Promise<string> {
+  const existing = await prisma.divDepositType.findFirst({
+    where: { name: 'Dividend' },
+  });
+  if (existing !== null) {
+    return existing.id;
+  }
+
+  const created = await prisma.divDepositType.create({
+    data: { name: 'Dividend' },
+  });
+  return created.id;
+}
+
+function buildMonthlyDates(totalMonths: number): Date[] {
+  const dates: Date[] = [];
+  const now = new Date();
+
+  for (let monthOffset = totalMonths - 1; monthOffset >= 0; monthOffset--) {
+    const date = new Date(now);
+    date.setDate(1);
+    date.setMonth(date.getMonth() - monthOffset);
+    dates.push(date);
+  }
+
+  return dates;
+}
+
+function buildUniverseCreateData(
+  symbol: string,
+  riskGroupId: string,
+  currentDistribution: number
+): Prisma.universeUncheckedCreateInput {
+  return {
+    symbol,
+    risk_group_id: riskGroupId,
+    distribution: currentDistribution,
+    distributions_per_year: DISTRIBUTIONS_PER_YEAR,
+    last_price: LAST_PRICE,
+    ex_date: null,
+    most_recent_sell_date: null,
+    most_recent_sell_price: null,
+    expired: false,
+    is_closed_end_fund: true,
+  };
+}
+
+function buildSeedPlans(uniqueId: string): SeedCategoryPlan[] {
+  return [
+    {
+      symbol: `E2EFLT${uniqueId}`,
+      amounts: FLAT_AMOUNTS,
+    },
+    {
+      symbol: `E2EUTD${uniqueId}`,
+      amounts: UP_THEN_DOWN_AMOUNTS,
+    },
+    {
+      symbol: `E2EDTU${uniqueId}`,
+      amounts: DOWN_THEN_UP_AMOUNTS,
+    },
+  ];
+}
+
+async function seedUniverseCategory(
+  prisma: PrismaClient,
+  plan: SeedCategoryPlan,
+  riskGroupId: string,
+  accountId: string,
+  divDepositTypeId: string,
+  universeIds: string[]
+): Promise<void> {
+  const universe = await prisma.universe.create({
+    data: buildUniverseCreateData(
+      plan.symbol,
+      riskGroupId,
+      plan.amounts[plan.amounts.length - 1]
+    ),
+  });
+
+  universeIds.push(universe.id);
+
+  const dates = buildMonthlyDates(plan.amounts.length);
+  await prisma.divDeposits.createMany({
+    data: dates.map(function buildDepositRecord(date: Date, index: number) {
+      return {
+        date,
+        amount: plan.amounts[index],
+        accountId,
+        divDepositTypeId,
+        universeId: universe.id,
+      };
+    }),
+  });
+}
+
+async function cleanupOnError(
+  prisma: PrismaClient,
+  universeIds: string[],
+  symbols: string[],
+  accountName: string
+): Promise<void> {
+  function suppressError(): undefined {
+    return undefined;
+  }
+
+  if (universeIds.length > 0) {
+    await prisma.divDeposits
+      .deleteMany({ where: { universeId: { in: universeIds } } })
+      .catch(suppressError);
+  }
+
+  if (symbols.length > 0) {
+    await prisma.universe
+      .deleteMany({ where: { symbol: { in: symbols } } })
+      .catch(suppressError);
+  }
+
+  await prisma.accounts
+    .deleteMany({ where: { name: accountName } })
+    .catch(suppressError);
+}
+
+export async function seedVolatilityNewCategoriesData(): Promise<VolatilityNewCategoriesSeederResult> {
+  const prisma = await initializePrismaClient();
+  const uniqueId = generateUniqueId();
+  const seedPlans = buildSeedPlans(uniqueId);
+  const accountName = `E2E-VOL-CATS-${uniqueId}`;
+  const universeIds: string[] = [];
+
+  try {
+    const riskGroupId = await getOrCreateRiskGroupId(prisma);
+    const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
+    const account = await prisma.accounts.create({
+      data: { name: accountName },
+    });
+
+    for (const plan of seedPlans) {
+      await seedUniverseCategory(
+        prisma,
+        plan,
+        riskGroupId,
+        account.id,
+        divDepositTypeId,
+        universeIds
+      );
+    }
+  } catch (error) {
+    await cleanupOnError(
+      prisma,
+      universeIds,
+      seedPlans.map(function extractSymbol(plan: SeedCategoryPlan) {
+        return plan.symbol;
+      }),
+      accountName
+    );
+    await prisma.$disconnect();
+    throw error;
+  }
+
+  return {
+    flatSymbol: seedPlans[0].symbol,
+    upThenDownSymbol: seedPlans[1].symbol,
+    downThenUpSymbol: seedPlans[2].symbol,
+    symbols: seedPlans.map(function extractSymbol(plan: SeedCategoryPlan) {
+      return plan.symbol;
+    }),
+    cleanup:
+      async function cleanupVolatilityNewCategoriesData(): Promise<void> {
+        try {
+          await prisma.divDeposits.deleteMany({
+            where: { universeId: { in: universeIds } },
+          });
+          await prisma.universe.deleteMany({
+            where: {
+              symbol: {
+                in: seedPlans.map(function extractSymbol(
+                  plan: SeedCategoryPlan
+                ) {
+                  return plan.symbol;
+                }),
+              },
+            },
+          });
+          await prisma.accounts.deleteMany({ where: { name: accountName } });
+        } finally {
+          await prisma.$disconnect();
+        }
+      },
+  };
+}

--- a/apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-volatility-new-categories.helper.ts
@@ -21,6 +21,20 @@ interface SeedCategoryPlan {
   amounts: number[];
 }
 
+interface SeedCategoryContext {
+  prisma: PrismaClient;
+  riskGroupId: string;
+  accountId: string;
+  divDepositTypeId: string;
+  universeIds: string[];
+}
+
+interface SeedRuntimeData {
+  accountName: string;
+  seedPlans: SeedCategoryPlan[];
+  universeIds: string[];
+}
+
 async function getOrCreateRiskGroupId(prisma: PrismaClient): Promise<string> {
   const riskGroup = await prisma.risk_group.upsert({
     where: { name: 'Equities' },
@@ -96,36 +110,77 @@ function buildSeedPlans(uniqueId: string): SeedCategoryPlan[] {
   ];
 }
 
+function extractSymbols(seedPlans: SeedCategoryPlan[]): string[] {
+  return seedPlans.map(function extractSymbol(plan: SeedCategoryPlan) {
+    return plan.symbol;
+  });
+}
+
+function createSeedRuntimeData(): SeedRuntimeData {
+  const uniqueId = generateUniqueId();
+
+  return {
+    accountName: `E2E-VOL-CATS-${uniqueId}`,
+    seedPlans: buildSeedPlans(uniqueId),
+    universeIds: [],
+  };
+}
+
 async function seedUniverseCategory(
-  prisma: PrismaClient,
-  plan: SeedCategoryPlan,
-  riskGroupId: string,
-  accountId: string,
-  divDepositTypeId: string,
-  universeIds: string[]
+  context: SeedCategoryContext,
+  plan: SeedCategoryPlan
 ): Promise<void> {
-  const universe = await prisma.universe.create({
+  const universe = await context.prisma.universe.create({
     data: buildUniverseCreateData(
       plan.symbol,
-      riskGroupId,
+      context.riskGroupId,
       plan.amounts[plan.amounts.length - 1]
     ),
   });
 
-  universeIds.push(universe.id);
+  context.universeIds.push(universe.id);
 
   const dates = buildMonthlyDates(plan.amounts.length);
-  await prisma.divDeposits.createMany({
+  await context.prisma.divDeposits.createMany({
     data: dates.map(function buildDepositRecord(date: Date, index: number) {
       return {
         date,
         amount: plan.amounts[index],
-        accountId,
-        divDepositTypeId,
+        accountId: context.accountId,
+        divDepositTypeId: context.divDepositTypeId,
         universeId: universe.id,
       };
     }),
   });
+}
+
+async function createSeedCategoryContext(
+  prisma: PrismaClient,
+  accountName: string,
+  universeIds: string[]
+): Promise<SeedCategoryContext> {
+  const riskGroupId = await getOrCreateRiskGroupId(prisma);
+  const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
+  const account = await prisma.accounts.create({
+    data: { name: accountName },
+  });
+
+  return {
+    prisma,
+    riskGroupId,
+    accountId: account.id,
+    divDepositTypeId,
+    universeIds,
+  };
+}
+
+async function seedAllCategories(
+  context: SeedCategoryContext,
+  seedPlans: SeedCategoryPlan[]
+): Promise<void> {
+  for (const plan of seedPlans) {
+    await seedUniverseCategory(context, plan);
+  }
 }
 
 async function cleanupOnError(
@@ -155,71 +210,64 @@ async function cleanupOnError(
     .catch(suppressError);
 }
 
+function buildCleanup(
+  prisma: PrismaClient,
+  universeIds: string[],
+  symbols: string[],
+  accountName: string
+): () => Promise<void> {
+  return async function cleanupVolatilityNewCategoriesData(): Promise<void> {
+    try {
+      await prisma.divDeposits.deleteMany({
+        where: { universeId: { in: universeIds } },
+      });
+      await prisma.universe.deleteMany({
+        where: {
+          symbol: {
+            in: symbols,
+          },
+        },
+      });
+      await prisma.accounts.deleteMany({ where: { name: accountName } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  };
+}
+
 export async function seedVolatilityNewCategoriesData(): Promise<VolatilityNewCategoriesSeederResult> {
   const prisma = await initializePrismaClient();
-  const uniqueId = generateUniqueId();
-  const seedPlans = buildSeedPlans(uniqueId);
-  const accountName = `E2E-VOL-CATS-${uniqueId}`;
-  const universeIds: string[] = [];
+  const runtimeData = createSeedRuntimeData();
+  const symbols = extractSymbols(runtimeData.seedPlans);
 
   try {
-    const riskGroupId = await getOrCreateRiskGroupId(prisma);
-    const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
-    const account = await prisma.accounts.create({
-      data: { name: accountName },
-    });
-
-    for (const plan of seedPlans) {
-      await seedUniverseCategory(
-        prisma,
-        plan,
-        riskGroupId,
-        account.id,
-        divDepositTypeId,
-        universeIds
-      );
-    }
+    const context = await createSeedCategoryContext(
+      prisma,
+      runtimeData.accountName,
+      runtimeData.universeIds
+    );
+    await seedAllCategories(context, runtimeData.seedPlans);
   } catch (error) {
     await cleanupOnError(
       prisma,
-      universeIds,
-      seedPlans.map(function extractSymbol(plan: SeedCategoryPlan) {
-        return plan.symbol;
-      }),
-      accountName
+      runtimeData.universeIds,
+      symbols,
+      runtimeData.accountName
     );
     await prisma.$disconnect();
     throw error;
   }
 
   return {
-    flatSymbol: seedPlans[0].symbol,
-    upThenDownSymbol: seedPlans[1].symbol,
-    downThenUpSymbol: seedPlans[2].symbol,
-    symbols: seedPlans.map(function extractSymbol(plan: SeedCategoryPlan) {
-      return plan.symbol;
-    }),
-    cleanup:
-      async function cleanupVolatilityNewCategoriesData(): Promise<void> {
-        try {
-          await prisma.divDeposits.deleteMany({
-            where: { universeId: { in: universeIds } },
-          });
-          await prisma.universe.deleteMany({
-            where: {
-              symbol: {
-                in: seedPlans.map(function extractSymbol(
-                  plan: SeedCategoryPlan
-                ) {
-                  return plan.symbol;
-                }),
-              },
-            },
-          });
-          await prisma.accounts.deleteMany({ where: { name: accountName } });
-        } finally {
-          await prisma.$disconnect();
-        }
-      },
+    flatSymbol: runtimeData.seedPlans[0].symbol,
+    upThenDownSymbol: runtimeData.seedPlans[1].symbol,
+    downThenUpSymbol: runtimeData.seedPlans[2].symbol,
+    symbols,
+    cleanup: buildCleanup(
+      prisma,
+      runtimeData.universeIds,
+      symbols,
+      runtimeData.accountName
+    ),
   };
 }

--- a/apps/dms-material-e2e/src/volatility-new-categories.spec.ts
+++ b/apps/dms-material-e2e/src/volatility-new-categories.spec.ts
@@ -1,0 +1,83 @@
+import { expect, Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedVolatilityNewCategoriesData } from './helpers/seed-volatility-new-categories.helper';
+
+async function searchForSymbol(page: Page, symbol: string) {
+  const searchInput = page.locator('input[placeholder="Search Symbol"]');
+  const row = page.locator('tbody tr').filter({
+    has: page.locator('td.mat-column-symbol', { hasText: symbol }),
+  });
+
+  await searchInput.fill(symbol);
+  await expect(row).toHaveCount(1, { timeout: 10_000 });
+  await expect(row.locator('td.mat-column-symbol')).toContainText(symbol);
+
+  return row.first();
+}
+
+async function expectVolatilityIconForSymbol(
+  page: Page,
+  symbol: string,
+  ariaLabel: string
+) {
+  const row = await searchForSymbol(page, symbol);
+
+  await expect(row.locator('td.mat-column-position')).toContainText('0.00');
+  await expect(
+    row.locator(`td.mat-column-vol [aria-label="${ariaLabel}"]`)
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('Volatility - new icon categories', function describeNewCategories() {
+  let cleanup: (() => Promise<void>) | undefined;
+  let flatSymbol: string;
+  let upThenDownSymbol: string;
+  let downThenUpSymbol: string;
+
+  test.beforeAll(async function seedData() {
+    const result = await seedVolatilityNewCategoriesData();
+    cleanup = result.cleanup;
+    flatSymbol = result.flatSymbol;
+    upThenDownSymbol = result.upThenDownSymbol;
+    downThenUpSymbol = result.downThenUpSymbol;
+  });
+
+  test.afterAll(async function teardown() {
+    if (cleanup !== undefined) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async function navigateToUniverse({ page }) {
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('flat symbol shows flat icon', async function flatSymbolShowsFlatIcon({
+    page,
+  }) {
+    await expectVolatilityIconForSymbol(page, flatSymbol, 'Volatility: flat');
+  });
+
+  test('up-then-down symbol shows up-then-down icon', async function upThenDownSymbolShowsIcon({
+    page,
+  }) {
+    await expectVolatilityIconForSymbol(
+      page,
+      upThenDownSymbol,
+      'Volatility: up-then-down'
+    );
+  });
+
+  test('down-then-up symbol shows down-then-up icon', async function downThenUpSymbolShowsIcon({
+    page,
+  }) {
+    await expectVolatilityIconForSymbol(
+      page,
+      downThenUpSymbol,
+      'Volatility: down-then-up'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated E2E seed helper for deterministic `flat`, `up-then-down`, and `down-then-up` volatility fixtures
- add a Playwright spec that asserts the exact volatility icon `aria-label` for each seeded zero-position symbol
- record Story 84.4 validation evidence and move the story to `review`

## Validation
- `pnpm exec prisma generate`
- `pnpm exec playwright test src/volatility-new-categories.spec.ts --project=chromium --config=apps/dms-material-e2e/playwright.config.ts`
- `pnpm exec playwright test src/vol-column.spec.ts --project=chromium --config=apps/dms-material-e2e/playwright.config.ts`
- `pnpm exec playwright test src/volatility-visibility.spec.ts --project=integration --config=apps/dms-material-e2e/playwright.config.ts`
- `pnpm all`

Fixes #1137