### PR TITLE
feat: Story 86.1 - Expose volatilityShort in Universe API

### DIFF
--- a/_bmad-output/implementation-artifacts/86-1-api-expose-short-term-volatility.md
+++ b/_bmad-output/implementation-artifacts/86-1-api-expose-short-term-volatility.md
@@ -31,24 +31,27 @@ Story 86.2.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Verify `volatilityShort` is included in the backend response (AC: #1)
-  - [ ] Open `apps/server/src/app/routes/universe/universe.interface.ts`
-  - [ ] Confirm `volatilityShort: string | null` is present (added in Story 85.3)
-  - [ ] If Story 85.3 did not include it, add it now alongside `volatilityLong`
-  - [ ] Open `apps/server/src/app/routes/universe/index.ts` — confirm `mapUniverseToResponse` maps `volatility_short → volatilityShort`
+- [x] Task 1: Verify `volatilityShort` is included in the backend response (AC: #1)
 
-- [ ] Task 2: Verify frontend `Universe` interface includes `volatilityShort` (AC: #2)
-  - [ ] Open `apps/dms-material/src/app/store/universe/universe.interface.ts`
-  - [ ] Confirm `volatilityShort: string | null` is declared (added in Story 85.3)
-  - [ ] If missing, add it now
-  - [ ] Run `pnpm nx build dms-material` to confirm no TypeScript errors
+  - [x] Open `apps/server/src/app/routes/universe/universe.interface.ts`
+  - [x] Confirm `volatilityShort: string | null` is present (added in Story 85.3)
+  - [x] If Story 85.3 did not include it, add it now alongside `volatilityLong`
+  - [x] Open `apps/server/src/app/routes/universe/index.ts` — confirm `mapUniverseToResponse` maps `volatility_short → volatilityShort`
 
-- [ ] Task 3: Write/update unit tests for Universe route asserting `volatilityShort` (AC: #3)
-  - [ ] Open or create `apps/server/src/app/routes/universe/index.spec.ts`
-  - [ ] Add a test case: mock a `universe` row with a non-null `volatility_short` value
-  - [ ] Assert the route response JSON includes `volatilityShort` with the expected value
-  - [ ] Add a test case: mock a `universe` row with `volatility_short: null`
-  - [ ] Assert the response includes `volatilityShort: null` (not `undefined`)
+- [x] Task 2: Verify frontend `Universe` interface includes `volatilityShort` (AC: #2)
+
+  - [x] Open `apps/dms-material/src/app/store/universe/universe.interface.ts`
+  - [x] Confirm `volatilityShort: string | null` is declared (added in Story 85.3)
+  - [x] If missing, add it now
+  - [x] Run `pnpm nx build dms-material` to confirm no TypeScript errors
+
+- [x] Task 3: Write/update unit tests for Universe route asserting `volatilityShort` (AC: #3)
+
+  - [x] Open or create `apps/server/src/app/routes/universe/index.spec.ts`
+  - [x] Add a test case: mock a `universe` row with a non-null `volatility_short` value
+  - [x] Assert the route response JSON includes `volatilityShort` with the expected value
+  - [x] Add a test case: mock a `universe` row with `volatility_short: null`
+  - [x] Assert the response includes `volatilityShort: null` (not `undefined`)
 
 - [ ] Task 4: Full test run (AC: #4)
   - [ ] Run `pnpm all` and confirm all tests pass
@@ -72,8 +75,8 @@ this story's primary work is the unit tests (Task 3). Do not duplicate changes a
   id: string;
   symbol: string;
   // ... other fields ...
-  volatilityLong: string | null;   // 5-year category — from Story 85.3
-  volatilityShort: string | null;  // 1-year category — confirmed in this story
+  volatilityLong: string | null; // 5-year category — from Story 85.3
+  volatilityShort: string | null; // 1-year category — confirmed in this story
 }
 ```
 

--- a/_bmad-output/implementation-artifacts/86-1-api-expose-short-term-volatility.md
+++ b/_bmad-output/implementation-artifacts/86-1-api-expose-short-term-volatility.md
@@ -53,8 +53,8 @@ Story 86.2.
   - [x] Add a test case: mock a `universe` row with `volatility_short: null`
   - [x] Assert the response includes `volatilityShort: null` (not `undefined`)
 
-- [ ] Task 4: Full test run (AC: #4)
-  - [ ] Run `pnpm all` and confirm all tests pass
+- [x] Task 4: Full test run (AC: #4)
+  - [x] Run `pnpm all` and confirm all tests pass
 
 ## Dev Notes
 

--- a/apps/server/src/app/prisma/optimized-batch-account-load.function.ts
+++ b/apps/server/src/app/prisma/optimized-batch-account-load.function.ts
@@ -22,7 +22,7 @@ export async function optimizedBatchAccountLoad(
   }
 
   async function performBatchAccountLoad(): Promise<BatchAccountResult> {
-    return optimizedPrisma.accounts.findMany({
+    const accounts = await optimizedPrisma.accounts.findMany({
       where: { id: { in: accountIds } },
       select: {
         id: true,
@@ -50,6 +50,7 @@ export async function optimizedBatchAccountLoad(
         name: 'asc',
       },
     });
+    return accounts;
   }
 
   return databasePerformanceService.measureQueryPerformance(

--- a/apps/server/src/app/routes/universe/index.spec.ts
+++ b/apps/server/src/app/routes/universe/index.spec.ts
@@ -330,3 +330,55 @@ describe('POST /api/universe - avg_purchase_yield_percent (regression: AS.9 Bug 
     expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith('u1');
   });
 });
+
+describe('POST /api/universe - volatilityShort field (Story 86.1)', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async function setupApp() {
+    app = fastify({ logger: false });
+    await app.register(registerUniverseRoutes, { prefix: '/api/universe' });
+    await app.ready();
+    mockPrismaUniverse.findMany.mockReset();
+    mockPrismaUniverse.update.mockReset();
+  });
+
+  afterEach(async function teardownApp() {
+    await app.close();
+  });
+
+  it('includes volatilityShort in universe response when value is set', async function assertVolatilityShortInResponse() {
+    mockPrismaUniverse.findMany.mockResolvedValue([
+      makeUniverseRow({ volatility_short: 'steady' }),
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/universe/',
+      payload: ['u1'],
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as Array<{
+      volatilityShort: string | null;
+    }>;
+    expect(body[0].volatilityShort).toBe('steady');
+  });
+
+  it('includes volatilityShort as null when not yet calculated', async function assertVolatilityShortNullInResponse() {
+    mockPrismaUniverse.findMany.mockResolvedValue([
+      makeUniverseRow({ volatility_short: null }),
+    ]);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/universe/',
+      payload: ['u1'],
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = JSON.parse(response.body) as Array<{
+      volatilityShort: string | null;
+    }>;
+    expect(body[0].volatilityShort).toBeNull();
+  });
+});


### PR DESCRIPTION
## Story 86.1: Extend Universe API to Expose Short-Term Volatility

This PR confirms and tests the `volatilityShort` field exposure in the Universe API response, providing a typed contract and unit test coverage as a foundation for Story 86.2 (the SVol column).

### Changes

- **Verified** `volatilityShort: string | null` is present in the server `Universe` interface (`apps/server/src/app/routes/universe/universe.interface.ts`)
- **Verified** `mapUniverseToResponse` maps `volatility_short → volatilityShort` in both `index.ts` and `get-all-universes/index.ts`
- **Verified** frontend `Universe` interface (`apps/dms-material/src/app/store/universe/universe.interface.ts`) includes `volatilityShort: string | null`
- **Added** two dedicated unit tests in `apps/server/src/app/routes/universe/index.spec.ts`:
  - `includes volatilityShort in universe response when value is set` — asserts non-null `volatility_short` maps correctly
  - `includes volatilityShort as null when not yet calculated` — asserts `null` value maps to `volatilityShort: null` (not `undefined`)
- **Fixed** ESLint async-await pattern in `optimized-batch-account-load.function.ts`

### Testing

All tests pass:
- `CI=1 pnpm all` — 882 tests passed
- `pnpm e2e:dms-material:chromium` — 682 passed, 130 skipped
- `pnpm e2e:dms-material:firefox` — 683 passed, 130 skipped
- `pnpm dupcheck` — 0 clones

Closes #1147


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API responses now include short-term volatility.

* **Bug Fixes**
  * Short-term volatility is correctly preserved when explicitly null.

* **Tests**
  * Added regression tests validating short-term volatility is returned for both provided and null cases.

* **Documentation**
  * Updated implementation checklist and adjusted example response formatting for volatility fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->