### PR TITLE
feat: Comprehensive Scrolling Regression Prevention Suite (Story 87.3)

### DIFF
--- a/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Story 87.3: Dividend Deposits Scrolling Regression Prevention Suite
+ *
+ * Regression guard covering multiple scroll patterns on the Dividend Deposits screen.
+ * Extends the coverage added by Story 87.1 (`scrolling-regression-87.spec.ts`)
+ * with the oscillation pattern.
+ *
+ * The Dividend Deposits placeholder (Story 87.2) uses symbol: '\u2026' for loading rows.
+ * These tests guard against any future change that re-introduces blank symbol cells
+ * at any scroll position.
+ *
+ * Data volume: ≥ 60 dividend deposit rows seeded via `seedScrollDivDepositsWithSymbolsData`.
+ * All rows are seeded with a universeId so every row should have a non-empty symbol.
+ */
+
+import { expect, Locator, test } from 'playwright/test';
+
+import { assertVisibleRowsNonEmpty } from './helpers/assert-visible-rows-non-empty.helper';
+import { login } from './helpers/login.helper';
+import { seedScrollDivDepositsWithSymbolsData } from './helpers/seed-scroll-div-deposits-with-symbols-data.helper';
+
+const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
+const ROW_SELECTOR = 'tr.mat-mdc-row';
+const SYMBOL_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-symbol';
+
+// ─── Scroll Helpers ────────────────────────────────────────────────────────────
+
+async function scrollViewportToBottom(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = node.scrollHeight;
+  });
+}
+
+async function scrollViewportToTop(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = 0;
+  });
+}
+
+// ─── Dividend Deposits Scrolling Regression Tests ─────────────────────────────
+
+test.describe('Dividend Deposits Scrolling Regression — Story 87.3', () => {
+  let cleanup: () => Promise<void>;
+  let accountId: string;
+
+  test.beforeAll(async () => {
+    // Use the "with symbols" seed helper so all 60 rows have a universeId and
+    // thus a symbol. Rows without a universeId have symbol: '' by design (no
+    // universe link), which is not a bug. We test only rows that SHOULD have a
+    // symbol so blank cells are unambiguous regression evidence.
+    const seeder = await seedScrollDivDepositsWithSymbolsData();
+    cleanup = seeder.cleanup;
+    accountId = seeder.accountId;
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto(`/account/${accountId}/div-dep`);
+    await expect(page.locator('dms-base-table')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForSelector(ROW_SELECTOR, { timeout: 15000 });
+  });
+
+  test('all deposit rows populate after fast scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — fast scroll to the bottom triggers the
+    // SmartNgRX lazy-load in-flight window where placeholder rows with
+    // symbol: '\u2026' (or '' before Story 87.2) may briefly appear.
+    // Asserts no blank symbol cells are visible after the scroll completes.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Dividend Deposits: blank symbol cells detected after fast scroll to bottom. ' +
+        'Story 87.3 regression guard: SmartNgRX lazy-load placeholder rows should not produce blank cells.'
+    );
+  });
+
+  test('no blank rows after oscillation scroll', async ({ page }) => {
+    // Story 87.3 regression guard — oscillation (bottom\u2192top\u2192bottom) maximises
+    // the number of SmartNgRX lazy-load in-flight windows that overlap with
+    // the viewport. Each direction change may trigger a new batch of isLoading
+    // rows; if any produce blank symbol cells the assertion will fail.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+    await scrollViewportToTop(viewport);
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Dividend Deposits: blank symbol cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
+        'Story 87.3 regression guard: repeated isLoading cycles should not produce blank symbol cells.'
+    );
+  });
+});

--- a/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
@@ -128,4 +128,5 @@ test.describe('Dividend Deposits Scrolling Regression — Story 87.3', () => {
       'Dividend Deposits: blank symbol cells detected after sort change + scroll to bottom. ' +
         'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank rows.'
     );
-  });});
+  });
+});

--- a/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts
@@ -107,4 +107,25 @@ test.describe('Dividend Deposits Scrolling Regression — Story 87.3', () => {
         'Story 87.3 regression guard: repeated isLoading cycles should not produce blank symbol cells.'
     );
   });
-});
+  test('no blank rows after sort change and scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — changing sort order triggers a new
+    // server-side request and an isLoading window. A fast scroll into the
+    // newly sorted data should not expose placeholder rows with blank symbol
+    // cells.
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await expect(symbolHeader).toBeVisible({ timeout: 10000 });
+    await symbolHeader.click();
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Dividend Deposits: blank symbol cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank rows.'
+    );
+  });});

--- a/apps/dms-material-e2e/src/helpers/assert-visible-rows-non-empty.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/assert-visible-rows-non-empty.helper.ts
@@ -1,0 +1,52 @@
+import { expect, Page } from 'playwright/test';
+
+const ROW_SELECTOR = 'tr.mat-mdc-row';
+
+/**
+ * Assert that all currently visible cells matching `cellSelector` have non-empty
+ * text content.
+ * Uses expect.poll to retry the assertion until all cells are populated or the
+ * timeout expires — no fixed sleeps required.
+ *
+ * Regression guard for CDK virtual scroll blank rows (Epics 29/31/44/60/64/87).
+ *
+ * @param page           - The Playwright Page object.
+ * @param cellSelector   - CSS selector for the cells to check
+ *                         (e.g. `'tr.mat-mdc-row td.mat-column-symbol'`).
+ * @param failureMessage - Message to display when the assertion fails.
+ * @param timeout        - Maximum polling time in milliseconds. Default: 10000.
+ */
+export async function assertVisibleRowsNonEmpty(
+  page: Page,
+  cellSelector: string,
+  failureMessage: string,
+  timeout = 10000
+): Promise<void> {
+  // Wait for at least one row to be visible first
+  await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({ timeout });
+
+  // Poll until no empty cells remain (auto-retries until timeout)
+  await expect
+    .poll(
+      async function countEmptyCells() {
+        const cells = page.locator(cellSelector);
+        // Read the currently rendered cells in one DOM snapshot so CDK
+        // row recycling cannot race a count()+nth() loop mid-poll.
+        const texts = await cells.evaluateAll(function readTexts(
+          cellElements: Element[]
+        ) {
+          return cellElements.map(function readText(cell) {
+            return (cell.textContent ?? '').trim();
+          });
+        });
+        if (texts.length === 0) {
+          return -1; // no rows yet — keep polling
+        }
+        return texts.filter(function isEmpty(text) {
+          return text === '';
+        }).length;
+      },
+      { message: failureMessage, timeout }
+    )
+    .toBe(0);
+}

--- a/apps/dms-material-e2e/src/helpers/assert-visible-rows-non-empty.helper.ts
+++ b/apps/dms-material-e2e/src/helpers/assert-visible-rows-non-empty.helper.ts
@@ -2,6 +2,13 @@ import { expect, Page } from 'playwright/test';
 
 const ROW_SELECTOR = 'tr.mat-mdc-row';
 
+/** Serialise cell text content for use inside `evaluateAll` (runs in browser context). */
+function readCellTexts(cellElements: Element[]): string[] {
+  return cellElements.map(function readText(cell) {
+    return (cell.textContent ?? '').trim();
+  });
+}
+
 /**
  * Assert that all currently visible cells matching `cellSelector` have non-empty
  * text content.
@@ -32,13 +39,7 @@ export async function assertVisibleRowsNonEmpty(
         const cells = page.locator(cellSelector);
         // Read the currently rendered cells in one DOM snapshot so CDK
         // row recycling cannot race a count()+nth() loop mid-poll.
-        const texts = await cells.evaluateAll(function readTexts(
-          cellElements: Element[]
-        ) {
-          return cellElements.map(function readText(cell) {
-            return (cell.textContent ?? '').trim();
-          });
-        });
+        const texts = await cells.evaluateAll(readCellTexts);
         if (texts.length === 0) {
           return -1; // no rows yet — keep polling
         }

--- a/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
@@ -187,7 +187,10 @@ test.describe('Open Positions Scrolling Regression — Story 87.3', () => {
     // newly sorted data should not expose placeholder rows.
     // Buy Date is used as the sort trigger because Symbol is not sortable on
     // this screen.
-    const buyDateHeader = page.getByRole('button', { name: 'Buy Date', exact: true });
+    const buyDateHeader = page.getByRole('button', {
+      name: 'Buy Date',
+      exact: true,
+    });
     await expect(buyDateHeader).toBeVisible({ timeout: 10000 });
     await buyDateHeader.click();
 

--- a/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Story 87.3: Open Positions Scrolling Regression Prevention Suite
+ *
+ * Regression guard covering multiple scroll patterns on the Open Positions screen.
+ * Extends the coverage added by Story 87.1 (`scrolling-regression-87.spec.ts`)
+ * with additional patterns: oscillation, and multi-column data validation.
+ *
+ * The Open Positions placeholder (Story 87.2) uses symbol: '\u2026' for loading rows.
+ * These tests guard against any future change that re-introduces blank symbol cells,
+ * missing quantity data, or empty buy-price cells at any scroll position.
+ *
+ * Data volume: ≥ 40 open-position rows seeded via `seedScrollOpenPositionsData`.
+ */
+
+import { expect, Locator, test } from 'playwright/test';
+
+import { assertVisibleRowsNonEmpty } from './helpers/assert-visible-rows-non-empty.helper';
+import { login } from './helpers/login.helper';
+import { seedScrollOpenPositionsData } from './helpers/seed-scroll-open-positions-data.helper';
+
+const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
+const ROW_SELECTOR = 'tr.mat-mdc-row';
+const SYMBOL_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-symbol';
+const QUANTITY_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-quantity';
+const BUY_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-buy';
+
+// ─── Scroll Helpers ────────────────────────────────────────────────────────────
+
+async function scrollViewportToBottom(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = node.scrollHeight;
+  });
+}
+
+async function scrollViewportToTop(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = 0;
+  });
+}
+
+// ─── Open Positions Scrolling Regression Tests ─────────────────────────────────
+
+test.describe('Open Positions Scrolling Regression — Story 87.3', () => {
+  let cleanup: () => Promise<void>;
+  let accountId: string;
+
+  test.beforeAll(async () => {
+    const seeder = await seedScrollOpenPositionsData();
+    cleanup = seeder.cleanup;
+    accountId = seeder.accountId;
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto(`/account/${accountId}/open`);
+    await expect(page.locator('dms-base-table')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForSelector(ROW_SELECTOR, { timeout: 15000 });
+  });
+
+  test('all position rows populate after fast scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — fast scroll to the bottom triggers the
+    // SmartNgRX lazy-load in-flight window where placeholder rows with
+    // symbol: '\u2026' (or '' before Story 87.2) may briefly appear.
+    // Asserts no blank symbol cells are visible after the scroll completes.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Open Positions: blank symbol cells detected after fast scroll to bottom. ' +
+        'Story 87.3 regression guard: SmartNgRX lazy-load placeholder rows should not produce blank cells.'
+    );
+  });
+
+  test('no blank rows after oscillation scroll (bottom-top-bottom)', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — oscillation (bottom\u2192top\u2192bottom) maximises
+    // the number of SmartNgRX lazy-load in-flight windows that overlap with
+    // the viewport. Each direction change triggers a new batch of isLoading
+    // rows; if any produce blank symbol cells the assertion will fail.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+    await scrollViewportToTop(viewport);
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Open Positions: blank symbol cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
+        'Story 87.3 regression guard: repeated isLoading cycles should not produce blank symbol cells.'
+    );
+  });
+
+  test('position data (symbol, quantity, buy price) non-empty at all scroll positions', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — scrolls to the bottom and asserts that
+    // all three key data columns (symbol, quantity, buy price) are non-empty
+    // at the final scroll position. Blank cells in any of these columns would
+    // indicate that placeholder rows are being rendered to the user.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Open Positions: blank symbol cells detected after scroll to bottom. ' +
+        'Story 87.3 regression guard: symbol column must be non-empty at all scroll positions.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      QUANTITY_CELL_SELECTOR,
+      'Open Positions: blank quantity cells detected after scroll to bottom. ' +
+        'Story 87.3 regression guard: quantity column must be non-empty at all scroll positions.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      BUY_CELL_SELECTOR,
+      'Open Positions: blank buy-price cells detected after scroll to bottom. ' +
+        'Story 87.3 regression guard: buy-price column must be non-empty at all scroll positions.'
+    );
+  });
+});

--- a/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
@@ -105,6 +105,20 @@ test.describe('Open Positions Scrolling Regression — Story 87.3', () => {
       'Open Positions: blank symbol cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
         'Story 87.3 regression guard: repeated isLoading cycles should not produce blank symbol cells.'
     );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      QUANTITY_CELL_SELECTOR,
+      'Open Positions: blank quantity cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
+        'Story 87.3 regression guard: repeated isLoading cycles should not produce blank quantity cells.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      BUY_CELL_SELECTOR,
+      'Open Positions: blank buy-price cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
+        'Story 87.3 regression guard: repeated isLoading cycles should not produce blank buy-price cells.'
+    );
   });
 
   test('position data (symbol, quantity, buy price) non-empty at all scroll positions', async ({

--- a/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts
@@ -140,4 +140,80 @@ test.describe('Open Positions Scrolling Regression — Story 87.3', () => {
         'Story 87.3 regression guard: buy-price column must be non-empty at all scroll positions.'
     );
   });
+
+  test('no blank rows after symbol filter and scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — applying a symbol filter triggers a
+    // server-side request and an isLoading window (server-side filter via
+    // interceptor). All seeded rows use symbols starting with 'TEST' so
+    // filtering by 'T' keeps all rows visible while still triggering the
+    // round-trip and the resulting isLoading cycle.
+    const symbolFilter = page.getByTestId('symbol-search-input');
+    await expect(symbolFilter).toBeVisible({ timeout: 10000 });
+    await symbolFilter.fill('T');
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Open Positions: blank symbol cells detected after symbol filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank rows.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      QUANTITY_CELL_SELECTOR,
+      'Open Positions: blank quantity cells detected after symbol filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank quantity cells.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      BUY_CELL_SELECTOR,
+      'Open Positions: blank buy-price cells detected after symbol filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank buy cells.'
+    );
+  });
+
+  test('no blank rows after sort change and scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — changing sort order triggers a new
+    // server-side request and an isLoading window. A fast scroll into the
+    // newly sorted data should not expose placeholder rows.
+    // Buy Date is used as the sort trigger because Symbol is not sortable on
+    // this screen.
+    const buyDateHeader = page.getByRole('button', { name: 'Buy Date', exact: true });
+    await expect(buyDateHeader).toBeVisible({ timeout: 10000 });
+    await buyDateHeader.click();
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Open Positions: blank symbol cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank rows.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      QUANTITY_CELL_SELECTOR,
+      'Open Positions: blank quantity cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank quantity cells.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      BUY_CELL_SELECTOR,
+      'Open Positions: blank buy-price cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank buy cells.'
+    );
+  });
 });

--- a/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
@@ -122,12 +122,15 @@ test.describe('Sold Positions Scrolling Regression — Story 87.3', () => {
     page,
   }) => {
     // Story 87.3 regression guard — applying a symbol filter triggers a
-    // new isLoading window. All seeded rows use symbols starting with 'TEST'
-    // so filtering by 'T' keeps all rows visible while still triggering the
-    // isLoading cycle that can expose blank cells.
+    // new isLoading window. The filter prefix is derived from the first visible
+    // symbol so the test stays data-driven and is not coupled to any specific
+    // seed-data naming convention.
     const symbolFilter = page.getByPlaceholder('Search Symbol');
     await expect(symbolFilter).toBeVisible({ timeout: 10000 });
-    await symbolFilter.fill('T');
+    const firstSymbolCell = page.locator(SYMBOL_CELL_SELECTOR).first();
+    await expect(firstSymbolCell).toBeVisible({ timeout: 10000 });
+    const firstSymbol = ((await firstSymbolCell.textContent()) ?? '').trim();
+    await symbolFilter.fill(firstSymbol.slice(0, 1));
 
     const viewport = page.locator(VIEWPORT_SELECTOR);
     await expect(viewport).toBeVisible({ timeout: 10000 });

--- a/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
@@ -117,4 +117,65 @@ test.describe('Sold Positions Scrolling Regression — Story 87.3', () => {
         'Story 87.3 regression guard: sell-price column must remain non-empty across all oscillation cycles.'
     );
   });
+
+  test('no blank rows after symbol filter and scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — applying a symbol filter triggers a
+    // new isLoading window. All seeded rows use symbols starting with 'TEST'
+    // so filtering by 'T' keeps all rows visible while still triggering the
+    // isLoading cycle that can expose blank cells.
+    const symbolFilter = page.getByPlaceholder('Search Symbol');
+    await expect(symbolFilter).toBeVisible({ timeout: 10000 });
+    await symbolFilter.fill('T');
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Sold Positions: blank symbol cells detected after symbol filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank rows.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SELL_CELL_SELECTOR,
+      'Sold Positions: blank sell-price cells detected after symbol filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank sell cells.'
+    );
+  });
+
+  test('no blank rows after sort change and scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — changing sort order triggers a new
+    // server-side request and an isLoading window. A fast scroll into the
+    // newly sorted data should not expose placeholder rows.
+    // Sell Date is used as the sort trigger because Symbol is not sortable on
+    // this screen.
+    const sellDateHeader = page.getByRole('button', { name: 'Sell Date', exact: true });
+    await expect(sellDateHeader).toBeVisible({ timeout: 10000 });
+    await sellDateHeader.click();
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Sold Positions: blank symbol cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank rows.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SELL_CELL_SELECTOR,
+      'Sold Positions: blank sell-price cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank sell cells.'
+    );
+  });
 });

--- a/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Story 87.3: Sold Positions Scrolling Regression Prevention Suite
+ *
+ * Regression guard covering multiple scroll patterns on the Sold Positions screen.
+ * Extends the coverage added by Story 87.1 (`scrolling-regression-87.spec.ts`)
+ * with the oscillation pattern and sell-price column validation.
+ *
+ * The Sold Positions placeholder (Story 87.2) uses symbol: '\u2026' for loading rows.
+ * These tests guard against any future change that re-introduces blank symbol cells
+ * or empty sell-price cells at any scroll position.
+ *
+ * Data volume: ≥ 40 sold-position rows seeded via `seedScrollSoldPositionsData`.
+ */
+
+import { expect, Locator, test } from 'playwright/test';
+
+import { assertVisibleRowsNonEmpty } from './helpers/assert-visible-rows-non-empty.helper';
+import { login } from './helpers/login.helper';
+import { seedScrollSoldPositionsData } from './helpers/seed-scroll-sold-positions-data.helper';
+
+const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
+const ROW_SELECTOR = 'tr.mat-mdc-row';
+const SYMBOL_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-symbol';
+const SELL_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-sell';
+
+// ─── Scroll Helpers ────────────────────────────────────────────────────────────
+
+async function scrollViewportToBottom(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = node.scrollHeight;
+  });
+}
+
+async function scrollViewportToTop(viewport: Locator): Promise<void> {
+  await viewport.evaluate(function setScrollTop(node: Element): void {
+    node.scrollTop = 0;
+  });
+}
+
+// ─── Sold Positions Scrolling Regression Tests ─────────────────────────────────
+
+test.describe('Sold Positions Scrolling Regression — Story 87.3', () => {
+  let cleanup: () => Promise<void>;
+  let accountId: string;
+
+  test.beforeAll(async () => {
+    const seeder = await seedScrollSoldPositionsData();
+    cleanup = seeder.cleanup;
+    accountId = seeder.accountId;
+  });
+
+  test.afterAll(async () => {
+    if (cleanup) {
+      await cleanup();
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await page.goto(`/account/${accountId}/sold`);
+    await expect(page.locator('dms-base-table')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.waitForSelector(ROW_SELECTOR, { timeout: 15000 });
+  });
+
+  test('all sold-position rows populate after fast scroll to bottom', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — fast scroll to the bottom triggers the
+    // SmartNgRX lazy-load in-flight window where placeholder rows with
+    // symbol: '\u2026' (or '' before Story 87.2) may briefly appear.
+    // Asserts no blank symbol or sell-price cells are visible after the scroll.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Sold Positions: blank symbol cells detected after fast scroll to bottom. ' +
+        'Story 87.3 regression guard: SmartNgRX lazy-load placeholder rows should not produce blank cells.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SELL_CELL_SELECTOR,
+      'Sold Positions: blank sell-price cells detected after fast scroll to bottom. ' +
+        'Story 87.3 regression guard: sell-price column must be non-empty at all scroll positions.'
+    );
+  });
+
+  test('no blank rows after oscillation scroll', async ({ page }) => {
+    // Story 87.3 regression guard — oscillation (bottom\u2192top\u2192bottom) maximises
+    // the number of SmartNgRX lazy-load in-flight windows that overlap with
+    // the viewport. Asserts symbol and sell-price cells remain non-empty
+    // throughout the oscillation cycle.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+    await scrollViewportToTop(viewport);
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Sold Positions: blank symbol cells detected after oscillation scroll (bottom\u2192top\u2192bottom). ' +
+        'Story 87.3 regression guard: repeated isLoading cycles should not produce blank symbol cells.'
+    );
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SELL_CELL_SELECTOR,
+      'Sold Positions: blank sell-price cells detected after oscillation scroll. ' +
+        'Story 87.3 regression guard: sell-price column must remain non-empty across all oscillation cycles.'
+    );
+  });
+});

--- a/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts
@@ -156,7 +156,10 @@ test.describe('Sold Positions Scrolling Regression — Story 87.3', () => {
     // newly sorted data should not expose placeholder rows.
     // Sell Date is used as the sort trigger because Symbol is not sortable on
     // this screen.
-    const sellDateHeader = page.getByRole('button', { name: 'Sell Date', exact: true });
+    const sellDateHeader = page.getByRole('button', {
+      name: 'Sell Date',
+      exact: true,
+    });
     await expect(sellDateHeader).toBeVisible({ timeout: 10000 });
     await sellDateHeader.click();
 

--- a/apps/dms-material-e2e/src/universe-scrolling-regression.spec.ts
+++ b/apps/dms-material-e2e/src/universe-scrolling-regression.spec.ts
@@ -26,54 +26,15 @@
  *   and the assertion will fail.
  */
 
-import { expect, Locator, Page, test } from 'playwright/test';
+import { expect, Locator, test } from 'playwright/test';
 
+import { assertVisibleRowsNonEmpty } from './helpers/assert-visible-rows-non-empty.helper';
 import { login } from './helpers/login.helper';
 import { seedScrollUniverseData } from './helpers/seed-scroll-universe-data.helper';
 
 const VIEWPORT_SELECTOR = 'cdk-virtual-scroll-viewport';
 const ROW_SELECTOR = 'tr.mat-mdc-row';
 const SYMBOL_CELL_SELECTOR = 'tr.mat-mdc-row td.mat-column-symbol';
-
-/**
- * Assert that all currently visible symbol cells have non-empty text content.
- * Uses expect.poll to retry the assertion until all rows are populated or the
- * timeout expires — no fixed sleeps required.
- *
- * Regression guard for Epics 29/31/44/60 (CDK virtual scroll blank rows).
- */
-async function assertVisibleSymbolsNonEmpty(
-  page: Page,
-  failureMessage: string
-): Promise<void> {
-  // Wait for at least one row to be visible first
-  await expect(page.locator(ROW_SELECTOR).first()).toBeVisible({
-    timeout: 10000,
-  });
-
-  // Poll until no empty cells remain (auto-retries until timeout)
-  await expect
-    .poll(
-      async function countEmptySymbols() {
-        const symbolCells = page.locator(SYMBOL_CELL_SELECTOR);
-        // Read the currently rendered symbol cells in one DOM snapshot so CDK
-        // row recycling cannot race a count()+nth() loop mid-poll.
-        const texts = await symbolCells.evaluateAll(function readTexts(cells) {
-          return cells.map(function readText(cell) {
-            return (cell.textContent ?? '').trim();
-          });
-        });
-        if (texts.length === 0) {
-          return -1; // no rows yet — keep polling
-        }
-        return texts.filter(function isEmpty(text) {
-          return text === '';
-        }).length;
-      },
-      { message: failureMessage, timeout: 10000 }
-    )
-    .toBe(0);
-}
 
 // ─── Scroll Helpers ──────────────────────────────────────────────────────────
 
@@ -136,8 +97,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     // triggering the isLoading window (SmartNgRX lazy-load in-flight).
     await scrollViewportToBottom(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after fast scroll to bottom. ' +
         'This indicates the CDK virtual scroll blank-row regression from Epic 60 is active. ' +
         'See enrich-universe-with-risk-groups.function.ts isLoading filter.'
@@ -159,8 +121,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     // Return to top
     await scrollViewportToTop(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after scrolling bottom→top. ' +
         'Epic 60 regression: isLoading filter in enrich-universe-with-risk-groups shrinks array on re-entry.'
     );
@@ -190,8 +153,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     await scrollViewportToBottom(viewport);
     await scrollViewportToTop(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after repeated scroll oscillation. ' +
         'Epic 60 regression: repeated isLoading cycles destabilise CDK viewport height.'
     );
@@ -244,8 +208,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     // Fast-scroll to the bottom to enter the new sorted data range.
     await scrollViewportToBottom(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after sort change + fast scroll. ' +
         'Round 5 (Epic 64) regression: excludeLoadingRows filter in filteredData$ removes ' +
         'placeholder rows, re-shrinking the CDK data array during isLoading window. ' +
@@ -282,8 +247,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     // Fast-scroll to the bottom while the filter response may still be loading.
     await scrollViewportToBottom(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after symbol filter change + fast scroll. ' +
         'Epic 60 regression: filter triggers mass isLoading state, old null-return collapses array.'
     );
@@ -328,8 +294,9 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
 
     await scrollViewportToBottom(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after multiple rapid sort toggles + fast scroll. ' +
         'Epic 64 regression: overlapping isLoading windows from consecutive sort clicks ' +
         're-shrink the CDK array when excludeLoadingRows filter is present. ' +
@@ -369,12 +336,85 @@ test.describe('Universe Scrolling Regression — blank rows on fast scroll', () 
     // Scroll to the bottom of the (now-smaller) filtered result set.
     await scrollViewportToBottom(viewport);
 
-    await assertVisibleSymbolsNonEmpty(
+    await assertVisibleRowsNonEmpty(
       page,
+      SYMBOL_CELL_SELECTOR,
       'Visible rows have empty symbol cells after subset symbol filter + scroll to bottom. ' +
         'Epic 64 regression: excludeLoadingRows filter interacted with reduced result size to ' +
         're-shrink the CDK array during the filter isLoading window. ' +
         'See global-universe.component.ts filteredData$ and Story 64.2 for the fix.'
+    );
+  });
+
+  // ─── Story 87.3: New scroll pattern tests ─────────────────────────────────
+
+  test('handles oscillation (fast bottom-top-bottom-top) without blank rows', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — oscillation (bottom→top→bottom→top)
+    // maximises the number of SmartNgRX lazy-load in-flight windows that
+    // overlap with the viewport. If placeholder rows with empty symbol cells
+    // are rendered at any oscillation step, the assertion will fail.
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+
+    await scrollViewportToBottom(viewport);
+    await scrollViewportToTop(viewport);
+    await scrollViewportToBottom(viewport);
+    await scrollViewportToTop(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Universe: blank symbol cells detected after oscillation scroll (bottom→top→bottom→top). ' +
+        'Story 87.3 regression guard: CDK viewport should remain stable across all oscillation cycles.'
+    );
+  });
+
+  test('no blank rows after applying a filter and scrolling', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — applying a risk group filter triggers a
+    // new server-side request and an isLoading window.  All 60 seeded rows are
+    // in the 'Equities' risk group, so filtering by it keeps all rows visible
+    // while still triggering the round-trip and the resulting isLoading cycle.
+    const riskGroupSelect = page.locator(
+      'tr.filter-row mat-select[panelwidth=""]'
+    );
+    await expect(riskGroupSelect).toBeVisible({ timeout: 10000 });
+    await riskGroupSelect.click();
+    await page.getByRole('option', { name: 'Equities' }).click();
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Universe: blank symbol cells detected after risk group filter + scroll to bottom. ' +
+        'Story 87.3 regression guard: filter-triggered isLoading window should not produce blank rows.'
+    );
+  });
+
+  test('no blank rows after changing sort order and scrolling', async ({
+    page,
+  }) => {
+    // Story 87.3 regression guard — changing sort order triggers a new
+    // server-side request and an isLoading window.  A fast scroll into the
+    // newly ordered data range should not expose placeholder rows.
+    const symbolHeader = page.getByRole('button', { name: 'Symbol' });
+    await symbolHeader.click();
+
+    const viewport = page.locator(VIEWPORT_SELECTOR);
+    await expect(viewport).toBeVisible({ timeout: 10000 });
+    await scrollViewportToBottom(viewport);
+
+    await assertVisibleRowsNonEmpty(
+      page,
+      SYMBOL_CELL_SELECTOR,
+      'Universe: blank symbol cells detected after sort change + scroll to bottom. ' +
+        'Story 87.3 regression guard: sort-triggered isLoading window should not produce blank rows.'
     );
   });
 });


### PR DESCRIPTION
Closes #1157

## Summary

Adds a comprehensive Playwright E2E regression-prevention suite covering all four affected screens (Universe, Open Positions, Sold Positions, Dividend Deposits) with scroll patterns and data volumes representative of the live application.

## Changes

- **New**: `apps/dms-material-e2e/src/helpers/assert-visible-rows-non-empty.helper.ts` — Shared polling assertion helper extracted from universe-scrolling-regression.spec.ts
- **New**: `apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts` — 3 regression tests (fast scroll, oscillation, multi-column data validation)
- **New**: `apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts` — 2 regression tests (fast scroll, oscillation)
- **New**: `apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts` — 2 regression tests (fast scroll, oscillation)
- **Modified**: `apps/dms-material-e2e/src/universe-scrolling-regression.spec.ts` — 3 new tests added (oscillation, filter+scroll, sort+scroll); existing tests preserved

## Testing

All new and existing scrolling regression tests pass under `pnpm e2e:dms-material:chromium` and `pnpm e2e:dms-material:firefox`. `CI=1 pnpm all` also passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression suites covering virtual scrolling for Dividend Deposits, Open Positions, Sold Positions, and Universe screens, validating UI stability under heavy scroll patterns.
  * New tests confirm visible table cells remain populated after fast scrolls, oscillations, filtering, and sort changes; seeded data is cleaned up after runs.
* **Refactor**
  * Replaced local assertions with a shared helper to assert visible rows contain non-empty data across tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->