### PR TITLE
feat(e2e): packaged Electron smoke test for DB creation and migration idempotency (Story 98.4)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@ pnpm-lock.yaml
 /node_modules
 
 .nx/self-healing
+_bmad-output/

--- a/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
+++ b/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
@@ -412,7 +412,7 @@ _To be populated during implementation._
 | ---------- | ------ | ---------------------------------------------------- |
 | 2026-05-06 | Dave   | Story created (Approved) via bmad-create-story flow. |
 
-## Dev Agent Record
+## Dev Agent Completion Record
 
 ### Completion Notes
 

--- a/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
+++ b/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
@@ -44,6 +44,7 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
 ## Tasks / Subtasks
 
 - [x] Task 1: Decide test location and document the choice (AC: #3)
+
   - [x] Inspect `apps/dms-material-e2e/playwright.config.ts` `electron` project (already
         configured: `testMatch: ['**/electron-*.spec.ts']`, no `baseURL`, no `webServer`
         dependency — the test launches Electron directly)
@@ -58,9 +59,10 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
   - [x] Document the decision in Dev Notes including the rationale.
 
 - [x] Task 2: Linux-only guard and packaged-artifact discovery (AC: #1, #3)
+
   - [x] Inside the new spec file, add a top-level guard:
         `test.skip(process.platform !== 'linux', 'Story 98.4 smoke test is Linux-only
-        until macOS/Windows build environments are available');`
+    until macOS/Windows build environments are available');`
   - [x] Locate the packaged AppImage produced by `nx run electron:build:linux` via
         `glob`/`fs.readdirSync` against `dist/electron-dist/*.AppImage` (the output path
         per `apps/electron/project.json`)
@@ -70,18 +72,20 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
   - [x] Make the AppImage executable (`fs.chmodSync(appImagePath, 0o755)`)
 
 - [x] Task 3: Isolated `HOME` plumbing (AC: #1, #2)
+
   - [x] In a `test.beforeAll` (or per-test `beforeEach` if the second-launch test needs a
         fresh isolated dir per run — it does NOT; both AC #1 and AC #2 share the same
         isolated `HOME`), create a unique temp directory via
         `fs.mkdtempSync(path.join(os.tmpdir(), 'dms-smoke-home-'))` and store its path
   - [x] In an `afterAll`, remove the temp directory recursively (`fs.rmSync(tmpHome,
-        { recursive: true, force: true })`) — even if a test failed; use a Playwright
+    { recursive: true, force: true })`) — even if a test failed; use a Playwright
         `test.afterAll` hook with try/finally semantics
   - [x] Pass the temp directory as `HOME` (Linux uses `HOME`; the resolution chain in
         Story 98.1 is `os.homedir()` which honours `HOME` on POSIX) when launching the
         AppImage; do NOT pollute the developer's real `~/.dms/`
 
 - [x] Task 4: Launch the packaged app, wait for readiness, then exit (AC: #1)
+
   - [x] Use `child_process.spawn` to launch the AppImage with:
     - Args: `['--no-sandbox']` (Story 91.4 precedent — required for many CI/sandboxed
       Linux environments)
@@ -90,7 +94,7 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
       Fastify health endpoint is reachable at a deterministic URL
     - `stdio: 'pipe'` so the test can capture stdout/stderr for failure diagnostics
   - [x] If `DISPLAY` is unset (typical CI), wrap the launch via `xvfb-run
-        --auto-servernum <appimage>` (Story 91.4 precedent). Detect via
+    --auto-servernum <appimage>` (Story 91.4 precedent). Detect via
         `process.env['DISPLAY'] === undefined`.
   - [x] Poll `http://127.0.0.1:<DMS_SMOKE_PORT>/api/health` until it returns 200 or a
         90-second timeout expires (use `expect.poll(...)` — do NOT use `setTimeout`
@@ -101,8 +105,9 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
         on timeout. Capture exit code in Dev Notes for diagnostics if it is non-zero.
 
 - [x] Task 5: Verify DB file and `_prisma_migrations` table contents (AC: #1)
+
   - [x] After the app exits, assert `fs.existsSync(path.join(tmpHome, '.dms',
-        'dms.db'))` is `true`
+    'dms.db'))` is `true`
   - [x] Open the SQLite DB read-only from the test using `better-sqlite3` if it is
         already a workspace dependency, else fall back to spawning `sqlite3` CLI with a
         SELECT query. Check `package.json` / `pnpm-lock.yaml` first; **do not** add a
@@ -116,8 +121,9 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
         On mismatch, include both lists in the failure message for fast diagnosis.
 
 - [x] Task 6: Idempotency — second launch reuses the existing DB (AC: #2)
+
   - [x] In a second `test('second launch reuses existing dms.db without re-applying
-        migrations', ...)` that runs **after** the first test (Playwright runs tests
+    migrations', ...)` that runs **after** the first test (Playwright runs tests
         within a file in declared order with `workers: 1`):
     - Snapshot before: read all rows from `_prisma_migrations` (the full row, including
       `started_at`, `finished_at`, `checksum`, `applied_steps_count`)
@@ -130,6 +136,7 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
         developer can see exactly which row changed.
 
 - [x] Task 7: Cleanup and resilience
+
   - [x] Ensure `afterAll` reliably terminates any still-running Electron process (track
         the spawned child's pid and `process.kill(pid, 'SIGKILL')` if it is still alive)
   - [x] Ensure the temp `HOME` directory is removed even on test failure (try/finally)
@@ -137,7 +144,7 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
 
 - [x] Task 8: Wire into the e2e command and verify (AC: #3, #4, #5)
   - [x] Confirm `pnpm e2e:electron` (existing root script: `nx run
-        dms-material-e2e:e2e-electron`) picks up the new spec file via the
+    dms-material-e2e:e2e-electron`) picks up the new spec file via the
         `electron` project's `testMatch`. If the `e2e-electron` Nx target does NOT
         already exist on `dms-material-e2e:project.json`, add it as
         `pnpm playwright test --project=electron` (cwd `apps/dms-material-e2e`).
@@ -216,16 +223,16 @@ the spec file as a constant.
 Prisma maintains a `_prisma_migrations` table with at least these columns (verify
 against the actual schema in a sample DB):
 
-| Column                | Notes                                                                     |
-| --------------------- | ------------------------------------------------------------------------- |
-| `id`                  | UUID assigned by Prisma                                                   |
-| `checksum`            | Hash of the migration SQL                                                 |
-| `finished_at`         | Set when migration completed successfully (NULL for in-progress/failed)   |
-| `migration_name`      | Directory name under `prisma/migrations/` (timestamped)                   |
-| `logs`                | Optional logs from the migration                                          |
-| `rolled_back_at`      | Set if the migration was rolled back                                      |
-| `started_at`          | When the migration started                                                |
-| `applied_steps_count` | Steps applied                                                             |
+| Column                | Notes                                                                   |
+| --------------------- | ----------------------------------------------------------------------- |
+| `id`                  | UUID assigned by Prisma                                                 |
+| `checksum`            | Hash of the migration SQL                                               |
+| `finished_at`         | Set when migration completed successfully (NULL for in-progress/failed) |
+| `migration_name`      | Directory name under `prisma/migrations/` (timestamped)                 |
+| `logs`                | Optional logs from the migration                                        |
+| `rolled_back_at`      | Set if the migration was rolled back                                    |
+| `started_at`          | When the migration started                                              |
+| `applied_steps_count` | Steps applied                                                           |
 
 The AC #1 assertion is: every directory under `prisma/migrations/` (with a
 `migration.sql` file) has a corresponding row in `_prisma_migrations` with a non-NULL

--- a/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
+++ b/_bmad-output/implementation-artifacts/98-4-e2e-electron-package-launch-smoke.md
@@ -1,6 +1,6 @@
 # Story 98.4: E2E Smoke Test — Packaged App Launches with Fresh DB and Applied Migrations
 
-Status: Approved
+Status: Done
 
 ## Story
 
@@ -43,80 +43,80 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Decide test location and document the choice (AC: #3)
-  - [ ] Inspect `apps/dms-material-e2e/playwright.config.ts` `electron` project (already
+- [x] Task 1: Decide test location and document the choice (AC: #3)
+  - [x] Inspect `apps/dms-material-e2e/playwright.config.ts` `electron` project (already
         configured: `testMatch: ['**/electron-*.spec.ts']`, no `baseURL`, no `webServer`
         dependency — the test launches Electron directly)
-  - [ ] Inspect existing `apps/dms-material-e2e/src/electron-launch.spec.ts` (Story 77.5)
+  - [x] Inspect existing `apps/dms-material-e2e/src/electron-launch.spec.ts` (Story 77.5)
         to understand the existing electron-launch pattern
-  - [ ] Decision (default — record in Dev Notes): add a NEW spec file
+  - [x] Decision (default — record in Dev Notes): add a NEW spec file
         `apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts` rather than
         extending `electron-launch.spec.ts`. The Story 77.5 spec exercises the **dev**
         Electron flow; this story exercises the **packaged** artifact — keeping them
         separate keeps the failure surface clearly attributable. The new file is picked
         up automatically by the `electron` project's `testMatch` glob.
-  - [ ] Document the decision in Dev Notes including the rationale.
+  - [x] Document the decision in Dev Notes including the rationale.
 
-- [ ] Task 2: Linux-only guard and packaged-artifact discovery (AC: #1, #3)
-  - [ ] Inside the new spec file, add a top-level guard:
+- [x] Task 2: Linux-only guard and packaged-artifact discovery (AC: #1, #3)
+  - [x] Inside the new spec file, add a top-level guard:
         `test.skip(process.platform !== 'linux', 'Story 98.4 smoke test is Linux-only
         until macOS/Windows build environments are available');`
-  - [ ] Locate the packaged AppImage produced by `nx run electron:build:linux` via
+  - [x] Locate the packaged AppImage produced by `nx run electron:build:linux` via
         `glob`/`fs.readdirSync` against `dist/electron-dist/*.AppImage` (the output path
         per `apps/electron/project.json`)
-  - [ ] If no AppImage is found, fail the test with a clear message that points the
+  - [x] If no AppImage is found, fail the test with a clear message that points the
         developer at the missing build step (do NOT silently skip — silent skips on a
         required test are the exact regression risk this story protects against)
-  - [ ] Make the AppImage executable (`fs.chmodSync(appImagePath, 0o755)`)
+  - [x] Make the AppImage executable (`fs.chmodSync(appImagePath, 0o755)`)
 
-- [ ] Task 3: Isolated `HOME` plumbing (AC: #1, #2)
-  - [ ] In a `test.beforeAll` (or per-test `beforeEach` if the second-launch test needs a
+- [x] Task 3: Isolated `HOME` plumbing (AC: #1, #2)
+  - [x] In a `test.beforeAll` (or per-test `beforeEach` if the second-launch test needs a
         fresh isolated dir per run — it does NOT; both AC #1 and AC #2 share the same
         isolated `HOME`), create a unique temp directory via
         `fs.mkdtempSync(path.join(os.tmpdir(), 'dms-smoke-home-'))` and store its path
-  - [ ] In an `afterAll`, remove the temp directory recursively (`fs.rmSync(tmpHome,
+  - [x] In an `afterAll`, remove the temp directory recursively (`fs.rmSync(tmpHome,
         { recursive: true, force: true })`) — even if a test failed; use a Playwright
         `test.afterAll` hook with try/finally semantics
-  - [ ] Pass the temp directory as `HOME` (Linux uses `HOME`; the resolution chain in
+  - [x] Pass the temp directory as `HOME` (Linux uses `HOME`; the resolution chain in
         Story 98.1 is `os.homedir()` which honours `HOME` on POSIX) when launching the
         AppImage; do NOT pollute the developer's real `~/.dms/`
 
-- [ ] Task 4: Launch the packaged app, wait for readiness, then exit (AC: #1)
-  - [ ] Use `child_process.spawn` to launch the AppImage with:
+- [x] Task 4: Launch the packaged app, wait for readiness, then exit (AC: #1)
+  - [x] Use `child_process.spawn` to launch the AppImage with:
     - Args: `['--no-sandbox']` (Story 91.4 precedent — required for many CI/sandboxed
       Linux environments)
     - Env: `{ ...process.env, HOME: tmpHome, DMS_SMOKE_PORT: '<some-fixed-port>' }`
       where `DMS_SMOKE_PORT` matches the env var added in Story 91.4's `main.ts` so the
       Fastify health endpoint is reachable at a deterministic URL
     - `stdio: 'pipe'` so the test can capture stdout/stderr for failure diagnostics
-  - [ ] If `DISPLAY` is unset (typical CI), wrap the launch via `xvfb-run
+  - [x] If `DISPLAY` is unset (typical CI), wrap the launch via `xvfb-run
         --auto-servernum <appimage>` (Story 91.4 precedent). Detect via
         `process.env['DISPLAY'] === undefined`.
-  - [ ] Poll `http://127.0.0.1:<DMS_SMOKE_PORT>/api/health` until it returns 200 or a
+  - [x] Poll `http://127.0.0.1:<DMS_SMOKE_PORT>/api/health` until it returns 200 or a
         90-second timeout expires (use `expect.poll(...)` — do NOT use `setTimeout`
         sleeps). The 90s timeout matches the Playwright config's CI timeout.
-  - [ ] After the health check succeeds (which guarantees the migration step from
+  - [x] After the health check succeeds (which guarantees the migration step from
         Story 98.2 ran successfully — the server only forks after migrations resolve),
         terminate the Electron process with SIGTERM and wait up to 10s for exit; SIGKILL
         on timeout. Capture exit code in Dev Notes for diagnostics if it is non-zero.
 
-- [ ] Task 5: Verify DB file and `_prisma_migrations` table contents (AC: #1)
-  - [ ] After the app exits, assert `fs.existsSync(path.join(tmpHome, '.dms',
+- [x] Task 5: Verify DB file and `_prisma_migrations` table contents (AC: #1)
+  - [x] After the app exits, assert `fs.existsSync(path.join(tmpHome, '.dms',
         'dms.db'))` is `true`
-  - [ ] Open the SQLite DB read-only from the test using `better-sqlite3` if it is
+  - [x] Open the SQLite DB read-only from the test using `better-sqlite3` if it is
         already a workspace dependency, else fall back to spawning `sqlite3` CLI with a
         SELECT query. Check `package.json` / `pnpm-lock.yaml` first; **do not** add a
         new dependency if one of these paths is already available.
-  - [ ] Query: `SELECT migration_name FROM _prisma_migrations ORDER BY started_at;`
-  - [ ] Compute the expected migration name list by reading directory names under
+  - [x] Query: `SELECT migration_name FROM _prisma_migrations ORDER BY started_at;`
+  - [x] Compute the expected migration name list by reading directory names under
         `prisma/migrations/` (filter to entries containing a `migration.sql` file) and
         sorting lexicographically — Prisma's directory naming is timestamped so this
         matches the applied order.
-  - [ ] Assert the DB list matches the directory list (length and per-element equality).
+  - [x] Assert the DB list matches the directory list (length and per-element equality).
         On mismatch, include both lists in the failure message for fast diagnosis.
 
-- [ ] Task 6: Idempotency — second launch reuses the existing DB (AC: #2)
-  - [ ] In a second `test('second launch reuses existing dms.db without re-applying
+- [x] Task 6: Idempotency — second launch reuses the existing DB (AC: #2)
+  - [x] In a second `test('second launch reuses existing dms.db without re-applying
         migrations', ...)` that runs **after** the first test (Playwright runs tests
         within a file in declared order with `workers: 1`):
     - Snapshot before: read all rows from `_prisma_migrations` (the full row, including
@@ -126,27 +126,27 @@ Prisma migrations on launch), 98.3 (per-platform `build:linux` target).
     - Snapshot after: read all rows from `_prisma_migrations` again
     - Assert the two snapshots are deeply equal — same row count, same rows, no new
       rows, no mutated columns. This proves no migrations were re-applied.
-  - [ ] If the assertion fails, include both snapshots in the failure message so the
+  - [x] If the assertion fails, include both snapshots in the failure message so the
         developer can see exactly which row changed.
 
-- [ ] Task 7: Cleanup and resilience
-  - [ ] Ensure `afterAll` reliably terminates any still-running Electron process (track
+- [x] Task 7: Cleanup and resilience
+  - [x] Ensure `afterAll` reliably terminates any still-running Electron process (track
         the spawned child's pid and `process.kill(pid, 'SIGKILL')` if it is still alive)
-  - [ ] Ensure the temp `HOME` directory is removed even on test failure (try/finally)
-  - [ ] Do NOT leave orphan AppImage processes on the test machine
+  - [x] Ensure the temp `HOME` directory is removed even on test failure (try/finally)
+  - [x] Do NOT leave orphan AppImage processes on the test machine
 
-- [ ] Task 8: Wire into the e2e command and verify (AC: #3, #4, #5)
-  - [ ] Confirm `pnpm e2e:electron` (existing root script: `nx run
+- [x] Task 8: Wire into the e2e command and verify (AC: #3, #4, #5)
+  - [x] Confirm `pnpm e2e:electron` (existing root script: `nx run
         dms-material-e2e:e2e-electron`) picks up the new spec file via the
         `electron` project's `testMatch`. If the `e2e-electron` Nx target does NOT
         already exist on `dms-material-e2e:project.json`, add it as
         `pnpm playwright test --project=electron` (cwd `apps/dms-material-e2e`).
-  - [ ] Document that the test requires a prior `nx run electron:build:linux` to have
+  - [x] Document that the test requires a prior `nx run electron:build:linux` to have
         run; add a `dependsOn` entry to the `e2e-electron` Nx target so the build is
         chained automatically.
-  - [ ] Run `pnpm e2e:electron` locally on Linux, confirm green
-  - [ ] Run `pnpm all` and confirm zero failures
-  - [ ] Run `pnpm format` and confirm zero diffs
+  - [x] Run `pnpm e2e:electron` locally on Linux, confirm green
+  - [x] Run `pnpm all` and confirm zero failures
+  - [x] Run `pnpm format` and confirm zero diffs
 
 ## Dev Notes
 
@@ -404,3 +404,22 @@ _To be populated during implementation._
 | Date       | Author | Description                                          |
 | ---------- | ------ | ---------------------------------------------------- |
 | 2026-05-06 | Dave   | Story created (Approved) via bmad-create-story flow. |
+
+## Dev Agent Record
+
+### Completion Notes
+
+- Created `apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts` with:
+  - Linux-only guard via `test.skip(process.platform !== 'linux', ...)`
+  - AppImage discovery from `dist/electron-dist/*.AppImage` with clear error if missing
+  - Isolated temp HOME via `fs.mkdtempSync`
+  - Launch via `child_process.spawn` with `--no-sandbox`; wraps with `xvfb-run --auto-servernum` if `DISPLAY` is unset
+  - Health-check polling via `expect.poll` at port 39001 with 90s timeout
+  - SIGTERM then SIGKILL (10s grace) on shutdown
+  - Test 1: verifies `~/.dms/dms.db` exists and `_prisma_migrations` rows match `prisma/migrations/` dirs
+  - Test 2: snapshots all migration rows before/after second launch and asserts deep equality
+  - `afterAll` cleanup: terminates process if still alive, removes tmpHome via try/finally
+- Updated `apps/dms-material-e2e/project.json`: added `dependsOn` on `electron:build:linux` to the `e2e-electron` target
+- Updated `apps/electron/README.md`: added "Smoke testing the packaged app" section cross-referencing `smoke-test.sh` and the new Playwright spec
+- `better-sqlite3` confirmed already a workspace dependency (no new deps added)
+- New spec file auto-discovered by Playwright `electron` project glob `**/electron-*.spec.ts`

--- a/apps/dms-material-e2e/project.json
+++ b/apps/dms-material-e2e/project.json
@@ -32,6 +32,12 @@
     },
     "e2e-electron": {
       "executor": "@nx/playwright:playwright",
+      "dependsOn": [
+        {
+          "projects": ["electron"],
+          "target": "build:linux"
+        }
+      ],
       "options": {
         "config": "apps/dms-material-e2e/playwright.config.ts",
         "project": ["electron"]

--- a/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
@@ -203,7 +203,15 @@ test.describe('Packaged Electron App – launch smoke test', () => {
 
     expect(
       appliedMigrations,
-      `Migration mismatch.\nExpected (from prisma/migrations/): ${JSON.stringify(expectedMigrations, null, 2)}\nActual (from _prisma_migrations): ${JSON.stringify(appliedMigrations, null, 2)}`
+      `Migration mismatch.\nExpected (from prisma/migrations/): ${JSON.stringify(
+        expectedMigrations,
+        null,
+        2
+      )}\nActual (from _prisma_migrations): ${JSON.stringify(
+        appliedMigrations,
+        null,
+        2
+      )}`
     ).toEqual(expectedMigrations);
   });
 
@@ -226,7 +234,11 @@ test.describe('Packaged Electron App – launch smoke test', () => {
 
     expect(
       rowsAfter,
-      `_prisma_migrations changed after second launch (idempotency violation).\nBefore: ${JSON.stringify(rowsBefore, null, 2)}\nAfter:  ${JSON.stringify(rowsAfter, null, 2)}`
+      `_prisma_migrations changed after second launch (idempotency violation).\nBefore: ${JSON.stringify(
+        rowsBefore,
+        null,
+        2
+      )}\nAfter:  ${JSON.stringify(rowsAfter, null, 2)}`
     ).toEqual(rowsBefore);
   });
 });

--- a/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
@@ -1,0 +1,232 @@
+import { ChildProcess, spawn } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import Database from 'better-sqlite3';
+import { expect, test } from 'playwright/test';
+
+// ─── Linux-only guard ────────────────────────────────────────────────────────
+// macOS and Windows AppImage builds are out of scope until build environments
+// for those platforms are available (Story 98.4).
+test.skip(
+  process.platform !== 'linux',
+  'Story 98.4 smoke test is Linux-only until macOS/Windows build environments are available'
+);
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../..');
+const DIST_DIR = path.join(WORKSPACE_ROOT, 'dist/electron-dist');
+const MIGRATIONS_DIR = path.join(WORKSPACE_ROOT, 'prisma/migrations');
+const DMS_SMOKE_PORT = 39001;
+const HEALTH_URL = `http://127.0.0.1:${DMS_SMOKE_PORT}/api/health`;
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function findAppImage(): string {
+  if (!fs.existsSync(DIST_DIR)) {
+    throw new Error(
+      `AppImage directory not found: ${DIST_DIR}\n` +
+        'Run `nx run electron:build:linux` before executing this smoke test.'
+    );
+  }
+  const entries = fs.readdirSync(DIST_DIR);
+  const appImages = entries
+    .filter((e) => e.endsWith('.AppImage'))
+    .map((e) => path.join(DIST_DIR, e));
+  if (appImages.length === 0) {
+    throw new Error(
+      `No *.AppImage found in ${DIST_DIR}\n` +
+        'Run `nx run electron:build:linux` before executing this smoke test.'
+    );
+  }
+  return appImages[0];
+}
+
+function getExpectedMigrationNames(): string[] {
+  if (!fs.existsSync(MIGRATIONS_DIR)) {
+    throw new Error(`Migrations directory not found: ${MIGRATIONS_DIR}`);
+  }
+  return fs
+    .readdirSync(MIGRATIONS_DIR, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() &&
+        fs.existsSync(path.join(MIGRATIONS_DIR, entry.name, 'migration.sql'))
+    )
+    .map((entry) => entry.name)
+    .sort();
+}
+
+interface MigrationRow {
+  id: string;
+  checksum: string;
+  finished_at: string | null;
+  migration_name: string;
+  logs: string | null;
+  rolled_back_at: string | null;
+  started_at: string;
+  applied_steps_count: number;
+}
+
+function readMigrationsTable(dbPath: string): MigrationRow[] {
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const rows = db
+      .prepare(
+        'SELECT id, checksum, finished_at, migration_name, logs, rolled_back_at, started_at, applied_steps_count FROM _prisma_migrations ORDER BY started_at'
+      )
+      .all() as MigrationRow[];
+    return rows;
+  } finally {
+    db.close();
+  }
+}
+
+async function launchAppImage(
+  appImagePath: string,
+  tmpHome: string
+): Promise<ChildProcess> {
+  const args = ['--no-sandbox'];
+  const env = {
+    ...process.env,
+    HOME: tmpHome,
+    DMS_SMOKE_PORT: String(DMS_SMOKE_PORT),
+  };
+
+  let child: ChildProcess;
+
+  // On headless CI (no DISPLAY), wrap with xvfb-run so Electron can open a window
+  if (process.env['DISPLAY'] === undefined) {
+    child = spawn('xvfb-run', ['--auto-servernum', appImagePath, ...args], {
+      env,
+      stdio: 'pipe',
+    });
+  } else {
+    child = spawn(appImagePath, args, { env, stdio: 'pipe' });
+  }
+
+  // Surface stdout/stderr for diagnostics if the test fails
+  child.stdout?.on('data', (data: Buffer) => {
+    process.stdout.write(`[AppImage stdout] ${data.toString()}`);
+  });
+  child.stderr?.on('data', (data: Buffer) => {
+    process.stderr.write(`[AppImage stderr] ${data.toString()}`);
+  });
+
+  return child;
+}
+
+async function waitForHealth(timeoutMs = 90_000): Promise<void> {
+  await expect
+    .poll(
+      async function checkHealth() {
+        try {
+          const res = await fetch(HEALTH_URL);
+          return res.status;
+        } catch {
+          return 0;
+        }
+      },
+      { timeout: timeoutMs, intervals: [500, 1000, 2000] }
+    )
+    .toBe(200);
+}
+
+async function terminateProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.killed) {
+    return; // already exited
+  }
+  child.kill('SIGTERM');
+  // Wait up to 10 s for graceful exit, then SIGKILL
+  await new Promise<void>((resolve) => {
+    const killTimer = setTimeout(() => {
+      if (child.exitCode === null && !child.killed) {
+        child.kill('SIGKILL');
+      }
+      resolve();
+    }, 10_000);
+    child.once('exit', () => {
+      clearTimeout(killTimer);
+      resolve();
+    });
+  });
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+test.describe('Packaged Electron App – launch smoke test', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let appImagePath: string;
+  let tmpHome: string;
+  let activeChild: ChildProcess | null = null;
+
+  test.beforeAll(() => {
+    appImagePath = findAppImage();
+    fs.chmodSync(appImagePath, 0o755);
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'dms-smoke-home-'));
+  });
+
+  test.afterAll(async () => {
+    try {
+      if (activeChild !== null) {
+        await terminateProcess(activeChild);
+        activeChild = null;
+      }
+    } finally {
+      if (tmpHome) {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test('first launch creates dms.db with all migrations applied', async () => {
+    const child = await launchAppImage(appImagePath, tmpHome);
+    activeChild = child;
+
+    await waitForHealth();
+
+    await terminateProcess(child);
+    activeChild = null;
+
+    const dbPath = path.join(tmpHome, '.dms', 'dms.db');
+    expect(
+      fs.existsSync(dbPath),
+      `Expected ${dbPath} to exist after first launch`
+    ).toBe(true);
+
+    const appliedMigrations = readMigrationsTable(dbPath).map(
+      (r) => r.migration_name
+    );
+    const expectedMigrations = getExpectedMigrationNames();
+
+    expect(
+      appliedMigrations,
+      `Migration mismatch.\nExpected (from prisma/migrations/): ${JSON.stringify(expectedMigrations, null, 2)}\nActual (from _prisma_migrations): ${JSON.stringify(appliedMigrations, null, 2)}`
+    ).toEqual(expectedMigrations);
+  });
+
+  test('second launch reuses existing dms.db without re-applying migrations', async () => {
+    const dbPath = path.join(tmpHome, '.dms', 'dms.db');
+
+    // Snapshot before second launch
+    const rowsBefore = readMigrationsTable(dbPath);
+
+    const child = await launchAppImage(appImagePath, tmpHome);
+    activeChild = child;
+
+    await waitForHealth();
+
+    await terminateProcess(child);
+    activeChild = null;
+
+    // Snapshot after second launch
+    const rowsAfter = readMigrationsTable(dbPath);
+
+    expect(
+      rowsAfter,
+      `_prisma_migrations changed after second launch (idempotency violation).\nBefore: ${JSON.stringify(rowsBefore, null, 2)}\nAfter:  ${JSON.stringify(rowsAfter, null, 2)}`
+    ).toEqual(rowsBefore);
+  });
+});

--- a/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import Database from 'better-sqlite3';
+import betterSqlite3 from 'better-sqlite3';
 import { expect, test } from 'playwright/test';
 
 // ─── Linux-only guard ────────────────────────────────────────────────────────
@@ -58,6 +58,7 @@ function getExpectedMigrationNames(): string[] {
     .sort();
 }
 
+/* eslint-disable @typescript-eslint/naming-convention */
 interface MigrationRow {
   id: string;
   checksum: string;
@@ -68,9 +69,10 @@ interface MigrationRow {
   started_at: string;
   applied_steps_count: number;
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 function readMigrationsTable(dbPath: string): MigrationRow[] {
-  const db = new Database(dbPath, { readonly: true });
+  const db = new betterSqlite3(dbPath, { readonly: true });
   try {
     const rows = db
       .prepare(
@@ -83,10 +85,7 @@ function readMigrationsTable(dbPath: string): MigrationRow[] {
   }
 }
 
-async function launchAppImage(
-  appImagePath: string,
-  tmpHome: string
-): Promise<ChildProcess> {
+function launchAppImage(appImagePath: string, tmpHome: string): ChildProcess {
   const args = ['--no-sandbox'];
   const env = {
     ...process.env,
@@ -98,10 +97,14 @@ async function launchAppImage(
 
   // On headless CI (no DISPLAY), wrap with xvfb-run so Electron can open a window
   if (process.env['DISPLAY'] === undefined) {
-    child = spawn('xvfb-run', ['--auto-servernum', appImagePath, ...args], {
-      env,
-      stdio: 'pipe',
-    });
+    child = spawn(
+      '/usr/bin/xvfb-run',
+      ['--auto-servernum', appImagePath, ...args],
+      {
+        env,
+        stdio: 'pipe',
+      }
+    );
   } else {
     child = spawn(appImagePath, args, { env, stdio: 'pipe' });
   }
@@ -164,7 +167,7 @@ test.describe('Packaged Electron App – launch smoke test', () => {
 
   test.beforeAll(() => {
     appImagePath = findAppImage();
-    fs.chmodSync(appImagePath, 0o755);
+    fs.chmodSync(appImagePath, 0o755); // NOSONAR: AppImage must be executable
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'dms-smoke-home-'));
   });
 
@@ -182,7 +185,7 @@ test.describe('Packaged Electron App – launch smoke test', () => {
   });
 
   test('first launch creates dms.db with all migrations applied', async () => {
-    const child = await launchAppImage(appImagePath, tmpHome);
+    const child = launchAppImage(appImagePath, tmpHome);
     activeChild = child;
 
     await waitForHealth();
@@ -221,7 +224,7 @@ test.describe('Packaged Electron App – launch smoke test', () => {
     // Snapshot before second launch
     const rowsBefore = readMigrationsTable(dbPath);
 
-    const child = await launchAppImage(appImagePath, tmpHome);
+    const child = launchAppImage(appImagePath, tmpHome);
     activeChild = child;
 
     await waitForHealth();

--- a/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
@@ -144,7 +144,7 @@ async function terminateProcess(child: ChildProcess): Promise<void> {
   // Wait up to 10 s for graceful exit, then SIGKILL
   await new Promise<void>((resolve) => {
     const killTimer = setTimeout(() => {
-      if (child.exitCode === null && !child.killed) {
+      if (child.exitCode === null) {
         child.kill('SIGKILL');
       }
       resolve();

--- a/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts
@@ -58,7 +58,7 @@ function getExpectedMigrationNames(): string[] {
     .sort();
 }
 
-/* eslint-disable @typescript-eslint/naming-convention */
+/* eslint-disable @typescript-eslint/naming-convention -- _prisma_migrations column names are snake_case by Prisma convention */
 interface MigrationRow {
   id: string;
   checksum: string;
@@ -69,7 +69,7 @@ interface MigrationRow {
   started_at: string;
   applied_steps_count: number;
 }
-/* eslint-enable @typescript-eslint/naming-convention */
+/* eslint-enable @typescript-eslint/naming-convention -- end of _prisma_migrations column name block */
 
 function readMigrationsTable(dbPath: string): MigrationRow[] {
   const db = new betterSqlite3(dbPath, { readonly: true });
@@ -167,7 +167,8 @@ test.describe('Packaged Electron App – launch smoke test', () => {
 
   test.beforeAll(() => {
     appImagePath = findAppImage();
-    fs.chmodSync(appImagePath, 0o755); // NOSONAR: AppImage must be executable
+    // eslint-disable-next-line sonarjs/file-permissions -- AppImage must be executable
+    fs.chmodSync(appImagePath, 0o755);
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'dms-smoke-home-'));
   });
 

--- a/apps/electron/README.md
+++ b/apps/electron/README.md
@@ -362,3 +362,15 @@ The embedded schema-engine approach was confirmed viable on the current target p
 The alternative "fresh DB + SQLite-only copy" fallback (described in story 98.2 Dev Notes)
 was **not** implemented because the embedded binary communicates cleanly via JSON-RPC
 without any Node dependency.
+
+## Smoke testing the packaged app
+
+Two complementary smoke-test mechanisms are provided:
+
+- **`apps/electron/scripts/smoke-test.sh`** (Story 91.4): A bash script that launches the
+  AppImage and curls `/api/health`. Useful as a quick developer-loop check.
+- **`apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts`** (Story 98.4): A
+  Playwright test that launches the AppImage in an isolated `HOME`, verifies
+  `~/.dms/dms.db` is created, checks all Prisma migrations are applied (first launch),
+  and confirms no re-migrations on a second launch (idempotency). Run via
+  `pnpm e2e:electron` (`nx run dms-material-e2e:e2e-electron`).


### PR DESCRIPTION
## Summary

Adds a Playwright smoke test that exercises the packaged Electron AppImage on Linux to regression-protect Stories 98.1 and 98.2.

## Changes

- **New:** `apps/dms-material-e2e/src/electron-package-launch-smoke.spec.ts`
  - Linux-only guard via `test.skip(process.platform !== 'linux', ...)`
  - Discovers the AppImage produced by `nx run electron:build:linux` from `dist/electron-dist/*.AppImage`; fails with a clear message if missing (no silent skips)
  - Creates an isolated temp `HOME` directory so the developer's real `~/.dms/dms.db` is untouched
  - Launches the AppImage with `--no-sandbox`; wraps with `xvfb-run --auto-servernum` when `DISPLAY` is unset (CI)
  - Polls `http://127.0.0.1:39001/api/health` via `expect.poll` (90 s timeout) — no `setTimeout` sleeps
  - **Test 1:** Verifies `~/.dms/dms.db` is created and `_prisma_migrations` rows match the source `prisma/migrations/` directories
  - **Test 2:** Snapshots all migration rows before and after a second launch; asserts deep equality to prove no migrations are re-applied
  - `afterAll` terminates the process (SIGTERM → SIGKILL) and removes the temp `HOME` via try/finally

- **Updated:** `apps/dms-material-e2e/project.json`
  - Added `dependsOn: [{ projects: ['electron'], target: 'build:linux' }]` to the `e2e-electron` target so the packaged artifact is built before the test runs

- **Updated:** `apps/electron/README.md`
  - Added "Smoke testing the packaged app" section cross-referencing `scripts/smoke-test.sh` (developer convenience, Story 91.4) and the new Playwright spec (regression suite)

## Testing

1. Build the packaged artifact: `pnpm exec nx run electron:build:linux`
2. Run the new smoke test: `pnpm exec nx run dms-material-e2e:e2e-electron --grep "Story 98.4"`
3. Run the full e2e electron suite: `pnpm e2e:electron`
4. Run full quality gates: `pnpm all`
5. Confirm formatting: `pnpm format`

Closes #1223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated Linux packaged-app smoke tests: launch + health polling, first-launch DB/migration verification, and second-launch idempotency checks.

* **Build**
  * e2e test now waits for the Linux app build before running.

* **Documentation**
  * Added smoke-testing instructions for the packaged app.

* **Chores**
  * Updated formatting ignore rules to exclude internal output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->