### PR TITLE
feat: Story 85.4 - E2E Verify Stored Volatility Correctness and Performance

### DIFF
--- a/apps/dms-material-e2e/src/helpers/build-monthly-dates.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/build-monthly-dates.helper.ts
@@ -1,0 +1,11 @@
+export function buildMonthlyDates(totalMonths: number): Date[] {
+  const dates: Date[] = [];
+  const now = new Date();
+  for (let offset = totalMonths - 1; offset >= 0; offset--) {
+    const d = new Date(now);
+    d.setDate(1);
+    d.setMonth(d.getMonth() - offset);
+    dates.push(d);
+  }
+  return dates;
+}

--- a/apps/dms-material-e2e/src/helpers/get-or-create-div-deposit-type-id.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/get-or-create-div-deposit-type-id.helper.ts
@@ -1,0 +1,14 @@
+import type { PrismaClient } from '@prisma/client';
+
+export async function getOrCreateDivDepositTypeId(
+  prisma: PrismaClient
+): Promise<string> {
+  const existing = await prisma.divDepositType.findFirst({
+    where: { name: 'Dividend' },
+  });
+  if (existing !== null) {
+    return existing.id;
+  }
+  return (await prisma.divDepositType.create({ data: { name: 'Dividend' } }))
+    .id;
+}

--- a/apps/dms-material-e2e/src/helpers/get-or-create-risk-group-id.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/get-or-create-risk-group-id.helper.ts
@@ -1,0 +1,12 @@
+import type { PrismaClient } from '@prisma/client';
+
+export async function getOrCreateRiskGroupId(
+  prisma: PrismaClient
+): Promise<string> {
+  const rg = await prisma.risk_group.upsert({
+    where: { name: 'Equities' },
+    update: {},
+    create: { name: 'Equities' },
+  });
+  return rg.id;
+}

--- a/apps/dms-material-e2e/src/helpers/seed-stored-volatility-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-stored-volatility-e2e-data.helper.ts
@@ -1,0 +1,190 @@
+import { buildMonthlyDates } from './build-monthly-dates.helper';
+import { generateUniqueId } from './generate-unique-id.helper';
+import { getOrCreateDivDepositTypeId } from './get-or-create-div-deposit-type-id.helper';
+import { getOrCreateRiskGroupId } from './get-or-create-risk-group-id.helper';
+import type { SeederResultBase } from './seeder-result-base.types';
+import { initializePrismaClient } from './shared-prisma-client.helper';
+
+const DISTRIBUTIONS_PER_YEAR = 12;
+const LAST_PRICE = 10.0;
+
+// Steady: oscillating ~5% around mean → CV ≈ 5% (between 2% and 10% thresholds)
+const STEADY_AMOUNTS = [
+  0.95, 1.05, 0.95, 1.05, 0.95, 1.05, 0.95, 1.05, 0.95, 1.05, 0.95, 1.05,
+];
+
+// Increasing: linear ramp → positive normalised slope > 0.001 threshold
+const INCREASING_AMOUNTS = [
+  0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6,
+];
+
+// Volatile: alternating high/low → CV >> 10%, no clear trend, no reversal
+const VOLATILE_AMOUNTS = [
+  0.5, 2.0, 0.3, 1.8, 0.4, 2.1, 0.6, 1.9, 0.5, 2.0, 0.4, 1.8,
+];
+
+interface StoredVolatilitySeederResult extends SeederResultBase {
+  steadySymbol: string;
+  increasingSymbol: string;
+  volatileSymbol: string;
+}
+
+interface SeedPlan {
+  symbol: string;
+  amounts: number[];
+  volatilityLong: string;
+}
+
+interface SeedContext {
+  prisma: PrismaClient;
+  riskGroupId: string;
+  accountId: string;
+  divDepositTypeId: string;
+}
+
+async function seedOnePlan(
+  ctx: SeedContext,
+  plan: SeedPlan,
+  universeIds: string[]
+): Promise<void> {
+  const currentDist = plan.amounts[plan.amounts.length - 1];
+  const universe = await ctx.prisma.universe.create({
+    data: {
+      symbol: plan.symbol,
+      risk_group_id: ctx.riskGroupId,
+      distribution: currentDist,
+      distributions_per_year: DISTRIBUTIONS_PER_YEAR,
+      last_price: LAST_PRICE,
+      ex_date: null,
+      most_recent_sell_date: null,
+      most_recent_sell_price: null,
+      expired: false,
+      is_closed_end_fund: true,
+      volatility_long: plan.volatilityLong,
+      volatility_short: plan.volatilityLong,
+    },
+  });
+  universeIds.push(universe.id);
+  const dates = buildMonthlyDates(plan.amounts.length);
+  await ctx.prisma.divDeposits.createMany({
+    data: dates.map(function buildDeposit(date: Date, i: number) {
+      return {
+        date,
+        amount: plan.amounts[i],
+        accountId: ctx.accountId,
+        divDepositTypeId: ctx.divDepositTypeId,
+        universeId: universe.id,
+      };
+    }),
+  });
+}
+
+function buildSeedPlans(uniqueId: string): SeedPlan[] {
+  return [
+    {
+      symbol: `E2ESVST${uniqueId}`,
+      amounts: STEADY_AMOUNTS,
+      volatilityLong: 'steady',
+    },
+    {
+      symbol: `E2ESVIC${uniqueId}`,
+      amounts: INCREASING_AMOUNTS,
+      volatilityLong: 'increasing',
+    },
+    {
+      symbol: `E2ESVVL${uniqueId}`,
+      amounts: VOLATILE_AMOUNTS,
+      volatilityLong: 'volatile',
+    },
+  ];
+}
+
+function suppressError(): undefined {
+  return undefined;
+}
+
+async function cleanupOnError(
+  prisma: PrismaClient,
+  universeIds: string[],
+  symbols: string[],
+  accountName: string
+): Promise<void> {
+  if (universeIds.length > 0) {
+    await prisma.divDeposits
+      .deleteMany({ where: { universeId: { in: universeIds } } })
+      .catch(suppressError);
+    await prisma.universe
+      .deleteMany({ where: { symbol: { in: symbols } } })
+      .catch(suppressError);
+  }
+  await prisma.accounts
+    .deleteMany({ where: { name: accountName } })
+    .catch(suppressError);
+}
+
+function buildCleanup(
+  prisma: PrismaClient,
+  universeIds: string[],
+  symbols: string[],
+  accountName: string
+): () => Promise<void> {
+  return async function cleanupStoredVolatilityData(): Promise<void> {
+    try {
+      await prisma.divDeposits.deleteMany({
+        where: { universeId: { in: universeIds } },
+      });
+      await prisma.universe.deleteMany({ where: { symbol: { in: symbols } } });
+      await prisma.accounts.deleteMany({ where: { name: accountName } });
+    } finally {
+      await prisma.$disconnect();
+    }
+  };
+}
+
+async function seedAllPlans(
+  ctx: SeedContext,
+  plans: SeedPlan[],
+  universeIds: string[]
+): Promise<void> {
+  for (const plan of plans) {
+    await seedOnePlan(ctx, plan, universeIds);
+  }
+}
+
+/**
+ * Seeds three universe symbols each with 12 months of div-deposit history
+ * and a pre-stored volatility_long value (steady / increasing / volatile).
+ */
+export async function seedStoredVolatilityData(): Promise<StoredVolatilitySeederResult> {
+  const prisma = await initializePrismaClient();
+  const uniqueId = generateUniqueId();
+  const accountName = `E2E-SV-${uniqueId}`;
+  const plans = buildSeedPlans(uniqueId);
+  const symbols = plans.map(function toSymbol(p: SeedPlan) {
+    return p.symbol;
+  });
+  const universeIds: string[] = [];
+
+  try {
+    const riskGroupId = await getOrCreateRiskGroupId(prisma);
+    const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
+    const acct = await prisma.accounts.create({ data: { name: accountName } });
+    await seedAllPlans(
+      { prisma, riskGroupId, accountId: acct.id, divDepositTypeId },
+      plans,
+      universeIds
+    );
+  } catch (error) {
+    await cleanupOnError(prisma, universeIds, symbols, accountName);
+    await prisma.$disconnect();
+    throw error;
+  }
+
+  return {
+    steadySymbol: plans[0].symbol,
+    increasingSymbol: plans[1].symbol,
+    volatileSymbol: plans[2].symbol,
+    symbols,
+    cleanup: buildCleanup(prisma, universeIds, symbols, accountName),
+  };
+}

--- a/apps/dms-material-e2e/src/helpers/seed-stored-volatility-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-stored-volatility-e2e-data.helper.ts
@@ -1,3 +1,5 @@
+import type { PrismaClient } from '@prisma/client';
+
 import { buildMonthlyDates } from './build-monthly-dates.helper';
 import { generateUniqueId } from './generate-unique-id.helper';
 import { getOrCreateDivDepositTypeId } from './get-or-create-div-deposit-type-id.helper';

--- a/apps/dms-material-e2e/src/helpers/seed-stored-volatility-update-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-stored-volatility-update-e2e-data.helper.ts
@@ -1,0 +1,192 @@
+import { buildMonthlyDates } from './build-monthly-dates.helper';
+import { generateUniqueId } from './generate-unique-id.helper';
+import { getOrCreateDivDepositTypeId } from './get-or-create-div-deposit-type-id.helper';
+import { getOrCreateRiskGroupId } from './get-or-create-risk-group-id.helper';
+import type { SeederResultBase } from './seeder-result-base.types';
+import { initializePrismaClient } from './shared-prisma-client.helper';
+
+const DISTRIBUTIONS_PER_YEAR = 12;
+const LAST_PRICE = 10.0;
+
+// Flat: all equal → CV = 0% → 'flat' category
+const FLAT_AMOUNTS = [
+  1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+];
+
+// Volatile: near-palindrome pattern → CV >> 10%, slope = 0, not up-then-down/down-then-up
+// Pattern: [2.0, 0.5, 2.0, 0.5, 2.0, 0.5, 0.5, 2.0, 0.5, 2.0, 0.5, 2.0]
+// mean=1.25, CV=0.6, normalizedSlope=0 → 'volatile' (mirrors the unit test pattern)
+const VOLATILE_AMOUNTS = [
+  2.0, 0.5, 2.0, 0.5, 2.0, 0.5, 0.5, 2.0, 0.5, 2.0, 0.5, 2.0,
+];
+
+interface StoredVolatilityUpdateSeederResult extends SeederResultBase {
+  symbol: string;
+  initialCategory: 'flat';
+  universeRecord: Record<string, unknown>;
+  updateToVolatile(): Promise<void>;
+}
+
+interface SeedFlatContext {
+  prisma: PrismaClient;
+  riskGroupId: string;
+  accountId: string;
+  divDepositTypeId: string;
+  symbol: string;
+}
+
+async function seedFlatSymbol(ctx: SeedFlatContext): Promise<string> {
+  const universe = await ctx.prisma.universe.create({
+    data: {
+      symbol: ctx.symbol,
+      risk_group_id: ctx.riskGroupId,
+      distribution: FLAT_AMOUNTS[FLAT_AMOUNTS.length - 1],
+      distributions_per_year: DISTRIBUTIONS_PER_YEAR,
+      last_price: LAST_PRICE,
+      ex_date: null,
+      most_recent_sell_date: null,
+      most_recent_sell_price: null,
+      expired: false,
+      is_closed_end_fund: true,
+      volatility_long: 'flat',
+      volatility_short: 'flat',
+    },
+  });
+
+  const dates = buildMonthlyDates(FLAT_AMOUNTS.length);
+  await ctx.prisma.divDeposits.createMany({
+    data: dates.map(function buildDeposit(date: Date, i: number) {
+      return {
+        date,
+        amount: FLAT_AMOUNTS[i],
+        accountId: ctx.accountId,
+        divDepositTypeId: ctx.divDepositTypeId,
+        universeId: universe.id,
+      };
+    }),
+  });
+
+  return universe.id;
+}
+
+function buildUniverseRecord(
+  universeId: string,
+  symbol: string,
+  riskGroupId: string
+): Record<string, unknown> {
+  return {
+    id: universeId,
+    symbol,
+    distribution: FLAT_AMOUNTS[FLAT_AMOUNTS.length - 1],
+    distributions_per_year: DISTRIBUTIONS_PER_YEAR,
+    last_price: LAST_PRICE,
+    most_recent_sell_date: null,
+    most_recent_sell_price: null,
+    ex_date: new Date().toISOString(),
+    risk_group_id: riskGroupId,
+    expired: false,
+    is_closed_end_fund: true,
+    position: 0,
+    avg_purchase_yield_percent: 0,
+    volatilityLong: 'flat',
+    volatilityShort: 'flat',
+  };
+}
+
+function buildUpdateToVolatile(
+  prisma: PrismaClient,
+  universeId: string,
+  accountId: string,
+  divDepositTypeId: string
+): () => Promise<void> {
+  return async function updateToVolatile(): Promise<void> {
+    await prisma.divDeposits.deleteMany({ where: { universeId } });
+    const dates = buildMonthlyDates(VOLATILE_AMOUNTS.length);
+    await prisma.divDeposits.createMany({
+      data: dates.map(function buildVolatileDeposit(date: Date, i: number) {
+        return {
+          date,
+          amount: VOLATILE_AMOUNTS[i],
+          accountId,
+          divDepositTypeId,
+          universeId,
+        };
+      }),
+    });
+  };
+}
+
+function suppressError(): undefined {
+  return undefined;
+}
+
+interface CleanupContext {
+  prisma: PrismaClient;
+  universeId: string;
+  symbol: string;
+  accountName: string;
+}
+
+async function performCleanup(ctx: CleanupContext): Promise<void> {
+  await ctx.prisma.divDeposits
+    .deleteMany({ where: { universeId: ctx.universeId } })
+    .catch(suppressError);
+  await ctx.prisma.universe
+    .deleteMany({ where: { symbol: ctx.symbol } })
+    .catch(suppressError);
+  await ctx.prisma.accounts
+    .deleteMany({ where: { name: ctx.accountName } })
+    .catch(suppressError);
+}
+
+/**
+ * Seeds one universe symbol with flat divDeposit history (volatility_long = 'flat').
+ * Returns helpers for the trigger-update AC#2 test.
+ */
+export async function seedStoredVolatilityUpdateData(): Promise<StoredVolatilityUpdateSeederResult> {
+  const prisma = await initializePrismaClient();
+  const uniqueId = generateUniqueId();
+  const symbol = `E2ESVUP${uniqueId}`;
+  const accountName = `E2E-SV-UP-${uniqueId}`;
+  let universeId = '';
+  let accountId = '';
+
+  try {
+    const riskGroupId = await getOrCreateRiskGroupId(prisma);
+    const divDepositTypeId = await getOrCreateDivDepositTypeId(prisma);
+    const acct = await prisma.accounts.create({ data: { name: accountName } });
+    accountId = acct.id;
+    universeId = await seedFlatSymbol({
+      prisma,
+      riskGroupId,
+      accountId,
+      divDepositTypeId,
+      symbol,
+    });
+    const cleanupCtx = { prisma, universeId, symbol, accountName };
+    return {
+      symbol,
+      symbols: [symbol],
+      initialCategory: 'flat',
+      universeRecord: buildUniverseRecord(universeId, symbol, riskGroupId),
+      updateToVolatile: buildUpdateToVolatile(
+        prisma,
+        universeId,
+        accountId,
+        divDepositTypeId
+      ),
+      cleanup: async function cleanup(): Promise<void> {
+        try {
+          await performCleanup(cleanupCtx);
+        } finally {
+          await prisma.$disconnect();
+        }
+      },
+    };
+  } catch (error) {
+    const cleanupCtx = { prisma, universeId, symbol, accountName };
+    await performCleanup(cleanupCtx);
+    await prisma.$disconnect();
+    throw error;
+  }
+}

--- a/apps/dms-material-e2e/src/helpers/seed-stored-volatility-update-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-stored-volatility-update-e2e-data.helper.ts
@@ -1,3 +1,5 @@
+import type { PrismaClient } from '@prisma/client';
+
 import { buildMonthlyDates } from './build-monthly-dates.helper';
 import { generateUniqueId } from './generate-unique-id.helper';
 import { getOrCreateDivDepositTypeId } from './get-or-create-div-deposit-type-id.helper';
@@ -82,7 +84,7 @@ function buildUniverseRecord(
     last_price: LAST_PRICE,
     most_recent_sell_date: null,
     most_recent_sell_price: null,
-    ex_date: new Date().toISOString(),
+    ex_date: null,
     risk_group_id: riskGroupId,
     expired: false,
     is_closed_end_fund: true,

--- a/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/seed-vol-column-e2e-data.helper.ts
@@ -54,25 +54,16 @@ function buildUniverseCreateData(
 ): Record<string, unknown> {
   return {
     symbol,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     risk_group_id: riskGroupId,
     distribution: 1.0,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     distributions_per_year: 12,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     last_price: 10.0,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     ex_date: null,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     most_recent_sell_date: null,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     most_recent_sell_price: null,
     expired: false,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     is_closed_end_fund: true,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     volatility_long: STORED_VOLATILITY,
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- database column name
     volatility_short: STORED_VOLATILITY,
   };
 }

--- a/apps/dms-material-e2e/src/stored-volatility.spec.ts
+++ b/apps/dms-material-e2e/src/stored-volatility.spec.ts
@@ -1,0 +1,143 @@
+import { expect, Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedStoredVolatilityData } from './helpers/seed-stored-volatility-e2e-data.helper';
+import { seedStoredVolatilityUpdateData } from './helpers/seed-stored-volatility-update-e2e-data.helper';
+
+async function searchForSymbol(page: Page, symbol: string) {
+  const searchInput = page.locator('input[placeholder="Search Symbol"]');
+  const row = page.locator('tbody tr').filter({
+    has: page.locator('td.mat-column-symbol', { hasText: symbol }),
+  });
+
+  await searchInput.fill(symbol);
+  await expect(row).toHaveCount(1, { timeout: 15_000 });
+  await expect(row.locator('td.mat-column-symbol')).toContainText(symbol);
+
+  return row.first();
+}
+
+async function expectVolIconForSymbol(
+  page: Page,
+  symbol: string,
+  expectedCategory: string
+): Promise<void> {
+  const row = await searchForSymbol(page, symbol);
+  const ariaLabel = `Volatility: ${expectedCategory}`;
+  await expect(
+    row.locator(`td.mat-column-vol [aria-label="${ariaLabel}"]`)
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+// ---------------------------------------------------------------------------
+// AC#1 – Stored volatility icons are correct for known symbols
+// ---------------------------------------------------------------------------
+
+test.describe('Stored Volatility - correct icons for known symbols', function describeStoredVolatilityIcons() {
+  let cleanup: (() => Promise<void>) | undefined;
+  let steadySymbol: string;
+  let increasingSymbol: string;
+  let volatileSymbol: string;
+
+  test.beforeAll(async function seedData() {
+    const result = await seedStoredVolatilityData();
+    cleanup = result.cleanup;
+    steadySymbol = result.steadySymbol;
+    increasingSymbol = result.increasingSymbol;
+    volatileSymbol = result.volatileSymbol;
+  });
+
+  test.afterAll(async function teardown() {
+    if (cleanup !== undefined) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async function navigateToUniverse({ page }) {
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('steady symbol shows steady volatility icon', async function steadySymbolShowsSteadyIcon({
+    page,
+  }) {
+    await expectVolIconForSymbol(page, steadySymbol, 'steady');
+  });
+
+  test('increasing symbol shows increasing volatility icon', async function increasingSymbolShowsIncreasingIcon({
+    page,
+  }) {
+    await expectVolIconForSymbol(page, increasingSymbol, 'increasing');
+  });
+
+  test('volatile symbol shows volatile volatility icon', async function volatileSymbolShowsVolatileIcon({
+    page,
+  }) {
+    await expectVolIconForSymbol(page, volatileSymbol, 'volatile');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC#2 – Vol icon updates after a data-change trigger
+// ---------------------------------------------------------------------------
+
+test.describe('Stored Volatility - icon updates after data-change trigger', function describeStoredVolatilityUpdate() {
+  let cleanup: (() => Promise<void>) | undefined;
+  let symbol: string;
+  let initialCategory: string;
+  let universeRecord: Record<string, unknown>;
+  let updateToVolatile: () => Promise<void>;
+
+  test.beforeAll(async function seedUpdateData() {
+    const result = await seedStoredVolatilityUpdateData();
+    cleanup = result.cleanup;
+    symbol = result.symbol;
+    initialCategory = result.initialCategory;
+    universeRecord = result.universeRecord;
+    updateToVolatile = result.updateToVolatile;
+  });
+
+  test.afterAll(async function teardown() {
+    if (cleanup !== undefined) {
+      await cleanup();
+    }
+  });
+
+  test('icon changes to volatile after divDeposits update triggers recalculation', async function iconUpdatesAfterTrigger({
+    page,
+    request,
+  }) {
+    // Verify initial icon reflects the pre-stored value
+    await login(page);
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+    await expectVolIconForSymbol(page, symbol, initialCategory);
+
+    // Replace flat deposits with high-variance deposits
+    await updateToVolatile();
+
+    // Trigger server-side volatility recalculation via PUT /api/universe
+    const response = await request.put('/api/universe', {
+      data: universeRecord,
+    });
+    expect(response.ok()).toBeTruthy();
+
+    // Navigate to the Universe screen so fresh data is fetched
+    await page.goto('/global/universe');
+    await page.waitForLoadState('networkidle');
+
+    // Poll until the icon reflects the newly recalculated 'volatile' category
+    await expect
+      .poll(
+        async function pollForUpdatedIcon() {
+          const row = await searchForSymbol(page, symbol);
+          return row
+            .locator('td.mat-column-vol mat-icon')
+            .getAttribute('aria-label');
+        },
+        { timeout: 15_000, intervals: [500, 1000, 2000] }
+      )
+      .toBe('Volatility: volatile');
+  });
+});


### PR DESCRIPTION
Closes #1145

## Summary

Implements story 85.4: E2E tests that verify the stored volatility feature (Epic 85) works correctly end-to-end.

## Changes

- **`stored-volatility.spec.ts`** — 4 E2E tests in 2 describe blocks
- **`seed-stored-volatility-e2e-data.helper.ts`** — Seeds 3 universe symbols with pre-stored `volatility_long` values (steady, increasing, volatile) for AC#1
- **`seed-stored-volatility-update-e2e-data.helper.ts`** — Seeds 1 flat symbol and provides `updateToVolatile()` for AC#2
- **`build-monthly-dates.helper.ts`** — Extracted shared helper for generating 12 monthly dates
- **`get-or-create-risk-group-id.helper.ts`** — Extracted shared helper
- **`get-or-create-div-deposit-type-id.helper.ts`** — Extracted shared helper
- **`seed-vol-column-e2e-data.helper.ts`** — Removed unused ESLint disable comments

## Acceptance Criteria Coverage

**AC#1**: Three symbols (steady, increasing, volatile) with known stored `volatility_long` values are seeded. Tests verify each displays the correct volatility icon in the Universe table.

**AC#2**: A flat symbol is seeded, divDeposit data is replaced with high-variance amounts, then `PUT /api/universe` triggers server-side recalculation. Test verifies the icon updates from `flat` to `volatile`.

## Testing

All 4 tests pass in both Chromium and Firefox:

```
✓ steady symbol shows steady volatility icon
✓ increasing symbol shows increasing volatility icon
✓ volatile symbol shows volatile volatility icon
✓ icon changes to volatile after divDeposits update triggers recalculation
```

Quality checks: `pnpm format` clean, `nx lint dms-material-e2e` 0 errors, `pnpm dupcheck` 0 clones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for stored volatility UI behavior, including automated test data seeding, icon validation, and update verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->