### PR TITLE
fix(account-panel): Story 87.2 - Fix Scrolling Blank Rows on Open/Sold Positions and Dividend Deposits

### DIFF
--- a/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits-component.service.ts
@@ -21,6 +21,15 @@ interface DividendRow {
   isLoading?: boolean;
 }
 
+/**
+ * Scrolling regression history (Epics 29, 31, 44, 60, 64, 87):
+ * See base-table.component.ts for full history.
+ * Story 87.2 fix: placeholder symbol changed from '' to '\u2026' so that
+ * SmartNgRX in-flight loading rows are visually distinct (ellipsis) rather
+ * than blank, matching the Universe screen pattern from Story 76.3.
+ * A blank symbol causes the blank-cell regression guard in
+ * scrolling-regression-87.spec.ts to fail.
+ */
 function buildPlaceholderDividendRow(id: string): DividendRow {
   return {
     id,
@@ -29,7 +38,7 @@ function buildPlaceholderDividendRow(id: string): DividendRow {
     accountId: '',
     divDepositTypeId: '',
     universeId: null,
-    symbol: '',
+    symbol: '\u2026',
     type: '',
     isLoading: true,
   };

--- a/apps/dms-material/src/app/account-panel/open-positions/open-positions-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/open-positions/open-positions-component.service.ts
@@ -10,10 +10,19 @@ import { OpenPosition } from '../../store/trades/open-position.interface';
 import { Trade } from '../../store/trades/trade.interface';
 import { Universe } from '../../store/universe/universe.interface';
 
+/**
+ * Scrolling regression history (Epics 29, 31, 44, 60, 64, 87):
+ * See base-table.component.ts for full history.
+ * Story 87.2 fix: placeholder symbol changed from '' to '\u2026' so that
+ * SmartNgRX in-flight loading rows are visually distinct (ellipsis) rather
+ * than blank, matching the Universe screen pattern from Story 76.3.
+ * A blank symbol causes the blank-cell regression guard in
+ * scrolling-regression-87.spec.ts to fail.
+ */
 function placeholderOpenPosition(id: string): OpenPosition {
   return {
     id,
-    symbol: '',
+    symbol: '\u2026',
     exDate: null,
     buy: 0,
     buyDate: new Date(),

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
@@ -9,10 +9,19 @@ import { Trade } from '../../store/trades/trade.interface';
 import { Universe } from '../../store/universe/universe.interface';
 import { classifyCapitalGain } from './classify-capital-gain.function';
 
+/**
+ * Scrolling regression history (Epics 29, 31, 44, 60, 64, 87):
+ * See base-table.component.ts for full history.
+ * Story 87.2 fix: placeholder symbol changed from '' to '\u2026' so that
+ * SmartNgRX in-flight loading rows are visually distinct (ellipsis) rather
+ * than blank, matching the Universe screen pattern from Story 76.3.
+ * A blank symbol causes the blank-cell regression guard in
+ * scrolling-regression-87.spec.ts to fail.
+ */
 function buildPlaceholderClosedPosition(id: string): ClosedPosition {
   return {
     id,
-    symbol: '',
+    symbol: '\u2026',
     buy: 0,
     buy_date: '',
     quantity: 0,

--- a/apps/dms-material/src/app/shared/components/base-table/base-table.component.ts
+++ b/apps/dms-material/src/app/shared/components/base-table/base-table.component.ts
@@ -31,6 +31,27 @@ import { debounceTime } from 'rxjs';
 import { SortColumn } from '../../services/sort-column.interface';
 import { ColumnDef } from './column-def.interface';
 
+/**
+ * SCROLLING REGRESSION HISTORY — DO NOT SIMPLIFY THIS CODE:
+ * Epic 29: rowHeight mismatch → CDK scroll height calculated incorrectly
+ * Epic 31: contain:strict on sticky header → jump on CDK viewport recalculation
+ * Epic 44: CSS transitions + extra CD cycles → CDK recalculated mid-animation
+ * Epic 60: isLoading=true rows filtered → array shrinks → CDK shrinks total height → scroll jumps
+ * Epic 64: Edge case follow-up to Epic 60 (excludeLoadingRows re-introduced the bug)
+ * Epic 87: Same root cause as Epic 60/64 but on account-panel screens (Open Positions,
+ *   Sold Positions, Dividend Deposits). Those screens used symbol: '' (empty string) as
+ *   the SmartNgRX placeholder, while Universe already used symbol: '\u2026'. A rapid
+ *   scroll triggered lazy-load in-flight windows where placeholder rows with blank symbols
+ *   were visible. Fix (Story 87.2): change placeholder symbol from '' to '\u2026' in all
+ *   three account-panel component services, matching the Universe screen pattern.
+ *
+ * The structural constraint: CDK virtual scroll requires a STABLE array length.
+ * SmartNgRX marks rows isLoading=true during in-flight requests; filtering those
+ * rows out shrinks the array and causes CDK to recalculate total height, jumping
+ * the viewport. Always keep placeholder/loading rows in the array.
+ * Placeholder rows must use a non-empty symbol (e.g. '\u2026') so blank-cell
+ * regression guards do not false-positive on loading rows.
+ */
 function compareNonNullValues(aVal: unknown, bVal: unknown): number {
   if (typeof aVal === 'string' && typeof bVal === 'string') {
     return aVal.localeCompare(bVal);


### PR DESCRIPTION
## Summary

Fixes the blank-row scrolling defect on account-panel screens (Open Positions, Sold Positions, Dividend Deposits) documented in Story 87.1.

**Root Cause (Story 87.1 finding):** The three account-panel screens used `symbol: ''` (empty string) as the SmartNgRX loading-row placeholder. During rapid scrolling, lazy-load in-flight windows exposed these placeholder rows as blank symbol cells. The Universe screen already used `symbol: '…'` (ellipsis U+2026) as its placeholder, making loading rows visually distinct instead of blank.

**Fix:** Changed `symbol: ''` to `symbol: '…'` in the three account-panel component service placeholder functions, aligning with the Universe pattern from Story 76.3.

## Changed Files

- `apps/dms-material/src/app/account-panel/open-positions/open-positions-component.service.ts` — `placeholderOpenPosition()`: symbol '' → '…'
- `apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts` — `buildPlaceholderClosedPosition()`: symbol '' → '…'
- `apps/dms-material/src/app/account-panel/dividend-deposits/dividend-deposits-component.service.ts` — `buildPlaceholderDividendRow()`: symbol '' → '…'
- `apps/dms-material/src/app/shared/components/base-table/base-table.component.ts` — Added full scrolling regression history comment (Epics 29, 31, 44, 60, 64, 87)

## Testing

- `CI=1 pnpm all` — all 1767+ unit tests pass
- `pnpm e2e:dms-material:chromium` — all 6 scrolling regression guards in `scrolling-regression-87.spec.ts` pass
- `pnpm e2e:dms-material:firefox` — all 6 scrolling regression guards pass
- `pnpm dupcheck` — no duplicate code
- `pnpm format` — no formatting changes

## Scrolling Regression History

This fix addresses the 6th iteration of the scrolling regression:
- Epic 29: rowHeight mismatch
- Epic 31: contain:strict on header
- Epic 44: CSS transitions + CD cycles
- Epic 60: isLoading filter shrinking array
- Epic 64: Edge case of Epic 60
- **Epic 87 (this fix):** Account-panel placeholder symbol was empty string, triggering blank-cell guard

Closes #1155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed placeholder row display in dividend deposits, open positions, and sold positions views to show an ellipsis character instead of blank values for improved visual clarity during data loading.

* **Documentation**
  * Added documentation regarding regression context and placeholder handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->