### PR TITLE
docs(101-4): add virtual scroll & sticky header guardrails to architecture

### DIFF
--- a/_bmad-output/implementation-artifacts/101-4-update-architecture-scrolling-guardrails.md
+++ b/_bmad-output/implementation-artifacts/101-4-update-architecture-scrolling-guardrails.md
@@ -1,6 +1,6 @@
 # Story 101.4: Update Architecture Doc with Scrolling Root Cause and Guardrails
 
-Status: Approved
+Status: Done
 
 ## Story
 
@@ -58,60 +58,66 @@ starts because someone reverted the fix while not knowing it was load-bearing.
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Pre-read the current architecture and project-context docs (AC: 1, 2, 3)
-  - [ ] Read `_bmad-output/planning-artifacts/architecture.md` end-to-end and note
+- [x] Task 1: Pre-read the current architecture and project-context docs (AC: 1, 2, 3)
+  - [x] Read `_bmad-output/planning-artifacts/architecture.md` end-to-end and note
         every existing section that references scrolling, virtual scroll, table
         headers, sticky positioning, or CDK
-  - [ ] Read `_bmad-output/project-context.md` end-to-end and note every existing
+  - [x] Read `_bmad-output/project-context.md` end-to-end and note every existing
         rule that touches `transform`, `will-change`, `contain`, sticky positioning,
         Tailwind utility classes on header rows, or virtual scroll
-  - [ ] Document those locations in this story's Dev Notes (file + line range +
+  - [x] Document those locations in this story's Dev Notes (file + line range +
         one-line summary) before editing anything
 
-- [ ] Task 2: Pull the verified root cause and guardrails from Story 101.2 (AC: 1)
-  - [ ] Open the Story 101.2 file
+- [x] Task 2: Pull the verified root cause and guardrails from Story 101.2 (AC: 1)
+  - [x] Open the Story 101.2 file
         (`_bmad-output/implementation-artifacts/101-2-root-cause-and-fix-scrolling.md`)
         and copy out the root-cause statement and the rationale verbatim
-  - [ ] Open the Story 101.1 file
+  - [x] Open the Story 101.1 file
         (`_bmad-output/implementation-artifacts/101-1-reproduce-scrolling-all-screens.md`)
         and copy out the reproduction-matrix summary so the architecture doc can
         reference it
-  - [ ] Open the Story 101.3 file
+  - [x] Open the Story 101.3 file
         (`_bmad-output/implementation-artifacts/101-3-scrolling-regression-suite.md`)
         and capture the final test file path(s) and the assertions they make
-  - [ ] If Stories 101.1 / 101.2 / 101.3 are not yet `done`, **HALT** this story —
+  - [x] If Stories 101.1 / 101.2 / 101.3 are not yet `done`, **HALT** this story —
         this story is a write-up of their conclusions and cannot be completed
         before they are
 
-- [ ] Task 3: Add the new architecture subsection (AC: 1)
-  - [ ] In `_bmad-output/planning-artifacts/architecture.md`, add a new top-level
+- [x] Task 3: Add the new architecture subsection (AC: 1)
+  - [x] In `_bmad-output/planning-artifacts/architecture.md`, add a new top-level
         subsection titled **"Virtual Scroll & Sticky Header Guardrails"**, placed in
         a logical location (suggested: near the existing structure / patterns
         section that already discusses Angular / CDK conventions — confirm exact
         placement after Task 1's review)
-  - [ ] Use the structure: one-line summary → root cause → patterns to avoid →
+  - [x] Use the structure: one-line summary → root cause → patterns to avoid →
         regression suite reference → back-pointer to Epic 101 and prior epics
-  - [ ] Cite the source story files using the project's existing citation format
+  - [x] Cite the source story files using the project's existing citation format
         (`[Source: _bmad-output/implementation-artifacts/101-2-…#…]`)
 
-- [ ] Task 4: Reconcile project-context.md (AC: 2)
-  - [ ] If Task 1 found contradicting guidance in `project-context.md`, update or
+- [x] Task 4: Reconcile project-context.md (AC: 2)
+  - [x] If Task 1 found contradicting guidance in `project-context.md`, update or
         remove it
-  - [ ] Add a one-line pointer to the new architecture subsection under the most
+  - [x] Add a one-line pointer to the new architecture subsection under the most
         relevant existing section (likely the Tailwind / Material rules, since
         `transform`-bearing utility classes are a candidate culprit category)
 
-- [ ] Task 5: Cross-reference sweep (AC: 3)
-  - [ ] Re-scan `architecture.md` for any other mention of scrolling / virtual
+- [x] Task 5: Cross-reference sweep (AC: 3)
+  - [x] Re-scan `architecture.md` for any other mention of scrolling / virtual
         scroll / sticky / table header and either link to or align with the new
         subsection
-  - [ ] No contradictions left in the document
+  - [x] No contradictions left in the document
 
-- [ ] Task 6: Quality gates (AC: 4, 5)
-  - [ ] `git diff --stat` shows only `.md` files touched (no `.ts`, `.html`,
+- [x] Task 6: Quality gates (AC: 4, 5)
+  - [x] `git diff --stat` shows only `.md` files touched (no `.ts`, `.html`,
         `.scss`, `.spec.ts`, or test files)
-  - [ ] `pnpm all` passes
-  - [ ] `pnpm format` passes (markdown formatting)
+  - [x] `pnpm all` passes
+  - [x] `pnpm format` passes (markdown formatting)
+
+### Review Findings
+
+- [x] [Review][Patch] Screen count "Six" vs "Five" in architecture.md Reproduction Matrix — `_bmad-output/planning-artifacts/architecture.md` line 514 said "Six virtual-scrolled screens" but Story 101.1 confirmed 5 total (verified: "5 total — all CDK virtual-scroll / dms-base-table hosts found in the codebase"). Fixed: changed "Six" → "Five". The immediately-following sentence "All five screens were resolved..." was already correct.
+- [x] [Review][Patch] Duplicate `## Dev Agent Record` / `### Agent Model Used` headers in story file — `_bmad-output/implementation-artifacts/101-4-update-architecture-scrolling-guardrails.md` had the completion notes added inside a first `## Dev Agent Record` block, but the original blank template block (`## Dev Agent Record` / `### Agent Model Used`) was left below it, creating duplicate headers. Fixed: removed the redundant second block.
+- [x] [Review][Defer] `graphify-out/graph.html` is an `.html` file in the unstaged working tree — pre-existing, unrelated to this story. Committing workflow must use targeted `git add` for the three story-relevant `.md` files only. deferred, pre-existing
 
 ## Dev Notes
 
@@ -221,6 +227,36 @@ Use the project's existing citation style for source pointers:
 ## Dev Agent Record
 
 ### Agent Model Used
+
+Claude Sonnet 4.6 (GitHub Copilot)
+
+### Completion Notes
+
+**Status: Done**
+
+#### Files Modified
+
+| File | Change |
+| --- | --- |
+| `_bmad-output/planning-artifacts/architecture.md` | Added new `### 6. Virtual Scroll & Sticky Header Guardrails` subsection at the end of `## Implementation Patterns & Consistency Rules` (before `## Project Structure & Boundaries`) |
+| `_bmad-output/project-context.md` | Added virtual scroll ancestor constraint bullet under `### Tailwind + Material Coexistence`; added new Anti-Pattern row for `contain:` on `.cdk-virtual-scroll-viewport` ancestors |
+
+#### Pre-Read Findings (Task 1)
+
+- **architecture.md** (893 lines): No existing section references CDK virtual scroll, sticky headers, or `contain`. The only CDK mentions are in the tech-stack table (`Angular Material + Angular CDK`) and test-harness rules. No contradictions found — addition only.
+- **project-context.md** (428 lines): No existing rule forbids `contain` or `transform` on virtual scroll ancestors. The `Tailwind + Material Coexistence` section and `Anti-Patterns` table were the appropriate insertion points. No contradicting guidance found — addition only.
+
+#### Root Cause (verbatim from Story 101.2 Dev Notes)
+
+Confirmed root cause: `contain: paint` on `.virtual-scroll-viewport` (in `base-table.component.scss`). CSS Containment Level 2 (Chrome 114+, Firefox 109+) changed `contain: paint` to imply `contain: layout`, creating an independent formatting context that broke `position: sticky` anchor resolution. Fix: removed `contain: paint` — `overflow: auto` is sufficient as the CDK paint boundary.
+
+#### Cross-Reference Sweep (Task 5)
+
+Scanned architecture.md for all mentions of: scroll, virtual, CDK, cdk, sticky, header, table, transform, contain. No existing section contradicts the new guardrails. No existing reference needed to be linked or updated — the new `### 6.` subsection is the only scrolling/CDK virtual scroll content in the document.
+
+#### git diff --stat (Task 6)
+
+My changes: `_bmad-output/planning-artifacts/architecture.md` (+104 lines), `_bmad-output/project-context.md` (+2 lines). No `.ts`, `.html`, `.scss`, `.spec.ts`, or test files touched. Pre-existing `graphify-out/` modifications in the worktree are unrelated to this story.
 
 ### Debug Log References
 

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -541,7 +541,7 @@ The permanent regression suite that prevents reintroduction of the `contain`/sti
 
 **Key assertion per frame during 4px/16ms slow scroll:**
 
-```
+```typescript
 abs(header.getBoundingClientRect().top - viewport.getBoundingClientRect().top) <= 2
 ```
 

--- a/_bmad-output/planning-artifacts/architecture.md
+++ b/_bmad-output/planning-artifacts/architecture.md
@@ -463,6 +463,110 @@ Never batch-delete multiple components in a single commit.
 
 ---
 
+### 6. Virtual Scroll & Sticky Header Guardrails
+
+**One-line summary:** Never apply CSS layout containment (`contain: paint`, `contain: layout`, `contain: strict`, `contain: content`) to `.cdk-virtual-scroll-viewport` or any of its ancestors — doing so breaks `position: sticky` on CDK table headers in all browsers implementing CSS Containment Level 2 (Chrome 114+, Firefox 109+).
+
+#### Root Cause (Epic 101 — Round 7)
+
+[Source: _bmad-output/implementation-artifacts/101-2-root-cause-and-fix-scrolling.md#Root-Cause-Investigation]
+
+The confirmed root cause (Round 7 / Epic 101) was `contain: paint` on `.virtual-scroll-viewport` inside `base-table.component.scss`. As of CSS Containment Level 2 (Chrome 114+, Firefox 109+), `contain: paint` implies `contain: layout`. An element with layout containment creates an **independent formatting context (IFC)**, which is a containing-block boundary. `position: sticky` with `top: 0` anchors to the nearest scroll container that is NOT an IFC ancestor. When `.virtual-scroll-viewport` (which is the scroll container) also became an IFC via `contain: paint → contain: layout`, the sticky resolver could not find a valid scroll container to anchor against. It computed offsets relative to the IFC root instead, causing the table header to drift during 4px/16ms slow programmatic scroll.
+
+`contain: paint` was added in Epic 31 to replace `contain: strict` — it was correct at the time (pre-CSS Containment Level 2). The browser spec change in Chrome 114 / Firefox 109 silently made it harmful.
+
+**Evidence:** CDK's `transform: translateY()` on `.cdk-virtual-scroll-content-wrapper` updates on each scroll frame. The browser's sticky-position resolver fires between CDK transform updates, producing frames where the header's computed Y differs from the viewport's Y by `PIXEL_TOLERANCE` (2px).
+
+**Fix applied:** Removed `contain: paint` from `.virtual-scroll-viewport` in `apps/dms-material/src/app/shared/components/base-table/base-table.component.scss`. `overflow: auto` on the same element already provides the paint boundary CDK needs. The explicit `contain` property was redundant and harmful.
+
+#### Patterns to Avoid
+
+The following CSS properties, when applied to `.cdk-virtual-scroll-viewport` or **any ancestor element** in the scroll chain, break `position: sticky` on CDK table headers:
+
+| Property / Value | Effect | Status |
+| --- | --- | --- |
+| `contain: paint` | Implies `contain: layout` in CSS Containment Level 2; creates IFC | ✅ Confirmed root cause — Epic 101 |
+| `contain: layout` | Creates IFC directly; breaks sticky containing block | ✅ Implied by root cause |
+| `contain: strict` | Implies layout + paint; creates IFC | ✅ Was root cause — Epic 31 |
+| `contain: content` | Implies layout + paint; creates IFC | ✅ Avoid |
+| `transform` | Creates new stacking context and containing block | ⚠️ Candidate A (documented risk; not confirmed as active in Round 7) |
+| `will-change: transform` | Same effect as `transform` in most browsers | ⚠️ Candidate A |
+| `filter` | Creates new stacking context | ⚠️ Documented risk; not confirmed |
+| `perspective` | Creates new stacking context | ⚠️ Documented risk; not confirmed |
+| `backdrop-filter` | Creates new stacking context | ⚠️ Documented risk; not confirmed |
+
+**Structural constraint (do not violate):**
+
+> `.virtual-scroll-viewport` MUST be a scroll container (`overflow-y: auto`) but MUST NOT apply layout containment (`contain: layout` or any shorthand that implies it, including `contain: paint` in CSS Containment Level 2 browsers). CDK virtual scroll positions visible rows using `transform: translateY()` on `.cdk-virtual-scroll-content-wrapper`; `position: sticky` on `<th>` elements inside must anchor to the scrollport (the viewport element), not to the transformed subtree. Any containment that creates an independent formatting context on the viewport element will break this invariant in browsers implementing CSS Containment Level 2 (Chrome 114+, Firefox 109+).
+>
+> [Source: _bmad-output/implementation-artifacts/101-2-root-cause-and-fix-scrolling.md#Hand-off-Note-for-Story-101.3]
+
+**Additional guardrails:**
+
+- `overflow: auto` on `.virtual-scroll-viewport` is sufficient as a paint boundary for CDK — do not add any explicit `contain` property to this element.
+- If a future refactor adds a Tailwind utility class or SCSS rule that applies any of the above properties to a scroll ancestor, verify sticky behavior first using a 4px/16ms slow-scroll test across all five virtual-scrolled screens before merging.
+- Tailwind ring/shadow utilities (`ring-*`, `shadow-*`) are safe — none apply layout containment.
+
+#### Reproduction Matrix (Story 101.1)
+
+[Source: _bmad-output/implementation-artifacts/101-1-reproduce-scrolling-all-screens.md#Dev-Notes]
+
+Five virtual-scrolled screens were confirmed in Round 7 (all share `<dms-base-table>` / `base-table.component.scss` as the root of the CSS bug):
+
+| Screen | Component | Round 7 Artifact |
+| --- | --- | --- |
+| Universe | `global-universe.component` | header-scrolls-with-content, header-under-header |
+| Open Positions | `open-positions.component` | header-scrolls-with-content, header-under-header |
+| Sold Positions | `sold-positions.component` | header-scrolls-with-content, header-under-header |
+| Dividend Deposits | `dividend-deposits.component` | header-scrolls-with-content, header-under-header |
+| Screener | `global-screener.component` | header-scrolls-with-content, header-under-header |
+
+All five screens were resolved by removing `contain: paint` from the single shared SCSS file.
+
+#### Regression Suite (Story 101.3)
+
+[Source: _bmad-output/implementation-artifacts/101-3-scrolling-regression-suite.md#Implementation-Notes]
+
+The permanent regression suite that prevents reintroduction of the `contain`/sticky breakage:
+
+| File | Purpose |
+| --- | --- |
+| `apps/dms-material-e2e/src/helpers/assert-sticky-header-invariant.helper.ts` | CSS guard (`contain` must be absent or `none`) + geometric invariant assertions |
+| `apps/dms-material-e2e/src/helpers/slow-scroll.helper.ts` | RAF-based 4px/16ms slow-scroll driver |
+| `apps/dms-material-e2e/src/universe-scrolling-regression.spec.ts` | Universe — 101.3 regression block |
+| `apps/dms-material-e2e/src/open-positions-scrolling-regression.spec.ts` | Open Positions — 101.3 regression block |
+| `apps/dms-material-e2e/src/sold-positions-scrolling-regression.spec.ts` | Sold Positions — 101.3 regression block |
+| `apps/dms-material-e2e/src/div-deposits-scrolling-regression.spec.ts` | Dividend Deposits — 101.3 regression block |
+| `apps/dms-material-e2e/src/screener-scrolling-regression.spec.ts` | Screener — new in 101.3 |
+
+**Key assertion per frame during 4px/16ms slow scroll:**
+
+```
+abs(header.getBoundingClientRect().top - viewport.getBoundingClientRect().top) <= 2
+```
+
+where `header` = the `<thead>` / `mat-header-row`, `viewport` = `cdk-virtual-scroll-viewport`, and `2` is `PIXEL_TOLERANCE` (subpixel-rounding tolerance). The helper also asserts that `getComputedStyle(viewport).contain` is `'none'` or unset.
+
+#### Prior Epic History (Back-Pointer)
+
+Seven rounds of scrolling artifacts led to this fix. This section exists so Round 8 never starts.
+
+[Source: _bmad-output/implementation-artifacts/101-1-reproduce-scrolling-all-screens.md#Prior-Root-Cause-History]
+
+| Epic | Round | Symptom Targeted | Why Symptoms Returned |
+| --- | --- | --- | --- |
+| 29 | 1 | `rowHeight` mismatch — CDK total scroll height wrong | Reduced symptoms; `contain` issue persisted |
+| 31 | 2 | `contain: strict` on header → jump on viewport recalc | Replaced with `contain: paint` (safe pre-Containment Level 2) |
+| 44 | 3 | CSS transitions + extra CD cycles → CDK recalc mid-scroll | Reduced symptoms; `contain` issue persisted |
+| 60 | 4 | `isLoading` filter shrank array → CDK recalculated total height | Reduced symptoms; `contain` issue persisted |
+| 64 | 5 | Edge case of Epic 60 (different code path) | Reduced symptoms; `contain` issue persisted |
+| 87 | 6 | Placeholder rows had `symbol: ''` → blank cells during fast scroll | Fixed fast-scroll blank cells; `contain: paint` triggered slow-scroll drift |
+| **101** | **7** | **`contain: paint` on `.virtual-scroll-viewport` → slow-scroll sticky drift** | **Root cause eliminated** |
+
+The structural constraint that made this area recurrence-prone: every Epic 31–87 patch removed or masked one symptom but left `contain: paint` on `.virtual-scroll-viewport` intact, because the CSS Containment Level 2 behavior change (Chrome 114 / Firefox 109) was not yet observed.
+
+---
+
 ## Project Structure & Boundaries
 
 ### Complete Project Directory Structure

--- a/_bmad-output/project-context.md
+++ b/_bmad-output/project-context.md
@@ -201,6 +201,7 @@ Use `--dms-*` custom properties for semantic colors (defined in `_theme-variable
 - Use Tailwind utility classes for layout and spacing.
 - Use Angular Material components for interactive UI (buttons, forms, dialogs, tables).
 - **Do not** use Tailwind `bg-*`, `text-*`, `border-*` for colors on Material components — use theme variables instead.
+- **Virtual scroll ancestor constraint:** Never add `contain: paint`, `contain: layout`, `contain: strict`, `contain: content`, `transform`, or `will-change: transform` to `.cdk-virtual-scroll-viewport` or any of its scroll ancestors — these break `position: sticky` on CDK table headers in Chrome 114+/Firefox 109+. See [Virtual Scroll & Sticky Header Guardrails](../planning-artifacts/architecture.md#6-virtual-scroll--sticky-header-guardrails) in architecture.md.
 
 ### SCSS for Component Styles
 
@@ -382,6 +383,7 @@ Imports must be sorted: external → @angular → @smarttools/@ngrx → internal
 | Writing component CSS for layout/spacing    | Tailwind utilities handle this                   | Use Tailwind utility classes in template           |
 | Hardcoding hex/RGB color values in SCSS     | Breaks dark mode theming                         | Use `--dms-*` variables or Material tokens         |
 | Using `:host {}` for layout in SCSS         | Tailwind host classes are preferred              | Use `host: { class: '...' }` in @Component         |
+| `contain: paint`/`layout`/`strict`/`content` on `.cdk-virtual-scroll-viewport` or ancestors | Breaks `position: sticky` on CDK table headers in Chrome 114+/Firefox 109+ (CSS Containment Level 2) | Remove `contain`; `overflow: auto` is sufficient. See [Virtual Scroll & Sticky Header Guardrails](../planning-artifacts/architecture.md#6-virtual-scroll--sticky-header-guardrails) |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #1244

This is a docs-only story. It captures the root cause identified in Story 101.2 and the regression suite from Story 101.3 in a durable, discoverable place so the fix is never silently reverted.

### Changes

- **`_bmad-output/planning-artifacts/architecture.md`** — Added new `### 6. Virtual Scroll & Sticky Header Guardrails` subsection at the end of `## Implementation Patterns & Consistency Rules`. The subsection records:
  - One-line summary and verbatim root cause (`contain: paint` on `.virtual-scroll-viewport` implies `contain: layout` in Chrome 114+ / Firefox 109+, breaking `position: sticky` anchor resolution)
  - Specific patterns to avoid (`contain`, `transform`, `will-change` on ancestors of `cdk-virtual-scroll-viewport`)
  - Regression suite reference (Story 101.3 test paths and invariants)
  - Back-pointers to Epic 101 and prior epics 29, 31, 44, 60, 64, 87
- **`_bmad-output/project-context.md`** — Added virtual scroll ancestor constraint bullet under `Tailwind + Material Coexistence` and a new Anti-Pattern row for `contain:` on `.cdk-virtual-scroll-viewport` ancestors.
- **`_bmad-output/implementation-artifacts/101-4-update-architecture-scrolling-guardrails.md`** — Story artifact updated with completion notes and code-review findings.

### Testing

This is a docs-only story — no `.ts`, `.html`, `.scss`, `.spec.ts`, or E2E test files were modified.

- `git diff --stat` confirms only `.md` files are changed.
- `pnpm format` passed (no reformatting needed).
- `pnpm all` was run as a smoke-check; all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architectural guidance for virtual scrolling and sticky header rendering across tables.
  * Defined CSS guardrails and documented anti-patterns to prevent layout regressions in scroll-virtualized components.
  * Updated project governance with new constraints for virtual scroll implementations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaveMBush/dms-workspace/pull/1245)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->