### PR TITLE
feat(story-96.1): remove universe map from sold positions component service

### DIFF
--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.spec.ts
@@ -12,16 +12,6 @@ vi.mock('../../store/current-account/select-current-account.signal', () => ({
   selectCurrentAccountSignal: vi.fn(),
 }));
 
-vi.mock('../../shared/build-universe-map.function', () => ({
-  buildUniverseMap: vi.fn().mockReturnValue(
-    new Map([
-      ['universe-1', { symbol: 'AAPL' }],
-      ['universe-2', { symbol: 'MSFT' }],
-      ['universe-3', { symbol: 'GOOG' }],
-    ])
-  ),
-}));
-
 vi.mock('../../store/current-account/current-account.signal-store', () => ({
   currentAccountSignalStore: {
     selectCurrentAccountId: signal(''),
@@ -76,6 +66,7 @@ function createSoldTrade(overrides: Partial<Trade> = {}): Trade {
     id: 'trade-1',
     universeId: 'universe-1',
     accountId: 'acc-1',
+    symbol: 'PDI',
     buy: 100,
     sell: 150,
     buy_date: '2024-01-15',
@@ -87,6 +78,7 @@ function createSoldTrade(overrides: Partial<Trade> = {}): Trade {
 
 // Helper to create a mock SmartArray-like array of sold trades
 function createMockSoldTradesArray(count: number): Trade[] {
+  const symbols = ['AAPL', 'MSFT', 'GOOG'];
   const items: Trade[] = [];
   for (let i = 0; i < count; i++) {
     items.push(
@@ -96,6 +88,7 @@ function createMockSoldTradesArray(count: number): Trade[] {
         sell: (i + 1) * 15,
         quantity: (i + 1) * 5,
         universeId: `universe-${(i % 3) + 1}`,
+        symbol: symbols[i % 3],
         buy_date: '2024-01-15',
         sell_date: '2024-06-15',
       })
@@ -210,17 +203,17 @@ describe('SoldPositionsComponentService - Virtual Data Access (AX.11)', () => {
     expect(positions.length).toBe(200);
   });
 
-  // AC: Test that universe symbols are resolved for visible items
-  it('should resolve universe symbols for items within visible range', () => {
+  // AC: Test that trade.symbol is used directly
+  it('should use trade.symbol directly for sold positions', () => {
     service.visibleRange.set({ start: 0, end: 10 });
 
     const positions = service.selectSoldPositions();
 
-    // First item has universeId: 'universe-1' → symbol: 'AAPL'
+    // First item has trade.symbol: 'AAPL'
     expect(positions[0].symbol).toBe('AAPL');
-    // Second item has universeId: 'universe-2' → symbol: 'MSFT'
+    // Second item has trade.symbol: 'MSFT'
     expect(positions[1].symbol).toBe('MSFT');
-    // Third item has universeId: 'universe-3' → symbol: 'GOOG'
+    // Third item has trade.symbol: 'GOOG'
     expect(positions[2].symbol).toBe('GOOG');
   });
 
@@ -292,6 +285,7 @@ describe('SoldPositionsComponentService - Virtual Data Access (AX.11)', () => {
           sell: 150,
           quantity: 10,
           universeId: 'universe-1',
+          symbol: 'AAPL',
         }),
       ],
       openTrades: [],

--- a/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
+++ b/apps/dms-material/src/app/account-panel/sold-positions/sold-positions-component.service.ts
@@ -1,12 +1,10 @@
 import { computed, inject, Injectable, signal } from '@angular/core';
 
-import { buildUniverseMap } from '../../shared/build-universe-map.function';
 import { currentAccountSignalStore } from '../../store/current-account/current-account.signal-store';
 import { selectCurrentAccountSignal } from '../../store/current-account/select-current-account.signal';
 import { ClosedPosition } from '../../store/trades/closed-position.interface';
 import { differenceInTradingDays } from '../../store/trades/difference-in-trading-days.function';
 import { Trade } from '../../store/trades/trade.interface';
-import { Universe } from '../../store/universe/universe.interface';
 import { classifyCapitalGain } from './classify-capital-gain.function';
 
 /**
@@ -34,13 +32,13 @@ function buildPlaceholderClosedPosition(id: string): ClosedPosition {
   };
 }
 
-function buildPartialClosedPosition(trade: Trade): ClosedPosition {
+function buildFullClosedPosition(trade: Trade): ClosedPosition {
   const capitalGain = (trade.sell - trade.buy) * trade.quantity;
   const capitalGainPercentage =
     trade.buy !== 0 ? ((trade.sell - trade.buy) / trade.buy) * 100 : 0;
   return {
     id: trade.id,
-    symbol: trade.symbol ?? '',
+    symbol: trade.symbol,
     buy: trade.buy,
     buy_date: trade.buy_date,
     quantity: trade.quantity,
@@ -50,28 +48,6 @@ function buildPartialClosedPosition(trade: Trade): ClosedPosition {
       trade.sell_date !== undefined
         ? differenceInTradingDays(trade.buy_date, trade.sell_date)
         : 0,
-    capitalGain,
-    capitalGainPercentage,
-    gainLossType: classifyCapitalGain(capitalGain),
-  };
-}
-
-function buildFullClosedPosition(
-  trade: Trade,
-  universe: Universe
-): ClosedPosition {
-  const capitalGain = (trade.sell - trade.buy) * trade.quantity;
-  const capitalGainPercentage =
-    trade.buy !== 0 ? ((trade.sell - trade.buy) / trade.buy) * 100 : 0;
-  return {
-    id: trade.id,
-    symbol: universe.symbol,
-    buy: trade.buy,
-    buy_date: trade.buy_date,
-    quantity: trade.quantity,
-    sell: trade.sell,
-    sell_date: trade.sell_date,
-    daysHeld: differenceInTradingDays(trade.buy_date, trade.sell_date!),
     capitalGain,
     capitalGainPercentage,
     gainLossType: classifyCapitalGain(capitalGain),
@@ -98,7 +74,6 @@ export class SoldPositionsComponentService {
   // eslint-disable-next-line @smarttools/no-anonymous-functions -- computed signal
   selectSoldPositions = computed(() => {
     const trades = this.trades();
-    const universeMap = buildUniverseMap();
 
     const totalLength = trades.length;
     if (totalLength === 0) {
@@ -115,11 +90,7 @@ export class SoldPositionsComponentService {
         );
         continue;
       }
-      const universe = universeMap.get(trade.universeId);
-      soldPositions[i] =
-        universe === undefined
-          ? buildPartialClosedPosition(trade)
-          : buildFullClosedPosition(trade, universe);
+      soldPositions[i] = buildFullClosedPosition(trade);
     }
 
     return soldPositions;


### PR DESCRIPTION
## Summary

Use `trade.symbol` directly in the sold positions client component service instead of performing a universe lookup via `buildUniverseMap()`.

The `Trade` interface's `symbol` field is non-optional since Story 95.1, so the lookup map is redundant. This removes the last caller of `buildUniverseMap()` in the sold-positions pipeline.

## Changes

- Removed `buildUniverseMap()` import and call from `selectSoldPositions` computed signal
- Removed `buildPartialClosedPosition` helper (was the fallback for when universe lookup returned `undefined`)
- Simplified `buildFullClosedPosition` to accept only a `Trade` parameter, reading `trade.symbol` directly
- Removed `Universe` import from the service file
- Updated spec file: removed `vi.mock` for `build-universe-map.function`, added `symbol` to all test trade fixtures, updated test description to reflect direct symbol usage

## Testing

- All 13 unit tests for `sold-positions-component.service.spec.ts` pass
- `pnpm nx run dms-material:lint` passes
- `pnpm nx build dms-material` passes
- `pnpm nx run dms-material:test` passes (1768 tests, 2 skipped)
- `pnpm dupcheck` passes (0 clones found)
- `pnpm format` produces no changes

Closes #1204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of sold position calculations when sell date information is unavailable

* **Refactor**
  * Optimized symbol resolution for sold positions by using trade data directly
  * Streamlined position-building logic

* **Tests**
  * Updated tests to validate sold position symbol handling and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->