### PR TITLE
feat: research and document electron packaging approach (#1178)

### DIFF
--- a/_bmad-output/implementation-artifacts/91-1-research-electron-packaging-approach.md
+++ b/_bmad-output/implementation-artifacts/91-1-research-electron-packaging-approach.md
@@ -1,6 +1,6 @@
 # Story 91.1: Research and Document the Electron Packaging Approach
 
-Status: Done
+Status: Approved
 
 ## Story
 
@@ -40,36 +40,41 @@ So that Stories 91.2–91.4 each have an unambiguous implementation target.
 
 ## Tasks / Subtasks
 
-- [x] Task 1: Read existing Electron app docs and code
-  - [x] Read `apps/electron/README.md` completely
-  - [x] Read `apps/electron/project.json` build/start targets
-  - [x] Read `apps/electron/src/main.ts` to understand the current startup sequence
+- [ ] Task 1: Read existing Electron app docs and code
+
+  - [ ] Read `apps/electron/README.md` completely
+  - [ ] Read `apps/electron/project.json` build/start targets
+  - [ ] Read `apps/electron/src/main.ts` to understand the current startup sequence
         (port finding → server fork → health check → BrowserWindow)
-  - [x] Read `apps/server/src/main.ts` to understand how it serves static Angular assets
+  - [ ] Read `apps/server/src/main.ts` to understand how it serves static Angular assets
 
-- [x] Task 2: Evaluate packaging tools
-  - [x] Compare `electron-builder` vs `@electron-forge/cli`
-  - [x] Prefer `electron-builder` if it supports Nx's build output structure naturally
-  - [x] Document the chosen tool and rationale in Dev Notes
+- [ ] Task 2: Evaluate packaging tools
 
-- [x] Task 3: Determine asar bundle contents
-  - [x] Identify which files go inside the asar (Electron main/preload scripts,
+  - [ ] Compare `electron-builder` vs `@electron-forge/cli`
+  - [ ] Prefer `electron-builder` if it supports Nx's build output structure naturally
+  - [ ] Document the chosen tool and rationale in Dev Notes
+
+- [ ] Task 3: Determine asar bundle contents
+
+  - [ ] Identify which files go inside the asar (Electron main/preload scripts,
         Fastify server bundle, Angular browser build)
-  - [x] Identify which files must be outside the asar (SQLite `.db` file, Prisma
+  - [ ] Identify which files must be outside the asar (SQLite `.db` file, Prisma
         migration files, any write-able resources)
 
-- [x] Task 4: Design the database path strategy
-  - [x] Determine the `userData` path via `app.getPath('userData')`
-  - [x] Design how `DATABASE_URL` is set before the server forks
-  - [x] Consider first-launch DB creation (copy seed DB from resources?) vs create-on-migrate
+- [ ] Task 4: Design the database path strategy
 
-- [x] Task 5: Design the Prisma migration strategy
-  - [x] Decide timing: Electron main process runs migration before forking the server
-  - [x] Determine how `prisma migrate deploy` is invoked without `node_modules/.bin/prisma`
+  - [ ] Determine the `userData` path via `app.getPath('userData')`
+  - [ ] Design how `DATABASE_URL` is set before the server forks
+  - [ ] Consider first-launch DB creation (copy seed DB from resources?) vs create-on-migrate
+
+- [ ] Task 5: Design the Prisma migration strategy
+
+  - [ ] Decide timing: Electron main process runs migration before forking the server
+  - [ ] Determine how `prisma migrate deploy` is invoked without `node_modules/.bin/prisma`
         (use the bundled Prisma binary path relative to `process.resourcesPath`)
-  - [x] Document in Dev Notes
+  - [ ] Document in Dev Notes
 
-- [x] Task 6: Confirm `pnpm all` passes (no code changes)
+- [ ] Task 6: Confirm `pnpm all` passes (no code changes)
 
 ## Dev Notes
 
@@ -84,6 +89,7 @@ So that Stories 91.2–91.4 each have an unambiguous implementation target.
 ### Expected Packaging Tool: electron-builder
 
 `electron-builder` is the expected choice because:
+
 1. Wide Nx community adoption
 2. Supports asar bundling, auto-updater, and all three target platforms natively
 3. Does not require a separate boilerplate (`@electron-forge` requires migrating the project
@@ -92,12 +98,14 @@ So that Stories 91.2–91.4 each have an unambiguous implementation target.
 ### Expected Asar Contents
 
 Inside asar:
+
 - `dist/apps/electron/main.js` (compiled Electron main process)
 - `dist/apps/electron/preload.js` (compiled preload script)
 - `dist/apps/server/` (compiled Fastify server — the entire directory)
 - `dist/apps/dms-material/browser/` (compiled Angular app)
 
 Outside asar (in resources/):
+
 - Prisma migration files (`prisma/migrations/`)
 - Prisma schema (`prisma/schema.prisma`)
 - Prisma query engine binary

--- a/apps/electron/PACKAGING.md
+++ b/apps/electron/PACKAGING.md
@@ -1,0 +1,200 @@
+# Electron Packaging Research
+
+> **Story 91.1** — Research and Document the Electron Packaging Approach
+> This document is the primary deliverable. It informs Stories 91.2–91.4.
+
+---
+
+## 1. Selected Packaging Tool: `electron-builder`
+
+### Decision
+
+`electron-builder` is selected over `@electron-forge/cli`.
+
+### Rationale
+
+| Criterion | `electron-builder` | `@electron-forge/cli` |
+|-----------|-------------------|-----------------------|
+| Nx compatibility | Drop-in: reads existing `dist/` output; no project restructure required | Requires migrating to Forge's own build pipeline (conflicts with Nx targets) |
+| asar support | Native; configurable `files` globs | Native |
+| Auto-updater | `electron-updater` companion package | Built-in but tied to Forge workflow |
+| Cross-platform targets | deb, rpm, AppImage, dmg, pkg, nsis, portable | Same, but more boilerplate |
+| Community / Nx adoption | Dominant pattern in Nx + Electron monorepos | Less common with Nx |
+| Configuration | Single `electron-builder.yml` alongside `project.json` | `forge.config.js` inside app directory |
+
+`electron-builder` can be bolted onto the existing setup by adding a `package` Nx target that
+runs `electron-builder --config electron-builder.yml` after the existing `build` target. No
+changes to `project.json`'s `build`, `start`, or `test` targets are required.
+
+---
+
+## 2. Asar Bundle Contents
+
+The asar is an append-only virtual file-system embedded inside the packaged app. Write-able
+resources and files that must survive app upgrades must live **outside** the asar.
+
+### Inside the asar
+
+| Artefact | Source path | Notes |
+|----------|-------------|-------|
+| Electron main process | `apps/electron/dist/main.js` | Compiled by `electron:build` (`tsc`) |
+| Electron preload script | `apps/electron/dist/preload.js` | Compiled by `electron:build` (`tsc`) |
+| Fastify server bundle | `dist/apps/server/` (entire directory) | Compiled by `server:build` |
+| Angular browser app | `dist/apps/dms-material/browser/` (entire directory) | Compiled by `dms-material:build` |
+
+### Outside the asar (in `resources/`)
+
+| Artefact | Destination in package | Reason |
+|----------|------------------------|--------|
+| Prisma migration files | `resources/prisma/migrations/` | `prisma migrate deploy` reads SQL files at runtime |
+| Prisma schema | `resources/prisma/schema.prisma` | Required by `migrate deploy` |
+| Prisma query engine binary | `resources/` (auto-placed by `electron-builder`) | Native binary; must not be inside asar |
+| SQLite database file | `app.getPath('userData')/dms.db` | Created/written at runtime; user data |
+
+> **Key constraint**: Files inside the asar are read-only. The SQLite `.db` file is created fresh
+> in `userData` on first launch via `prisma migrate deploy` and must never be placed inside the
+> asar.
+
+---
+
+## 3. `DATABASE_URL` Strategy
+
+### Platform-specific `userData` paths
+
+| Platform | `app.getPath('userData')` default |
+|----------|------------------------------------|
+| Linux | `~/.config/<app-name>` |
+| macOS | `~/Library/Application Support/<app-name>` |
+| Windows | `%APPDATA%\<app-name>` |
+
+### Implementation pattern
+
+The `DATABASE_URL` environment variable must be set in the Electron **main process** before the
+Fastify server is forked, so the forked child process inherits it automatically.
+
+```typescript
+// In apps/electron/src/main.ts — init() function, before startServer()
+import { app } from 'electron';
+import path from 'path';
+
+const userDataPath = app.getPath('userData');
+const dbPath = path.join(userDataPath, 'dms.db');
+process.env['DATABASE_URL'] = `file:${dbPath}`;
+```
+
+The existing `startServer()` in `main.ts` already spreads `process.env` into the fork env:
+
+```typescript
+serverProcess = fork(serverPath, [], {
+  env: { ...process.env, PORT: String(port) },
+  // ...
+});
+```
+
+Because `DATABASE_URL` is set on `process.env` before the fork, the server process inherits it
+without any additional changes. The server's `initializeDatabaseUrl()` in
+`apps/server/src/utils/aws-config.ts` already reads `process.env.DATABASE_URL` as the local
+dev/non-AWS fallback path, so no server-side changes are needed.
+
+### First-launch database creation
+
+On first launch (no `dms.db` in `userData`) `prisma migrate deploy` creates the database file and
+applies all migrations. No seed DB copy from resources is needed — the schema migrations are
+sufficient to produce a working empty database.
+
+---
+
+## 4. Prisma Migration Strategy
+
+### Timing
+
+Migrations run in the **Electron main process**, before `startServer()` forks the Fastify
+process. This guarantees that the database schema is current before any API requests are served.
+
+```
+init()
+  ├─ findAvailablePort()
+  ├─ set DATABASE_URL = userData/dms.db      ← new step (Story 91.2)
+  ├─ runMigrations()                          ← new step (Story 91.3)
+  │    └─ prisma migrate deploy
+  ├─ startServer(port)
+  ├─ healthCheck(port)
+  └─ app.whenReady() → createWindow(port)
+```
+
+### Invoking `prisma migrate deploy` without `node_modules/.bin/prisma`
+
+In a packaged app, `node_modules` is not present. `electron-builder` can be configured to include
+the Prisma CLI binary in `resources/`. The migration invocation uses `child_process.execFile` (or
+`spawnSync`) with the bundled binary path:
+
+```typescript
+import { execFileSync } from 'child_process';
+import path from 'path';
+
+function runMigrations(): void {
+  // process.resourcesPath = the resources/ directory outside the asar
+  const prismaBin = path.join(process.resourcesPath, 'prisma');
+  const schemaPath = path.join(process.resourcesPath, 'prisma', 'schema.prisma');
+
+  execFileSync(prismaBin, ['migrate', 'deploy', `--schema=${schemaPath}`], {
+    env: {
+      ...process.env,
+      // Ensure the query engine binary is discoverable
+      PRISMA_QUERY_ENGINE_BINARY: path.join(process.resourcesPath, 'query_engine'),
+    },
+    stdio: 'inherit',
+  });
+}
+```
+
+> **Note**: The exact binary names (`prisma`, `query_engine`) are platform-dependent.
+> `electron-builder` configuration in Story 91.3 will pin the correct binary names and paths.
+
+### Migration file location in `electron-builder` config
+
+```yaml
+# electron-builder.yml (to be created in Story 91.2)
+extraResources:
+  - from: prisma/migrations
+    to: prisma/migrations
+  - from: prisma/schema.prisma
+    to: prisma/schema.prisma
+  - from: node_modules/.prisma/client/libquery_engine-*
+    to: ./
+    filter:
+      - "**"
+```
+
+---
+
+## 5. Per-Platform Output Targets
+
+| Platform | Target format | Notes |
+|----------|--------------|-------|
+| Linux | `AppImage` (primary), `deb` | AppImage is self-contained; deb for Debian/Ubuntu distribution |
+| macOS | `dmg` | Standard macOS install experience |
+| Windows | `nsis` | Standard Windows installer |
+
+All three targets are supported natively by `electron-builder` without additional plugins.
+
+---
+
+## 6. Current Build Gap (baseline from Epic 83)
+
+As confirmed in `apps/electron/README.md`:
+
+> _"The repository does not currently include `electron-builder`, `electron-packager`, or
+> equivalent packaging configuration. Today, `electron:build` is a compile-only build, not a
+> true distributable packaging step."_
+
+The existing Nx targets (`build`, `start`, `test`) are **not modified** by this story. Story 91.2
+will add the `package` target and `electron-builder.yml` configuration.
+
+---
+
+## 7. `pnpm all` Verification
+
+No production code was changed as part of this research story. The `pnpm all` command (lint,
+build, test) passes without modification — the findings above inform implementation in Stories
+91.2–91.4 only.

--- a/apps/electron/PACKAGING.md
+++ b/apps/electron/PACKAGING.md
@@ -63,9 +63,9 @@ resources and files that must survive app upgrades must live **outside** the asa
 
 | Platform | `app.getPath('userData')` default          |
 | -------- | ------------------------------------------ |
-| Linux    | `~/.config/<app-name>`                     |
-| macOS    | `~/Library/Application Support/<app-name>` |
-| Windows  | `%APPDATA%\<app-name>`                     |
+| Linux    | `~/.config/{app-name}`                     |
+| macOS    | `~/Library/Application Support/{app-name}` |
+| Windows  | `%APPDATA%\{app-name}`                     |
 
 ### Implementation pattern
 
@@ -111,7 +111,7 @@ sufficient to produce a working empty database.
 Migrations run in the **Electron main process**, before `startServer()` forks the Fastify
 process. This guarantees that the database schema is current before any API requests are served.
 
-```
+```text
 init()
   ├─ findAvailablePort()
   ├─ set DATABASE_URL = userData/dms.db      ← new step (Story 91.2)

--- a/apps/electron/PACKAGING.md
+++ b/apps/electron/PACKAGING.md
@@ -13,14 +13,14 @@
 
 ### Rationale
 
-| Criterion | `electron-builder` | `@electron-forge/cli` |
-|-----------|-------------------|-----------------------|
-| Nx compatibility | Drop-in: reads existing `dist/` output; no project restructure required | Requires migrating to Forge's own build pipeline (conflicts with Nx targets) |
-| asar support | Native; configurable `files` globs | Native |
-| Auto-updater | `electron-updater` companion package | Built-in but tied to Forge workflow |
-| Cross-platform targets | deb, rpm, AppImage, dmg, pkg, nsis, portable | Same, but more boilerplate |
-| Community / Nx adoption | Dominant pattern in Nx + Electron monorepos | Less common with Nx |
-| Configuration | Single `electron-builder.yml` alongside `project.json` | `forge.config.js` inside app directory |
+| Criterion               | `electron-builder`                                                      | `@electron-forge/cli`                                                        |
+| ----------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| Nx compatibility        | Drop-in: reads existing `dist/` output; no project restructure required | Requires migrating to Forge's own build pipeline (conflicts with Nx targets) |
+| asar support            | Native; configurable `files` globs                                      | Native                                                                       |
+| Auto-updater            | `electron-updater` companion package                                    | Built-in but tied to Forge workflow                                          |
+| Cross-platform targets  | deb, rpm, AppImage, dmg, pkg, nsis, portable                            | Same, but more boilerplate                                                   |
+| Community / Nx adoption | Dominant pattern in Nx + Electron monorepos                             | Less common with Nx                                                          |
+| Configuration           | Single `electron-builder.yml` alongside `project.json`                  | `forge.config.js` inside app directory                                       |
 
 `electron-builder` can be bolted onto the existing setup by adding a `package` Nx target that
 runs `electron-builder --config electron-builder.yml` after the existing `build` target. No
@@ -35,21 +35,21 @@ resources and files that must survive app upgrades must live **outside** the asa
 
 ### Inside the asar
 
-| Artefact | Source path | Notes |
-|----------|-------------|-------|
-| Electron main process | `apps/electron/dist/main.js` | Compiled by `electron:build` (`tsc`) |
-| Electron preload script | `apps/electron/dist/preload.js` | Compiled by `electron:build` (`tsc`) |
-| Fastify server bundle | `dist/apps/server/` (entire directory) | Compiled by `server:build` |
-| Angular browser app | `dist/apps/dms-material/browser/` (entire directory) | Compiled by `dms-material:build` |
+| Artefact                | Source path                                          | Notes                                |
+| ----------------------- | ---------------------------------------------------- | ------------------------------------ |
+| Electron main process   | `apps/electron/dist/main.js`                         | Compiled by `electron:build` (`tsc`) |
+| Electron preload script | `apps/electron/dist/preload.js`                      | Compiled by `electron:build` (`tsc`) |
+| Fastify server bundle   | `dist/apps/server/` (entire directory)               | Compiled by `server:build`           |
+| Angular browser app     | `dist/apps/dms-material/browser/` (entire directory) | Compiled by `dms-material:build`     |
 
 ### Outside the asar (in `resources/`)
 
-| Artefact | Destination in package | Reason |
-|----------|------------------------|--------|
-| Prisma migration files | `resources/prisma/migrations/` | `prisma migrate deploy` reads SQL files at runtime |
-| Prisma schema | `resources/prisma/schema.prisma` | Required by `migrate deploy` |
-| Prisma query engine binary | `resources/` (auto-placed by `electron-builder`) | Native binary; must not be inside asar |
-| SQLite database file | `app.getPath('userData')/dms.db` | Created/written at runtime; user data |
+| Artefact                   | Destination in package                           | Reason                                             |
+| -------------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| Prisma migration files     | `resources/prisma/migrations/`                   | `prisma migrate deploy` reads SQL files at runtime |
+| Prisma schema              | `resources/prisma/schema.prisma`                 | Required by `migrate deploy`                       |
+| Prisma query engine binary | `resources/` (auto-placed by `electron-builder`) | Native binary; must not be inside asar             |
+| SQLite database file       | `app.getPath('userData')/dms.db`                 | Created/written at runtime; user data              |
 
 > **Key constraint**: Files inside the asar are read-only. The SQLite `.db` file is created fresh
 > in `userData` on first launch via `prisma migrate deploy` and must never be placed inside the
@@ -61,11 +61,11 @@ resources and files that must survive app upgrades must live **outside** the asa
 
 ### Platform-specific `userData` paths
 
-| Platform | `app.getPath('userData')` default |
-|----------|------------------------------------|
-| Linux | `~/.config/<app-name>` |
-| macOS | `~/Library/Application Support/<app-name>` |
-| Windows | `%APPDATA%\<app-name>` |
+| Platform | `app.getPath('userData')` default          |
+| -------- | ------------------------------------------ |
+| Linux    | `~/.config/<app-name>`                     |
+| macOS    | `~/Library/Application Support/<app-name>` |
+| Windows  | `%APPDATA%\<app-name>`                     |
 
 ### Implementation pattern
 
@@ -163,18 +163,18 @@ extraResources:
   - from: node_modules/.prisma/client/libquery_engine-*
     to: ./
     filter:
-      - "**"
+      - '**'
 ```
 
 ---
 
 ## 5. Per-Platform Output Targets
 
-| Platform | Target format | Notes |
-|----------|--------------|-------|
-| Linux | `AppImage` (primary), `deb` | AppImage is self-contained; deb for Debian/Ubuntu distribution |
-| macOS | `dmg` | Standard macOS install experience |
-| Windows | `nsis` | Standard Windows installer |
+| Platform | Target format               | Notes                                                          |
+| -------- | --------------------------- | -------------------------------------------------------------- |
+| Linux    | `AppImage` (primary), `deb` | AppImage is self-contained; deb for Debian/Ubuntu distribution |
+| macOS    | `dmg`                       | Standard macOS install experience                              |
+| Windows  | `nsis`                      | Standard Windows installer                                     |
 
 All three targets are supported natively by `electron-builder` without additional plugins.
 


### PR DESCRIPTION
## Summary

Researches and documents the Electron packaging approach to give Stories 91.2–91.4 unambiguous implementation targets. No production code is changed; all deliverables are documentation.

**Key decisions recorded in `apps/electron/PACKAGING.md`:**

- **Packaging tool:** `electron-builder` chosen over `@electron-forge/cli` — bolts onto the existing Nx setup without project-structure migration, supports asar, auto-updater, and all three target platforms natively.
- **Asar bundle contents:** Electron main/preload scripts, the compiled Fastify server bundle (`dist/apps/server/`), and the compiled Angular app (`dist/apps/dms-material/browser/`) go inside the asar. Prisma migration files, schema, and the query-engine binary stay outside so they remain readable at runtime.
- **Database path:** SQLite `.db` file lives in `app.getPath('userData')` (platform-native: `~/.config` on Linux, `~/Library/Application Support` on macOS, `%APPDATA%` on Windows). `DATABASE_URL` is set in the Electron main process before forking the Fastify server so the child process inherits it.
- **Prisma migration timing:** `prisma migrate deploy` runs in the Electron main process before the server fork, using the Prisma binary located relative to `process.resourcesPath` (no dev-dependency required in the packaged app).

## Testing

- `pnpm all` passes with no test changes (no production code was modified).

Closes #1178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Electron packaging research document detailing build configuration approach, database initialization and migration strategy, asset bundling and externalization guidance, first-launch behavior specifications, Prisma CLI integration for production use, environment variable setup procedures, and recommended per-platform packaging targets including AppImage, deb, dmg, and nsis formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->