### PR TITLE
feat: Story 86.2 - Add SVol Column to Universe Screen

### DIFF
--- a/apps/dms-material-e2e/src/universe-table-workflows.spec.ts
+++ b/apps/dms-material-e2e/src/universe-table-workflows.spec.ts
@@ -79,10 +79,10 @@ test.describe('Universe Table Workflows', () => {
       // The table has filter row and header row - count only header row
       const headers = page.locator('tr.mat-mdc-header-row:not(.filter-row) th');
       const headerCount = await headers.count();
-      // Vol, Symbol, Risk Group, Distribution, Dist/Year, Yield %,
+      // Vol, SVol, Symbol, Risk Group, Distribution, Dist/Year, Yield %,
       // Avg Purch Yield %, Last Price, Ex-Date, Most Recent Sell Date,
       // Most Recent Sell Price, Position, Expired, Actions
-      expect(headerCount).toBe(14);
+      expect(headerCount).toBe(15);
     });
 
     test('should display symbol data in symbol column', async ({ page }) => {

--- a/apps/dms-material/src/app/global/global-universe/global-universe.columns.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.columns.ts
@@ -7,6 +7,12 @@ export const UNIVERSE_COLUMNS: ColumnDef[] = [
     tooltip: 'Volatility',
     width: '50px',
   },
+  {
+    field: 'svol',
+    header: 'SVol',
+    tooltip: 'Short-Term Volatility',
+    width: '50px',
+  },
   { field: 'symbol', header: 'Symbol', sortable: true, width: '80px' },
   {
     field: 'risk_group',

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.html
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.html
@@ -206,6 +206,54 @@
           matTooltip="Insufficient history"
           >remove</mat-icon
         >
+        } } @case ('svol') { @if (row.volatilityShort === 'steady') {
+        <mat-icon
+          aria-label="Short-Term Volatility: steady"
+          matTooltip="Steady (Short-Term)"
+          >trending_flat</mat-icon
+        >
+        } @else if (row.volatilityShort === 'increasing') {
+        <mat-icon
+          aria-label="Short-Term Volatility: increasing"
+          matTooltip="Increasing (Short-Term)"
+          >trending_up</mat-icon
+        >
+        } @else if (row.volatilityShort === 'decreasing') {
+        <mat-icon
+          aria-label="Short-Term Volatility: decreasing"
+          matTooltip="Decreasing (Short-Term)"
+          >trending_down</mat-icon
+        >
+        } @else if (row.volatilityShort === 'flat') {
+        <mat-icon
+          aria-label="Short-Term Volatility: flat"
+          matTooltip="Flat (Short-Term)"
+          >drag_handle</mat-icon
+        >
+        } @else if (row.volatilityShort === 'volatile') {
+        <mat-icon
+          aria-label="Short-Term Volatility: volatile"
+          matTooltip="Volatile (Short-Term)"
+          >show_chart</mat-icon
+        >
+        } @else if (row.volatilityShort === 'up-then-down') {
+        <mat-icon
+          aria-label="Short-Term Volatility: up-then-down"
+          matTooltip="Up then Down (Short-Term)"
+          >change_history</mat-icon
+        >
+        } @else if (row.volatilityShort === 'down-then-up') {
+        <mat-icon
+          aria-label="Short-Term Volatility: down-then-up"
+          matTooltip="Down then Up (Short-Term)"
+          >swap_vert</mat-icon
+        >
+        } @else if (row.volatilityShort === 'insufficient-history') {
+        <mat-icon
+          aria-label="Short-Term Volatility: insufficient history"
+          matTooltip="Insufficient history (Short-Term)"
+          >remove</mat-icon
+        >
         } } @case ('distribution') {
         <dms-editable-cell
           [value]="row.distribution"

--- a/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
+++ b/apps/dms-material/src/app/global/global-universe/global-universe.component.spec.ts
@@ -161,6 +161,26 @@ describe('GlobalUniverseComponent', () => {
       expect(col?.editable).toBe(true);
       expect(col?.type).toBe('date');
     });
+
+    it('should have svol column', () => {
+      const col = component.columns.find(function findSvol(c) {
+        return c.field === 'svol';
+      });
+      expect(col).toBeDefined();
+      expect(col?.header).toBe('SVol');
+      expect(col?.tooltip).toBe('Short-Term Volatility');
+    });
+
+    it('should have svol column immediately after vol column', () => {
+      const volIndex = component.columns.findIndex(function findVol(c) {
+        return c.field === 'vol';
+      });
+      const svolIndex = component.columns.findIndex(function findSvol(c) {
+        return c.field === 'svol';
+      });
+      expect(volIndex).toBeGreaterThanOrEqual(0);
+      expect(svolIndex).toBe(volIndex + 1);
+    });
   });
 
   describe('syncUniverse', () => {


### PR DESCRIPTION
## Summary

Adds a short-term volatility (SVol) column as the 2nd column on the Universe screen, immediately after the existing Vol column.

The SVol column renders distribution volatility icons using the same pattern as the Vol column but reads from `volatilityShort` (1-year short-term) instead of `volatilityLong` (5-year). All 8 volatility categories are supported plus a null/no-data state that renders nothing.

## Changes

- **Column definition**: Added `svol` entry to `UNIVERSE_COLUMNS` with header `SVol`, tooltip `Short-Term Volatility`, and width `50px`
- **Template**: Added `@case ('svol')` block in the Universe screen template, replicating the vol icon rendering pattern with `row.volatilityShort` and aria-labels `Short-Term Volatility: {category}`
- **Unit tests**: Added 2 tests verifying svol column presence and that it immediately follows the vol column
- **E2E tests**: Updated column count assertion from 14 to 15

## Testing

- `pnpm all`: 1767/1769 tests pass (2 pre-existing skips)
- Chromium E2E: 671 passed, 11 failed (all pre-existing, unrelated to SVol)
- Firefox E2E: 672 passed, 11 failed (all pre-existing, unrelated to SVol)
- Column count E2E test (`should display correct number of columns`) passes on both browsers

Closes #1149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Added a new Short-Term Volatility (SVol) column to the universe data table to provide comprehensive volatility metrics alongside existing long-term measurements. The column features semantic icons with interactive tooltips for enhanced visual clarity, helping users interpret market volatility data more effectively and make better-informed trading and investment decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->