### PR TITLE
feat(server): add volatility recalculation to batch field update pipeline

### DIFF
--- a/apps/server/src/app/routes/settings/update/index.spec.ts
+++ b/apps/server/src/app/routes/settings/update/index.spec.ts
@@ -4,6 +4,7 @@ import type { StructuredLogger } from '../../../../utils/structured-logger';
 
 // Hoisted mocks — created before module resolution
 const h = vi.hoisted(() => ({
+  prismaFindMany: vi.fn(),
   prismaUpdate: vi.fn().mockResolvedValue({}),
   getDistributions: vi.fn(),
   getLastPrice: vi.fn(),
@@ -13,7 +14,7 @@ const h = vi.hoisted(() => ({
 vi.mock('../../../prisma/prisma-client', () => ({
   prisma: {
     universe: {
-      findMany: vi.fn(),
+      findMany: h.prismaFindMany,
       update: h.prismaUpdate,
     },
   },
@@ -139,5 +140,44 @@ describe('settings/update route — volatility recalculation', () => {
     // Assert
     expect(result.success).toBe(false);
     expect(result.error).toContain('Volatility calculation failed');
+  });
+
+  it('updateAllUniverses should continue processing when one volatility recalculation fails', async () => {
+    // Arrange — two universes; first fails volatility, second succeeds
+    const mockUniverse2 = {
+      ...mockUniverse,
+      id: 'test-universe-id-2',
+      symbol: 'TST2',
+    };
+
+    h.prismaFindMany.mockResolvedValue([mockUniverse, mockUniverse2]);
+
+    // Both universes return distributions without errors
+    h.getLastPrice.mockResolvedValue(155.0);
+    h.getDistributions.mockResolvedValue({
+      result: {
+        distribution: 0.26,
+        distributions_per_year: 4,
+        ex_date: new Date('2024-02-01'),
+      },
+      history: mockHistory,
+    });
+
+    // First universe: volatility fails; second: succeeds
+    h.recalculateUniverseVolatility
+      .mockRejectedValueOnce(new Error('Volatility calculation failed'))
+      .mockResolvedValueOnce(undefined);
+
+    // Act
+    const summary = await testExports.updateAllUniverses(mockLogger);
+
+    // Assert — batch continues; one failure, one success
+    expect(summary.totalProcessed).toBe(2);
+    expect(summary.successful).toBe(1);
+    expect(summary.failed).toBe(1);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0].symbol).toBe(mockUniverse.symbol);
+    expect(summary.errors[0].error).toContain('Volatility calculation failed');
+    expect(h.recalculateUniverseVolatility).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/server/src/app/routes/settings/update/index.spec.ts
+++ b/apps/server/src/app/routes/settings/update/index.spec.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StructuredLogger } from '../../../../utils/structured-logger';
+
+// Hoisted mocks — created before module resolution
+const h = vi.hoisted(() => ({
+  prismaUpdate: vi.fn().mockResolvedValue({}),
+  getDistributions: vi.fn(),
+  getLastPrice: vi.fn(),
+  recalculateUniverseVolatility: vi.fn(),
+}));
+
+vi.mock('../../../prisma/prisma-client', () => ({
+  prisma: {
+    universe: {
+      findMany: vi.fn(),
+      update: h.prismaUpdate,
+    },
+  },
+}));
+
+vi.mock('../common/get-distributions.function', () => ({
+  getDistributions: h.getDistributions,
+}));
+
+vi.mock('../common/get-last-price.function', () => ({
+  getLastPrice: h.getLastPrice,
+}));
+
+vi.mock('../../../volatility/recalculate-universe-volatility.function', () => ({
+  recalculateUniverseVolatility: h.recalculateUniverseVolatility,
+}));
+
+import { testExports } from './index';
+
+const mockHistory = [
+  { amount: 0.25, date: new Date('2024-01-15') },
+  { amount: 0.24, date: new Date('2023-10-15') },
+  { amount: 0.24, date: new Date('2023-07-15') },
+];
+
+const mockUniverse = {
+  id: 'test-universe-id',
+  symbol: 'TST',
+  distribution: 0.24,
+  distributions_per_year: 4,
+  last_price: 150,
+  ex_date: new Date('2023-07-01'),
+  risk_group_id: 'rg-1',
+  expired: false,
+  is_closed_end_fund: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  deletedAt: null,
+  version: 1,
+  volatility_long: null,
+  volatility_short: null,
+  volatility_calculated_at: null,
+  most_recent_sell_date: null,
+  most_recent_sell_price: null,
+};
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+} as unknown as StructuredLogger;
+
+describe('settings/update route — volatility recalculation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.prismaUpdate.mockResolvedValue({});
+  });
+
+  it('should call recalculateUniverseVolatility with universe.id and history when distributions are available', async () => {
+    // Arrange
+    h.getLastPrice.mockResolvedValue(155.0);
+    h.getDistributions.mockResolvedValue({
+      result: {
+        distribution: 0.26,
+        distributions_per_year: 4,
+        ex_date: new Date('2024-02-01'),
+      },
+      history: mockHistory,
+    });
+    h.recalculateUniverseVolatility.mockResolvedValue(undefined);
+
+    // Act
+    const result = await testExports.processUniverse(mockUniverse, mockLogger);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(h.recalculateUniverseVolatility).toHaveBeenCalledOnce();
+    expect(h.recalculateUniverseVolatility).toHaveBeenCalledWith(
+      mockUniverse.id,
+      mockHistory
+    );
+  });
+
+  it('should call recalculateUniverseVolatility with empty array when no distribution history', async () => {
+    // Arrange
+    h.getLastPrice.mockResolvedValue(155.0);
+    h.getDistributions.mockResolvedValue({
+      result: undefined,
+      history: [],
+    });
+    h.recalculateUniverseVolatility.mockResolvedValue(undefined);
+
+    // Act
+    const result = await testExports.processUniverse(mockUniverse, mockLogger);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(h.recalculateUniverseVolatility).toHaveBeenCalledOnce();
+    expect(h.recalculateUniverseVolatility).toHaveBeenCalledWith(
+      mockUniverse.id,
+      []
+    );
+  });
+
+  it('should mark symbol as failed when recalculateUniverseVolatility throws', async () => {
+    // Arrange
+    h.getLastPrice.mockResolvedValue(155.0);
+    h.getDistributions.mockResolvedValue({
+      result: {
+        distribution: 0.26,
+        distributions_per_year: 4,
+        ex_date: new Date('2024-02-01'),
+      },
+      history: mockHistory,
+    });
+    h.recalculateUniverseVolatility.mockRejectedValue(
+      new Error('Volatility calculation failed')
+    );
+
+    // Act
+    const result = await testExports.processUniverse(mockUniverse, mockLogger);
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Volatility calculation failed');
+  });
+});

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -3,10 +3,10 @@ import { FastifyInstance, FastifyRequest } from 'fastify';
 
 import { StructuredLogger } from '../../../../utils/structured-logger';
 import { prisma } from '../../../prisma/prisma-client';
+import { recalculateUniverseVolatility } from '../../../volatility/recalculate-universe-volatility.function';
 import type { ProcessedRow } from '../../common/distribution-api.function';
 import { getDistributions } from '../common/get-distributions.function';
 import { getLastPrice } from '../common/get-last-price.function';
-import { recalculateUniverseVolatility } from '../../../volatility/recalculate-universe-volatility.function';
 
 interface Distribution {
   distribution: number;

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -1,11 +1,12 @@
+/* eslint-disable @smarttools/one-exported-item-per-file -- Test helper exports alongside default route registration */
 import { FastifyInstance, FastifyRequest } from 'fastify';
 
 import { StructuredLogger } from '../../../../utils/structured-logger';
 import { prisma } from '../../../prisma/prisma-client';
+import type { ProcessedRow } from '../../common/distribution-api.function';
 import { getDistributions } from '../common/get-distributions.function';
 import { getLastPrice } from '../common/get-last-price.function';
 import { recalculateUniverseVolatility } from '../../../volatility/recalculate-universe-volatility.function';
-import type { ProcessedRow } from '../common/distribution-api.function';
 
 interface Distribution {
   distribution: number;
@@ -83,6 +84,58 @@ async function updateUniverseWithoutDistribution(
   });
 }
 
+async function applyUniverseUpdate(
+  universe: Awaited<ReturnType<typeof prisma.universe.findMany>>[number],
+  lastPriceValue: number,
+  distribution: Distribution,
+  logger: StructuredLogger
+): Promise<void> {
+  if (shouldUpdateDistribution(distribution, universe)) {
+    await updateUniverseWithDistribution(universe, lastPriceValue, distribution);
+    logger.info('Updated universe with new distribution', {
+      symbol: universe.symbol,
+      lastPrice: lastPriceValue,
+      exDate: distribution.ex_date,
+      distribution: distribution.distribution,
+    });
+  } else {
+    await updateUniverseWithoutDistribution(universe, lastPriceValue);
+    logger.info('Updated universe with last price only', {
+      symbol: universe.symbol,
+      lastPrice: lastPriceValue,
+    });
+  }
+}
+
+async function recalculateVolatilityWithLogging(
+  universe: Awaited<ReturnType<typeof prisma.universe.findMany>>[number],
+  history: ProcessedRow[],
+  logger: StructuredLogger
+): Promise<void> {
+  try {
+    await recalculateUniverseVolatility(universe.id, history);
+    logger.info('Recalculated universe volatility', {
+      symbol: universe.symbol,
+      universeId: universe.id,
+      historyLength: history.length,
+    });
+  } catch (volatilityError) {
+    const errorMessage =
+      volatilityError instanceof Error
+        ? volatilityError.message
+        : 'Unknown volatility calculation error';
+    const errorStack =
+      volatilityError instanceof Error ? volatilityError.stack : undefined;
+    logger.error('Failed to recalculate universe volatility', undefined, {
+      symbol: universe.symbol,
+      universeId: universe.id,
+      error: errorMessage,
+      stack: errorStack,
+    });
+    throw new Error(`Volatility calculation failed: ${errorMessage}`);
+  }
+}
+
 async function processUniverse(
   universe: Awaited<ReturnType<typeof prisma.universe.findMany>>[number],
   logger: StructuredLogger
@@ -104,52 +157,8 @@ async function processUniverse(
 
     const lastPriceValue = lastPrice ?? 0;
 
-    if (shouldUpdateDistribution(distribution, universe)) {
-      await updateUniverseWithDistribution(
-        universe,
-        lastPriceValue,
-        distribution
-      );
-      logger.info('Updated universe with new distribution', {
-        symbol: universe.symbol,
-        lastPrice: lastPriceValue,
-        exDate: distribution.ex_date,
-        distribution: distribution.distribution,
-      });
-    } else {
-      await updateUniverseWithoutDistribution(universe, lastPriceValue);
-      logger.info('Updated universe with last price only', {
-        symbol: universe.symbol,
-        lastPrice: lastPriceValue,
-      });
-    }
-
-    // Recalculate volatility using the history from getDistributions
-    try {
-      await recalculateUniverseVolatility(universe.id, history);
-      logger.info('Recalculated universe volatility', {
-        symbol: universe.symbol,
-        universeId: universe.id,
-        historyLength: history.length,
-      });
-    } catch (volatilityError) {
-      const errorMessage =
-        volatilityError instanceof Error
-          ? volatilityError.message
-          : 'Unknown volatility calculation error';
-      const errorStack =
-        volatilityError instanceof Error ? volatilityError.stack : undefined;
-
-      logger.error('Failed to recalculate universe volatility', undefined, {
-        symbol: universe.symbol,
-        universeId: universe.id,
-        error: errorMessage,
-        stack: errorStack,
-      });
-
-      // Rethrow to mark this universe as failed
-      throw new Error(`Volatility calculation failed: ${errorMessage}`);
-    }
+    await applyUniverseUpdate(universe, lastPriceValue, distribution, logger);
+    await recalculateVolatilityWithLogging(universe, history, logger);
 
     return { success: true };
   } catch (error) {

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -136,7 +136,9 @@ async function recalculateVolatilityWithLogging(
       error: errorMessage,
       stack: errorStack,
     });
-    throw new Error(`Volatility calculation failed: ${errorMessage}`);
+    throw volatilityError instanceof Error
+      ? volatilityError
+      : new Error(`Volatility calculation failed: ${errorMessage}`);
   }
 }
 

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -91,7 +91,11 @@ async function applyUniverseUpdate(
   logger: StructuredLogger
 ): Promise<void> {
   if (shouldUpdateDistribution(distribution, universe)) {
-    await updateUniverseWithDistribution(universe, lastPriceValue, distribution);
+    await updateUniverseWithDistribution(
+      universe,
+      lastPriceValue,
+      distribution
+    );
     logger.info('Updated universe with new distribution', {
       symbol: universe.symbol,
       lastPrice: lastPriceValue,

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -140,21 +140,15 @@ async function processUniverse(
       const errorStack =
         volatilityError instanceof Error ? volatilityError.stack : undefined;
 
-      logger.error(
-        'Failed to recalculate universe volatility',
-        undefined,
-        {
-          symbol: universe.symbol,
-          universeId: universe.id,
-          error: errorMessage,
-          stack: errorStack,
-        }
-      );
+      logger.error('Failed to recalculate universe volatility', undefined, {
+        symbol: universe.symbol,
+        universeId: universe.id,
+        error: errorMessage,
+        stack: errorStack,
+      });
 
       // Rethrow to mark this universe as failed
-      throw new Error(
-        `Volatility calculation failed: ${errorMessage}`
-      );
+      throw new Error(`Volatility calculation failed: ${errorMessage}`);
     }
 
     return { success: true };

--- a/apps/server/src/app/routes/settings/update/index.ts
+++ b/apps/server/src/app/routes/settings/update/index.ts
@@ -4,11 +4,18 @@ import { StructuredLogger } from '../../../../utils/structured-logger';
 import { prisma } from '../../../prisma/prisma-client';
 import { getDistributions } from '../common/get-distributions.function';
 import { getLastPrice } from '../common/get-last-price.function';
+import { recalculateUniverseVolatility } from '../../../volatility/recalculate-universe-volatility.function';
+import type { ProcessedRow } from '../common/distribution-api.function';
 
 interface Distribution {
   distribution: number;
   distributions_per_year: number;
   ex_date: Date;
+}
+
+interface DistributionWithHistory {
+  distribution: Distribution | null;
+  history: ProcessedRow[];
 }
 
 function getCurrentDistribution(
@@ -23,13 +30,16 @@ function getCurrentDistribution(
 
 async function checkForNewDistribution(
   universe: Awaited<ReturnType<typeof prisma.universe.findMany>>[number]
-): Promise<Distribution | null> {
-  const { result: newDistribution } = await getDistributions(universe.symbol);
+): Promise<DistributionWithHistory> {
+  const { result: newDistribution, history } = await getDistributions(
+    universe.symbol
+  );
+
   if (newDistribution === undefined) {
-    return null;
+    return { distribution: null, history };
   }
 
-  return newDistribution;
+  return { distribution: newDistribution, history };
 }
 
 function shouldUpdateDistribution(
@@ -86,7 +96,8 @@ async function processUniverse(
     const lastPrice = await getLastPrice(universe.symbol);
     let distribution = getCurrentDistribution(universe);
 
-    const newDistribution = await checkForNewDistribution(universe);
+    const { distribution: newDistribution, history } =
+      await checkForNewDistribution(universe);
     if (newDistribution !== null) {
       distribution = newDistribution;
     }
@@ -111,6 +122,39 @@ async function processUniverse(
         symbol: universe.symbol,
         lastPrice: lastPriceValue,
       });
+    }
+
+    // Recalculate volatility using the history from getDistributions
+    try {
+      await recalculateUniverseVolatility(universe.id, history);
+      logger.info('Recalculated universe volatility', {
+        symbol: universe.symbol,
+        universeId: universe.id,
+        historyLength: history.length,
+      });
+    } catch (volatilityError) {
+      const errorMessage =
+        volatilityError instanceof Error
+          ? volatilityError.message
+          : 'Unknown volatility calculation error';
+      const errorStack =
+        volatilityError instanceof Error ? volatilityError.stack : undefined;
+
+      logger.error(
+        'Failed to recalculate universe volatility',
+        undefined,
+        {
+          symbol: universe.symbol,
+          universeId: universe.id,
+          error: errorMessage,
+          stack: errorStack,
+        }
+      );
+
+      // Rethrow to mark this universe as failed
+      throw new Error(
+        `Volatility calculation failed: ${errorMessage}`
+      );
     }
 
     return { success: true };
@@ -244,6 +288,13 @@ function handleUpdateRoute(fastify: FastifyInstance): void {
     }
   );
 }
+
+// Export for testing
+export const testExports = {
+  processUniverse,
+  updateAllUniverses,
+  checkForNewDistribution,
+};
 
 export default function registerUpdateRoutes(fastify: FastifyInstance): void {
   handleUpdateRoute(fastify);


### PR DESCRIPTION
## Summary

Refactors  in `apps/server/src/app/routes/settings/update/index.ts` to return both the distribution result and the full history array fetched from `getDistributions`. The history is then passed to `recalculateUniverseVolatility(universe.id, history)` after each symbol's price/distribution update so every "Update Fields" run also refreshes the `volatility_long`, `volatility_short`, and `volatility_calculated_at` fields.

Error handling mirrors the existing pattern: a volatility failure marks the symbol as failed in the batch summary without aborting processing for remaining symbols.

No additional HTTP calls are made per symbol — `recalculateUniverseVolatility` is a pure-function wrapper that only calls `calculateVolatility` and writes to the database.

## Changes

- **`apps/server/src/app/routes/settings/update/index.ts`** — refactored `checkForNewDistribution` to return `{ distribution, history }`; added `recalculateUniverseVolatility` call with error handling in `processUniverse`
- **`apps/server/src/app/routes/settings/update/index.spec.ts`** — new unit-test file covering: history passed through on new distribution, history passed through when no new distribution, empty history forwarded, volatility error marks symbol as failed without aborting the batch

## Testing

1. Run `pnpm all` — all tests should pass including the new specs for `settings/update/index.ts`
2. Verify no additional `dividendhistory.net` requests per symbol (history reused from existing `getDistributions` call)
3. Confirm `volatility_long`, `volatility_short`, and `volatility_calculated_at` are updated after a batch field update run in the development environment

Closes #1193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for settings update volatility recalculation, covering history/no-history cases, error propagation, and batch processing where some universes succeed and others fail.

* **Bug Fixes**
  * Improved error handling and logging for volatility recalculation so failures are captured, reported, and do not halt batch updates; summaries reflect per-universe success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->