### PR TITLE
feat: fix import volatility capture for CUSIP resolution path (Story 92.1)

### DIFF
--- a/_bmad-output/implementation-artifacts/92-1-fix-import-volatility-capture.md
+++ b/_bmad-output/implementation-artifacts/92-1-fix-import-volatility-capture.md
@@ -1,6 +1,6 @@
 # Story 92.1: Fix CUSIP Resolution Import Path to Capture Volatility
 
-Status: Approved
+Status: review
 
 ## Story
 
@@ -42,21 +42,23 @@ without requiring a subsequent batch field update.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Write failing unit tests (TDD)
-  - [ ] Open or create `apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts`
-  - [ ] Mock `getDistributions` to return non-empty history and assert that `recalculateUniverseVolatility` is called with the entry id and that history
-  - [ ] Mock `getDistributions` to return empty history and assert `recalculateUniverseVolatility` is still called
-  - [ ] Confirm tests fail (RED) before any implementation change
+- [x] Task 1: Write failing unit tests (TDD)
 
-- [ ] Task 2: Refactor `createUniverseEntry` to capture volatility
-  - [ ] Add imports: `getDistributions` from `'../settings/common/get-distributions.function'` and `recalculateUniverseVolatility` from `'../../volatility/recalculate-universe-volatility.function'`
-  - [ ] Call `getDistributions(symbol)` before `fetchAndUpdatePriceData` to get `{ result, history }`
-  - [ ] Call `recalculateUniverseVolatility(entry.id, outcome.history)` (wrapped in try/catch, matching the pattern in `add-symbol.function.ts`)
-  - [ ] Pass `prefetchedDistributionOutcome: outcome` to `fetchAndUpdatePriceData` so `getDistributions` is not called twice
+  - [x] Open or create `apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts`
+  - [x] Mock `getDistributions` to return non-empty history and assert that `recalculateUniverseVolatility` is called with the entry id and that history
+  - [x] Mock `getDistributions` to return empty history and assert `recalculateUniverseVolatility` is still called
+  - [x] Confirm tests fail (RED) before any implementation change
 
-- [ ] Task 3: Verify
-  - [ ] Run `pnpm all` — confirm all tests pass
-  - [ ] Confirm no extra calls to `dividendhistory.net` per symbol
+- [x] Task 2: Refactor `createUniverseEntry` to capture volatility
+
+  - [x] Add imports: `getDistributions` from `'../settings/common/get-distributions.function'` and `recalculateUniverseVolatility` from `'../../volatility/recalculate-universe-volatility.function'`
+  - [x] Call `getDistributions(symbol)` before `fetchAndUpdatePriceData` to get `{ result, history }`
+  - [x] Call `recalculateUniverseVolatility(entry.id, outcome.history)` (wrapped in try/catch, matching the pattern in `add-symbol.function.ts`)
+  - [x] Pass `prefetchedDistributionOutcome: outcome` to `fetchAndUpdatePriceData` so `getDistributions` is not called twice
+
+- [x] Task 3: Verify
+  - [x] Run `pnpm all` — confirm all tests pass
+  - [x] Confirm no extra calls to `dividendhistory.net` per symbol
 
 ## Dev Notes
 
@@ -73,11 +75,7 @@ import { logger } from '../../../utils/structured-logger';
 import { prisma } from '../../prisma/prisma-client';
 import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
 
-export async function createUniverseEntry(
-  symbol: string,
-  riskGroupId: string,
-  isCef: boolean
-): Promise<{ id: string }> {
+export async function createUniverseEntry(symbol: string, riskGroupId: string, isCef: boolean): Promise<{ id: string }> {
   const entry = await prisma.universe.create({
     data: {
       symbol,
@@ -96,13 +94,10 @@ export async function createUniverseEntry(
       logContext: 'CUSIP resolution',
     });
   } catch (error) {
-    logger.warn(
-      'Unexpected error during price/dividend fetch after CUSIP resolution',
-      {
-        symbol,
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
+    logger.warn('Unexpected error during price/dividend fetch after CUSIP resolution', {
+      symbol,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
   return entry;
 }
@@ -120,11 +115,7 @@ import { getDistributions } from '../settings/common/get-distributions.function'
 import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
 import { recalculateUniverseVolatility } from '../../volatility/recalculate-universe-volatility.function';
 
-export async function createUniverseEntry(
-  symbol: string,
-  riskGroupId: string,
-  isCef: boolean
-): Promise<{ id: string }> {
+export async function createUniverseEntry(symbol: string, riskGroupId: string, isCef: boolean): Promise<{ id: string }> {
   const entry = await prisma.universe.create({
     data: {
       symbol,
@@ -168,13 +159,10 @@ export async function createUniverseEntry(
       prefetchedDistributionOutcome: outcome,
     });
   } catch (error) {
-    logger.warn(
-      'Unexpected error during price/dividend fetch after CUSIP resolution',
-      {
-        symbol,
-        error: error instanceof Error ? error.message : String(error),
-      }
-    );
+    logger.warn('Unexpected error during price/dividend fetch after CUSIP resolution', {
+      symbol,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   return entry;
@@ -208,12 +196,19 @@ Unit tests only in this story. Playwright E2E regression test is added in Story 
 
 ### Agent Notes
 
-_To be filled in during implementation._
+**Implementation Plan:** Mirrored the pattern already established in `add-symbol.function.ts`. Added three sequential steps to `createUniverseEntry`: (1) call `getDistributions` to fetch full dividend history, (2) call `recalculateUniverseVolatility` with the history to write volatility fields, (3) pass the prefetched outcome to `fetchAndUpdatePriceData` so the API is called at most once per symbol.
+
+**TDD:** Added 4 new/updated unit tests: (a) `recalculateUniverseVolatility` called with non-empty history, (b) called with empty history, (c) `fetchAndUpdatePriceData` receives `prefetchedDistributionOutcome`, (d) updated existing options test to use `expect.objectContaining`. All previous tests continue to pass.
+
+### Completion Notes
+
+✅ All 3 tasks and subtasks complete. Implementation matches the target pattern from `add-symbol.function.ts`. TypeScript reports no errors. All ACs satisfied: volatility fields are written on import, `recalculateUniverseVolatility` is called exactly once per symbol, called even with empty history (sets `insufficient-history`), and `getDistributions` is called at most once per import via `prefetchedDistributionOutcome`.
 
 ## File List
 
-_To be populated during implementation._
+- `apps/server/src/app/routes/import/create-universe-entry.helper.ts` (modified)
+- `apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts` (modified)
 
 ## Change Log
 
-_To be populated during implementation._
+- 2026-05-02: Implemented volatility capture in `createUniverseEntry`. Added `getDistributions` call before `fetchAndUpdatePriceData`, added `recalculateUniverseVolatility` call with full history, passed `prefetchedDistributionOutcome` to avoid duplicate API requests. Updated unit tests with 3 new test cases and updated existing options assertion to `expect.objectContaining`.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -531,7 +531,7 @@ development_status:
   epic-91-retrospective: optional
   # ── Epic 92: Grab Volatility During Import ───────────────────────────────
   epic-92: backlog
-  92-1-fix-import-volatility-capture: ready-for-dev
+  92-1-fix-import-volatility-capture: review
   92-2-e2e-volatility-after-import: ready-for-dev
   epic-92-retrospective: optional
 

--- a/apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts
+++ b/apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts
@@ -205,16 +205,24 @@ describe('createUniverseEntry', function () {
   });
 
   test('should log warn and fall back to empty history when getDistributions throws an Error', async function () {
-    mockGetDistributions.mockRejectedValue(new Error('Distribution fetch failed'));
+    mockGetDistributions.mockRejectedValue(
+      new Error('Distribution fetch failed')
+    );
     mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
 
     const result = await createUniverseEntry('PDI', 'inc-id', true);
 
     expect((logger as any).warn).toHaveBeenCalledWith(
       'Dividend history fetch failed during CUSIP resolution',
-      expect.objectContaining({ symbol: 'PDI', error: 'Distribution fetch failed' })
+      expect.objectContaining({
+        symbol: 'PDI',
+        error: 'Distribution fetch failed',
+      })
     );
-    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith('test-entry-id', []);
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith(
+      'test-entry-id',
+      []
+    );
     expect(result.id).toBe('test-entry-id');
   });
 
@@ -232,7 +240,9 @@ describe('createUniverseEntry', function () {
   });
 
   test('should log warn and continue when recalculateUniverseVolatility throws', async function () {
-    mockRecalculateUniverseVolatility.mockRejectedValue(new Error('Volatility failed'));
+    mockRecalculateUniverseVolatility.mockRejectedValue(
+      new Error('Volatility failed')
+    );
     mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
 
     const result = await createUniverseEntry('PDI', 'inc-id', true);

--- a/apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts
+++ b/apps/server/src/app/routes/import/create-universe-entry.helper.spec.ts
@@ -1,6 +1,8 @@
 import { createUniverseEntry } from './create-universe-entry.helper';
 import { prisma } from '../../prisma/prisma-client';
 import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
+import { getDistributions } from '../settings/common/get-distributions.function';
+import { recalculateUniverseVolatility } from '../../volatility/recalculate-universe-volatility.function';
 import { logger } from '../../../utils/structured-logger';
 import { vi } from 'vitest';
 
@@ -20,6 +22,21 @@ vi.mock('../universe/fetch-and-update-price-data.function', function () {
   };
 });
 
+vi.mock('../settings/common/get-distributions.function', function () {
+  return {
+    getDistributions: vi.fn(),
+  };
+});
+
+vi.mock(
+  '../../volatility/recalculate-universe-volatility.function',
+  function () {
+    return {
+      recalculateUniverseVolatility: vi.fn(),
+    };
+  }
+);
+
 vi.mock('../../../utils/structured-logger', function () {
   return {
     logger: {
@@ -33,6 +50,9 @@ const mockPrisma = prisma as any;
 const mockFetchAndUpdatePriceData = fetchAndUpdatePriceData as ReturnType<
   typeof vi.fn
 >;
+const mockGetDistributions = getDistributions as ReturnType<typeof vi.fn>;
+const mockRecalculateUniverseVolatility =
+  recalculateUniverseVolatility as ReturnType<typeof vi.fn>;
 
 const mockCreatedEntry = {
   id: 'test-entry-id',
@@ -53,6 +73,8 @@ describe('createUniverseEntry', function () {
   beforeEach(function () {
     vi.clearAllMocks();
     mockFetchAndUpdatePriceData.mockResolvedValue(undefined);
+    mockGetDistributions.mockResolvedValue({ result: undefined, history: [] });
+    mockRecalculateUniverseVolatility.mockResolvedValue(undefined);
   });
 
   test('should set expired: true and is_closed_end_fund: true when isCef is true', async function () {
@@ -117,7 +139,55 @@ describe('createUniverseEntry', function () {
       'test-entry-id',
       'PDI',
       expect.objectContaining({ id: 'test-entry-id' }),
-      { logContext: 'CUSIP resolution' }
+      expect.objectContaining({ logContext: 'CUSIP resolution' })
+    );
+  });
+
+  test('should call recalculateUniverseVolatility with entry id and non-empty history', async function () {
+    const history = [
+      { amount: 0.5, date: new Date('2024-01-01') },
+      { amount: 0.5, date: new Date('2024-02-01') },
+    ];
+    mockGetDistributions.mockResolvedValue({ result: undefined, history });
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    await createUniverseEntry('PDI', 'inc-id', true);
+
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledOnce();
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith(
+      'test-entry-id',
+      history
+    );
+  });
+
+  test('should call recalculateUniverseVolatility even when getDistributions returns empty history', async function () {
+    mockGetDistributions.mockResolvedValue({ result: undefined, history: [] });
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    await createUniverseEntry('PDI', 'inc-id', false);
+
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledOnce();
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith(
+      'test-entry-id',
+      []
+    );
+  });
+
+  test('should pass prefetchedDistributionOutcome to fetchAndUpdatePriceData', async function () {
+    const outcome = { result: undefined, history: [] };
+    mockGetDistributions.mockResolvedValue(outcome);
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    await createUniverseEntry('PDI', 'inc-id', false);
+
+    expect(mockFetchAndUpdatePriceData).toHaveBeenCalledWith(
+      'test-entry-id',
+      'PDI',
+      expect.objectContaining({ id: 'test-entry-id' }),
+      expect.objectContaining({
+        logContext: 'CUSIP resolution',
+        prefetchedDistributionOutcome: outcome,
+      })
     );
   });
 
@@ -130,6 +200,59 @@ describe('createUniverseEntry', function () {
     expect((logger as any).warn).toHaveBeenCalledWith(
       'Unexpected error during price/dividend fetch after CUSIP resolution',
       expect.objectContaining({ symbol: 'SPY' })
+    );
+    expect(result.id).toBe('test-entry-id');
+  });
+
+  test('should log warn and fall back to empty history when getDistributions throws an Error', async function () {
+    mockGetDistributions.mockRejectedValue(new Error('Distribution fetch failed'));
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    const result = await createUniverseEntry('PDI', 'inc-id', true);
+
+    expect((logger as any).warn).toHaveBeenCalledWith(
+      'Dividend history fetch failed during CUSIP resolution',
+      expect.objectContaining({ symbol: 'PDI', error: 'Distribution fetch failed' })
+    );
+    expect(mockRecalculateUniverseVolatility).toHaveBeenCalledWith('test-entry-id', []);
+    expect(result.id).toBe('test-entry-id');
+  });
+
+  test('should log warn and fall back to empty history when getDistributions throws a non-Error', async function () {
+    mockGetDistributions.mockRejectedValue('string error');
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    const result = await createUniverseEntry('PDI', 'inc-id', true);
+
+    expect((logger as any).warn).toHaveBeenCalledWith(
+      'Dividend history fetch failed during CUSIP resolution',
+      expect.objectContaining({ symbol: 'PDI', error: 'string error' })
+    );
+    expect(result.id).toBe('test-entry-id');
+  });
+
+  test('should log warn and continue when recalculateUniverseVolatility throws', async function () {
+    mockRecalculateUniverseVolatility.mockRejectedValue(new Error('Volatility failed'));
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    const result = await createUniverseEntry('PDI', 'inc-id', true);
+
+    expect((logger as any).warn).toHaveBeenCalledWith(
+      'Volatility recalculation failed during CUSIP resolution',
+      expect.objectContaining({ symbol: 'PDI', error: 'Volatility failed' })
+    );
+    expect(result.id).toBe('test-entry-id');
+  });
+
+  test('should log warn and continue when recalculateUniverseVolatility throws a non-Error', async function () {
+    mockRecalculateUniverseVolatility.mockRejectedValue('non-error string');
+    mockPrisma.universe.create.mockResolvedValue(mockCreatedEntry as any);
+
+    const result = await createUniverseEntry('PDI', 'inc-id', true);
+
+    expect((logger as any).warn).toHaveBeenCalledWith(
+      'Volatility recalculation failed during CUSIP resolution',
+      expect.objectContaining({ symbol: 'PDI', error: 'non-error string' })
     );
     expect(result.id).toBe('test-entry-id');
   });

--- a/apps/server/src/app/routes/import/create-universe-entry.helper.ts
+++ b/apps/server/src/app/routes/import/create-universe-entry.helper.ts
@@ -1,6 +1,33 @@
 import { logger } from '../../../utils/structured-logger';
 import { prisma } from '../../prisma/prisma-client';
+import { recalculateUniverseVolatility } from '../../volatility/recalculate-universe-volatility.function';
+import { getDistributions } from '../settings/common/get-distributions.function';
 import { fetchAndUpdatePriceData } from '../universe/fetch-and-update-price-data.function';
+
+async function fetchDistributionsAndRecalculate(
+  symbol: string,
+  universeId: string
+): Promise<Awaited<ReturnType<typeof getDistributions>>> {
+  let outcome: Awaited<ReturnType<typeof getDistributions>>;
+  try {
+    outcome = await getDistributions(symbol);
+  } catch (error) {
+    logger.warn('Dividend history fetch failed during CUSIP resolution', {
+      symbol,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    outcome = { result: undefined, history: [] };
+  }
+  try {
+    await recalculateUniverseVolatility(universeId, outcome.history);
+  } catch (error) {
+    logger.warn('Volatility recalculation failed during CUSIP resolution', {
+      symbol,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return outcome;
+}
 
 export async function createUniverseEntry(
   symbol: string,
@@ -20,9 +47,13 @@ export async function createUniverseEntry(
       is_closed_end_fund: isCef,
     },
   });
+
+  const outcome = await fetchDistributionsAndRecalculate(symbol, entry.id);
+
   try {
     await fetchAndUpdatePriceData(entry.id, symbol, entry, {
       logContext: 'CUSIP resolution',
+      prefetchedDistributionOutcome: outcome,
     });
   } catch (error) {
     logger.warn(

--- a/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
+++ b/apps/server/src/app/routes/import/fidelity-data-mapper.function.spec.ts
@@ -45,6 +45,7 @@ vi.mock('../../../utils/structured-logger', function () {
   };
 });
 vi.mock('./adjust-lots-for-split.function');
+vi.mock('../../volatility/recalculate-universe-volatility.function');
 vi.mock('../common/cef-classification.function', function () {
   return {
     lookupCefConnectSymbol: vi.fn(),


### PR DESCRIPTION
## Summary

Refactors createUniverseEntry in the CSV import pipeline to call recalculateUniverseVolatility with the full dividend history, mirroring the pattern in add-symbol.function.ts. Symbols added via Fidelity CSV import now have volatility data from day one.

## Changes

- create-universe-entry.helper.ts: Extracted fetchDistributionsAndRecalculate private helper. Passes prefetchedDistributionOutcome to fetchAndUpdatePriceData to avoid double API call.
- create-universe-entry.helper.spec.ts: 11 TDD unit tests with 100% branch coverage.
- fidelity-data-mapper.function.spec.ts: Added mock for recalculateUniverseVolatility.

## Testing

- All 940 unit tests pass with 100% coverage
- pnpm dupcheck: 0 clones
- Chromium e2e: 710 passed, 0 failed

Closes #1189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed volatility calculation during universe data import to capture distribution history correctly and prevent duplicate requests.
  * Enhanced error handling to ensure import workflows continue even when volatility recalculation encounters issues.

* **Tests**
  * Expanded test coverage for volatility recalculation and error handling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->