### PR TITLE
feat(e2e): E2E Smoke Test — Packaged Electron App Launches Cleanly

### DIFF
--- a/_bmad-output/implementation-artifacts/102-3-e2e-electron-package-launch.md
+++ b/_bmad-output/implementation-artifacts/102-3-e2e-electron-package-launch.md
@@ -1,6 +1,6 @@
 # Story 102.3: E2E Smoke Test — Packaged Electron App Launches Cleanly
 
-Status: Approved
+Status: Complete
 
 <!-- Source: _bmad-output/planning-artifacts/epics-2026-05-08.md, Epic 102, Story 102.3 -->
 
@@ -39,72 +39,72 @@ inlining) are caught before release.
 
 ## Tasks / Subtasks
 
-- [ ] Decide test placement and gating strategy (AC: #4)
-  - [ ] Inspect `apps/dms-material-e2e/playwright.config.ts` and existing `electron` project
+- [x] Decide test placement and gating strategy (AC: #4)
+  - [x] Inspect `apps/dms-material-e2e/playwright.config.ts` and existing `electron` project
         used by Story 77.5 (`electron-launch.spec.ts`) to confirm naming conventions
-  - [ ] Decide whether the new spec joins the existing `electron` project or lives in a new
+  - [x] Decide whether the new spec joins the existing `electron` project or lives in a new
         `electron-smoke` project (recommend new project: it requires a packaged installer,
         not just a built `main.js`)
-  - [ ] If `pnpm all` cannot reasonably install a packaged `.deb` in the developer/CI
+  - [x] If `pnpm all` cannot reasonably install a packaged `.deb` in the developer/CI
         environment, gate behind a new Nx target `e2e:electron:smoke` and document in
         `docs/architecture.md` (or `_bmad-output/planning-artifacts/architecture.md`) as a
         required release-gate check; otherwise wire into the default `pnpm all` flow
-  - [ ] Update `apps/dms-material-e2e/project.json` with the chosen target
+  - [x] Update `apps/dms-material-e2e/project.json` with the chosen target
 
-- [ ] Build a clean-fixture install helper (AC: #1)
-  - [ ] In a new spec (e.g., `apps/dms-material-e2e/src/electron-smoke.spec.ts`) add a helper
+- [x] Build a clean-fixture install helper (AC: #1)
+  - [x] In a new spec (e.g., `apps/dms-material-e2e/src/electron-smoke.spec.ts`) add a helper
         that: locates the latest `.deb` under `dist/electron-dist/` (per
         `apps/electron/electron-builder.yml` `directories.output`), installs it into an
         isolated fixture, and records the install root path
-  - [ ] Prefer `dpkg -x <deb> <fixture>` for an unprivileged extract when only verifying file
+  - [x] Prefer `dpkg -x <deb> <fixture>` for an unprivileged extract when only verifying file
         layout; use `sudo dpkg -i` (or `pkexec`) only when the test must validate the real
         post-install hook from Story 102.1 — which it must, per AC #1
-  - [ ] Capture `stdout`/`stderr` of the install and fail fast on non-zero exit
-  - [ ] If `sudo` is required, gate with a clear precondition skip + actionable error message
+  - [x] Capture `stdout`/`stderr` of the install and fail fast on non-zero exit
+  - [x] If `sudo` is required, gate with a clear precondition skip + actionable error message
 
-- [ ] Assert chrome-sandbox ownership and mode (AC: #1)
-  - [ ] After install, `stat -c '%U:%G %a' /opt/DMS/chrome-sandbox` (or installed equivalent
+- [x] Assert chrome-sandbox ownership and mode (AC: #1)
+  - [x] After install, `stat -c '%U:%G %a' /opt/DMS/chrome-sandbox` (or installed equivalent
         path resolved from the fixture) and assert `root:root` and `4755`
-  - [ ] On failure, surface the actual values and the install log to make Story 102.1
+  - [x] On failure, surface the actual values and the install log to make Story 102.1
         regressions obvious
 
-- [ ] Launch the installed binary without `--no-sandbox` and capture diagnostics (AC: #2, #3)
-  - [ ] Spawn the installed app binary directly (NOT via `playwright._electron.launch` against
+- [x] Launch the installed binary without `--no-sandbox` and capture diagnostics (AC: #2, #3)
+  - [x] Spawn the installed app binary directly (NOT via `playwright._electron.launch` against
         `dist/apps/electron/main.js` — that bypasses packaging). Use `child_process.spawn` to
         execute the installed binary at its real path (e.g., `/opt/DMS/dms`), then attach
         Playwright via Chrome DevTools Protocol if needed for window assertions
-  - [ ] Pass NO `--no-sandbox` argument
-  - [ ] Tee stdout+stderr; assert the captured text does NOT contain
+  - [x] Pass NO `--no-sandbox` argument
+  - [x] Tee stdout+stderr; assert the captured text does NOT contain
         `The SUID sandbox helper binary was found, but is not configured correctly`
-  - [ ] Assert the captured text does NOT contain `Cannot find module 'tslib'`
-  - [ ] Assert the process did not exit with a non-zero code within the launch window
-  - [ ] If using Playwright `_electron.launch` against the installed binary path is feasible
+  - [x] Assert the captured text does NOT contain `Cannot find module 'tslib'`
+  - [x] Assert the process did not exit with a non-zero code within the launch window
+  - [x] If using Playwright `_electron.launch` against the installed binary path is feasible
         (Playwright accepts an `executablePath` for ElectronApplication on some channels),
         prefer that for window/console assertions; otherwise fall back to CDP attach
 
-- [ ] Assert the main window renders cleanly (AC: #3)
-  - [ ] Wait for the first BrowserWindow and `domcontentloaded`, mirroring the Story 77.5
+- [x] Assert the main window renders cleanly (AC: #3)
+  - [x] Wait for the first BrowserWindow and `domcontentloaded`, mirroring the Story 77.5
         pattern in `apps/dms-material-e2e/src/electron-launch.spec.ts`
-  - [ ] Register `window.on('console', ...)` to collect console errors and assert empty
-  - [ ] Assert a known home-route element is visible (reuse the selector pattern from
+  - [x] Register `window.on('console', ...)` to collect console errors and assert empty
+  - [x] Assert a known home-route element is visible (reuse the selector pattern from
         `electron-launch.spec.ts`)
 
-- [ ] Cleanup (AC: #1, #2)
-  - [ ] In `afterAll`: close the app, then `dpkg -r dms` (or extract-only cleanup `rm -rf
+- [x] Cleanup (AC: #1, #2)
+  - [x] In `afterAll`: close the app, then `dpkg -r dms` (or extract-only cleanup `rm -rf
         <fixture>`) to leave the host clean
-  - [ ] Ensure cleanup runs even when the test fails
+  - [x] Ensure cleanup runs even when the test fails
 
-- [ ] Wire into the build pipeline (AC: #4)
-  - [ ] Add `dependsOn` so the smoke target requires `electron:package` (or whatever target
+- [x] Wire into the build pipeline (AC: #4)
+  - [x] Add `dependsOn` so the smoke target requires `electron:package` (or whatever target
         produces the `.deb` per `electron-builder.yml`) — not just `electron:build`
-  - [ ] Update `pnpm all` script in root `package.json` to include the smoke target IF not
+  - [x] Update `pnpm all` script in root `package.json` to include the smoke target IF not
         gated; otherwise add a docs note pointing to the gated `pnpm e2e:electron:smoke`
-  - [ ] Run the chosen path locally and confirm the test runs and passes
+  - [x] Run the chosen path locally and confirm the test runs and passes
 
-- [ ] Documentation (AC: #4)
-  - [ ] If gated: add a "Release Gate Tests" subsection to the architecture document
+- [x] Documentation (AC: #4)
+  - [x] If gated: add a "Release Gate Tests" subsection to the architecture document
         listing `e2e:electron:smoke` as required before tagging an Electron release
-  - [ ] Cross-link Stories 102.1 and 102.2 so future regressions to either are routed back to
+  - [x] Cross-link Stories 102.1 and 102.2 so future regressions to either are routed back to
         this test
 
 ## Dev Notes

--- a/apps/dms-material-e2e/playwright.config.ts
+++ b/apps/dms-material-e2e/playwright.config.ts
@@ -122,7 +122,17 @@ export default defineConfig({
     {
       name: 'electron',
       testMatch: ['**/electron-*.spec.ts'],
+      testIgnore: ['**/electron-smoke.spec.ts'],
       // No baseURL — the test launches Electron directly
+      use: {},
+    },
+
+    {
+      name: 'electron-smoke',
+      testMatch: ['**/electron-smoke.spec.ts'],
+      // Release-gate test: installs the packaged .deb; requires root (sudo).
+      // Run via: sudo pnpm e2e:electron:smoke
+      // NOT included in the default pnpm all pipeline.
       use: {},
     },
 

--- a/apps/dms-material-e2e/project.json
+++ b/apps/dms-material-e2e/project.json
@@ -43,6 +43,19 @@
         "project": ["electron"]
       }
     },
+    "e2e-electron-smoke": {
+      "executor": "@nx/playwright:playwright",
+      "dependsOn": [
+        {
+          "projects": ["electron"],
+          "target": "build:linux"
+        }
+      ],
+      "options": {
+        "config": "apps/dms-material-e2e/playwright.config.ts",
+        "project": ["electron-smoke"]
+      }
+    },
     "e2e-ui": {
       "executor": "@nx/playwright:playwright",
       "options": {

--- a/apps/dms-material-e2e/src/electron-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-smoke.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * E2E Smoke Test: Packaged Electron App Launches Cleanly
+ *
+ * Story 102.3 — Release-gate test that installs the packaged .deb artifact,
+ * validates chrome-sandbox ownership/mode (Story 102.1), asserts no tslib error
+ * (Story 102.2), and confirms the Angular app renders without console errors
+ * (Story 77.5 pattern).
+ *
+ * REQUIRES ROOT: dpkg -i sets the chrome-sandbox SUID bit (4755 root:root).
+ * Run via:  sudo pnpm e2e:electron:smoke
+ *
+ * This test is NOT part of the default `pnpm all` pipeline.
+ * It is a required release-gate check that must pass before tagging an
+ * Electron release.  See docs/deployment-guide.md § Release Gate Tests.
+ */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  _electron as electron,
+  ElectronApplication,
+  Page,
+} from 'playwright';
+import { expect, test } from 'playwright/test';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Installed binary path (electron-builder deb, productName: DMS → /opt/DMS/) */
+const INSTALLED_BINARY = '/opt/DMS/dms';
+/** chrome-sandbox path set by afterInstall.sh in Story 102.1 */
+const CHROME_SANDBOX_PATH = '/opt/DMS/chrome-sandbox';
+/** dpkg package name used for removal in cleanup */
+const DPKG_PACKAGE_NAME = 'dms';
+
+/** Workspace root: apps/dms-material-e2e/src → workspace root (3 levels up) */
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../');
+/** Directory where electron-builder writes the Linux .deb artifact */
+const DEB_DIST_DIR = path.join(WORKSPACE_ROOT, 'dist', 'electron-dist');
+
+/** Error string that must be ABSENT from process output (Story 102.1 regression) */
+const SANDBOX_FATAL =
+  'The SUID sandbox helper binary was found, but is not configured correctly';
+/** Error string that must be ABSENT from process output (Story 102.2 regression) */
+const TSLIB_MISSING = "Cannot find module 'tslib'";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the newest .deb artifact under dist/electron-dist/.
+ * Returns null if the directory does not exist or contains no .deb files.
+ */
+function findDebArtifact(): string | null {
+  if (!fs.existsSync(DEB_DIST_DIR)) {
+    return null;
+  }
+  const debs = fs
+    .readdirSync(DEB_DIST_DIR)
+    .filter((f) => f.endsWith('.deb'))
+    .map((f) => ({
+      file: f,
+      mtime: fs.statSync(path.join(DEB_DIST_DIR, f)).mtimeMs,
+    }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  return debs.length > 0 ? path.join(DEB_DIST_DIR, debs[0].file) : null;
+}
+
+// Evaluate preconditions at module load time so skip messages are immediate.
+const debPath = findDebArtifact();
+const isRoot =
+  typeof process.getuid === 'function' && process.getuid() === 0;
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+test.describe('Packaged Electron Smoke Test', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let app: ElectronApplication | null = null;
+  let window: Page | null = null;
+  const consoleErrors: string[] = [];
+
+  /** Aggregated stdout+stderr captured from the Electron process */
+  let processOutput = '';
+
+  // -------------------------------------------------------------------------
+  // beforeAll — install the .deb
+  // -------------------------------------------------------------------------
+  test.beforeAll(async () => {
+    if (!isRoot) {
+      test.skip(
+        true,
+        [
+          'Packaged Electron smoke test requires root privileges (dpkg -i must',
+          'set the chrome-sandbox SUID bit).',
+          'Run: sudo pnpm e2e:electron:smoke',
+        ].join(' ')
+      );
+      return;
+    }
+
+    if (!debPath) {
+      test.skip(
+        true,
+        [
+          `No .deb artifact found in ${DEB_DIST_DIR}.`,
+          'Build the package first: pnpm nx run electron:build:linux',
+        ].join(' ')
+      );
+      return;
+    }
+
+    try {
+      const installLog = execSync(`dpkg -i "${debPath}" 2>&1`, {
+        encoding: 'utf8',
+      });
+      processOutput += installLog;
+    } catch (err: unknown) {
+      const e = err as { stdout?: string; stderr?: string; message: string };
+      throw new Error(
+        [
+          `dpkg install failed — cannot proceed with smoke test.`,
+          `  artifact: ${debPath}`,
+          `  error: ${e.message}`,
+          `  stdout: ${e.stdout ?? '(none)'}`,
+          `  stderr: ${e.stderr ?? '(none)'}`,
+        ].join('\n')
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // afterAll — close app, uninstall package
+  // -------------------------------------------------------------------------
+  test.afterAll(async () => {
+    if (app) {
+      await app.close().catch(() => undefined);
+      app = null;
+    }
+
+    if (isRoot) {
+      try {
+        execSync(`dpkg -r ${DPKG_PACKAGE_NAME} 2>&1`, { encoding: 'utf8' });
+      } catch {
+        // Best-effort cleanup — dpkg -r may fail if the package was never
+        // fully installed; do not fail the suite.
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // AC#1: chrome-sandbox permissions
+  // -------------------------------------------------------------------------
+  test('AC#1: chrome-sandbox has owner root:root and mode 4755 after dpkg install', () => {
+    expect(
+      fs.existsSync(CHROME_SANDBOX_PATH),
+      `chrome-sandbox not found at ${CHROME_SANDBOX_PATH}. ` +
+        `The afterInstall hook from Story 102.1 may not have run.`
+    ).toBe(true);
+
+    const statOutput = execSync(
+      `stat -c '%U:%G %a' "${CHROME_SANDBOX_PATH}"`,
+      { encoding: 'utf8' }
+    ).trim();
+
+    expect(
+      statOutput,
+      `Expected "root:root 4755" — got "${statOutput}". ` +
+        `Story 102.1 afterInstall hook (chown/chmod) may have regressed.`
+    ).toBe('root:root 4755');
+  });
+
+  // -------------------------------------------------------------------------
+  // AC#2 + AC#3: launch installed binary, assert no fatal errors, assert
+  //              home route renders without console errors
+  // -------------------------------------------------------------------------
+  test(
+    'AC#2 + AC#3: app launches without sandbox FATAL or tslib error; ' +
+      'home route renders without console errors',
+    async () => {
+      // Build environment — mirror Story 77.5 (electron-launch.spec.ts)
+      const launchEnv: Record<string, string> = {
+        ...(process.env as Record<string, string>),
+        DMS_ENABLE_MOCK_AUTH: '1',
+        ELECTRON_TEST_MODE: '1',
+      };
+      // Unset ELECTRON_RUN_AS_NODE to avoid interfering with the packaged binary
+      delete launchEnv['ELECTRON_RUN_AS_NODE'];
+
+      // Launch the INSTALLED binary — this exercises the full packaged artifact,
+      // including the asar bundle (tslib resolution) and sandbox setup.
+      app = await electron.launch({
+        executablePath: INSTALLED_BINARY,
+        env: launchEnv,
+        timeout: 45000,
+      });
+
+      // Tee process stdout+stderr into processOutput for AC#2 assertions.
+      app.process().stdout?.on('data', (chunk: Buffer) => {
+        processOutput += chunk.toString();
+      });
+      app.process().stderr?.on('data', (chunk: Buffer) => {
+        processOutput += chunk.toString();
+      });
+
+      window = await app.firstWindow();
+
+      // Collect renderer console errors for AC#3.
+      window.on('console', function onConsoleMessage(msg): void {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      await window.waitForLoadState('domcontentloaded', { timeout: 30000 });
+
+      // Brief settle so synchronous startup errors appear in processOutput
+      // before we assert (sandbox FATAL prints at Electron startup).
+      await new Promise<void>((resolve) => setTimeout(resolve, 1500));
+
+      // --- AC#2 assertions ---
+
+      expect(
+        processOutput,
+        `Sandbox FATAL detected — Story 102.1 chrome-sandbox fix may have regressed.\n` +
+          `Captured output:\n${processOutput}`
+      ).not.toContain(SANDBOX_FATAL);
+
+      expect(
+        processOutput,
+        `tslib module-not-found error detected — Story 102.2 importHelpers inlining ` +
+          `may have regressed.\nCaptured output:\n${processOutput}`
+      ).not.toContain(TSLIB_MISSING);
+
+      // --- AC#3 assertions ---
+
+      await expect(window.locator('body')).toBeVisible({ timeout: 15000 });
+
+      const bodyText = await window.locator('body').textContent();
+      expect(
+        bodyText,
+        'body element has no text content — home route did not render'
+      ).toBeTruthy();
+
+      expect(
+        consoleErrors,
+        `Renderer console errors on initial load:\n${consoleErrors.join('\n')}`
+      ).toHaveLength(0);
+    }
+  );
+});

--- a/apps/dms-material-e2e/src/electron-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-smoke.spec.ts
@@ -113,7 +113,7 @@ test.describe('Packaged Electron Smoke Test', () => {
     }
 
     try {
-      // eslint-disable-next-line sonarjs/os-command
+      // eslint-disable-next-line sonarjs/os-command -- debPath is a validated local file path from a controlled test environment
       const installLog = execSync(`dpkg -i "${debPath}" 2>&1`, {
         encoding: 'utf8',
       });
@@ -143,7 +143,7 @@ test.describe('Packaged Electron Smoke Test', () => {
 
     if (isRoot) {
       try {
-        // eslint-disable-next-line sonarjs/os-command
+        // eslint-disable-next-line sonarjs/os-command -- DPKG_PACKAGE_NAME is a constant defined in this test file
         execSync(`dpkg -r ${DPKG_PACKAGE_NAME} 2>&1`, { encoding: 'utf8' });
       } catch {
         // Best-effort cleanup — dpkg -r may fail if the package was never
@@ -162,7 +162,7 @@ test.describe('Packaged Electron Smoke Test', () => {
         `The afterInstall hook from Story 102.1 may not have run.`
     ).toBe(true);
 
-    // eslint-disable-next-line sonarjs/os-command
+    // eslint-disable-next-line sonarjs/os-command -- CHROME_SANDBOX_PATH is a constant defined in this test file
     const statOutput = execSync(`stat -c '%U:%G %a' "${CHROME_SANDBOX_PATH}"`, {
       encoding: 'utf8',
     }).trim();

--- a/apps/dms-material-e2e/src/electron-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-smoke.spec.ts
@@ -88,7 +88,7 @@ test.describe('Packaged Electron Smoke Test', () => {
   // -------------------------------------------------------------------------
   // beforeAll — install the .deb
   // -------------------------------------------------------------------------
-  test.beforeAll(async () => {
+  test.beforeAll(() => {
     if (!isRoot) {
       test.skip(
         true,
@@ -113,6 +113,7 @@ test.describe('Packaged Electron Smoke Test', () => {
     }
 
     try {
+      // eslint-disable-next-line sonarjs/os-command
       const installLog = execSync(`dpkg -i "${debPath}" 2>&1`, {
         encoding: 'utf8',
       });
@@ -142,6 +143,7 @@ test.describe('Packaged Electron Smoke Test', () => {
 
     if (isRoot) {
       try {
+        // eslint-disable-next-line sonarjs/os-command
         execSync(`dpkg -r ${DPKG_PACKAGE_NAME} 2>&1`, { encoding: 'utf8' });
       } catch {
         // Best-effort cleanup — dpkg -r may fail if the package was never
@@ -160,6 +162,7 @@ test.describe('Packaged Electron Smoke Test', () => {
         `The afterInstall hook from Story 102.1 may not have run.`
     ).toBe(true);
 
+    // eslint-disable-next-line sonarjs/os-command
     const statOutput = execSync(`stat -c '%U:%G %a' "${CHROME_SANDBOX_PATH}"`, {
       encoding: 'utf8',
     }).trim();

--- a/apps/dms-material-e2e/src/electron-smoke.spec.ts
+++ b/apps/dms-material-e2e/src/electron-smoke.spec.ts
@@ -18,11 +18,7 @@ import { execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 
-import {
-  _electron as electron,
-  ElectronApplication,
-  Page,
-} from 'playwright';
+import { _electron as electron, ElectronApplication, Page } from 'playwright';
 import { expect, test } from 'playwright/test';
 
 // ---------------------------------------------------------------------------
@@ -73,8 +69,7 @@ function findDebArtifact(): string | null {
 
 // Evaluate preconditions at module load time so skip messages are immediate.
 const debPath = findDebArtifact();
-const isRoot =
-  typeof process.getuid === 'function' && process.getuid() === 0;
+const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
 
 // ---------------------------------------------------------------------------
 // Suite
@@ -165,10 +160,9 @@ test.describe('Packaged Electron Smoke Test', () => {
         `The afterInstall hook from Story 102.1 may not have run.`
     ).toBe(true);
 
-    const statOutput = execSync(
-      `stat -c '%U:%G %a' "${CHROME_SANDBOX_PATH}"`,
-      { encoding: 'utf8' }
-    ).trim();
+    const statOutput = execSync(`stat -c '%U:%G %a' "${CHROME_SANDBOX_PATH}"`, {
+      encoding: 'utf8',
+    }).trim();
 
     expect(
       statOutput,

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -304,3 +304,38 @@ Key metrics to monitor:
 - JWT auth failure rate (Cognito issues)
 - Database connection pool (PostgreSQL max_connections)
 - CUSIP cache hit rate (indicates Yahoo Finance API health)
+
+---
+
+## Release Gate Tests
+
+The following tests must pass before tagging an Electron release.
+They are **not** part of the default `pnpm all` pipeline because they require
+elevated privileges or a fully packaged artifact.
+
+### Packaged Electron Smoke Test (`e2e:electron:smoke`)
+
+**Story 102.3** — Validates the Linux `.deb` artifact end-to-end.
+
+| What it checks | Related story |
+|---|---|
+| `chrome-sandbox` has owner `root:root` and mode `4755` after `dpkg -i` | Story 102.1 |
+| No `The SUID sandbox helper binary was found, but is not configured correctly` in process output | Story 102.1 |
+| No `Cannot find module 'tslib'` in process output | Story 102.2 |
+| Angular home route renders without renderer console errors | Story 77.5 |
+
+**How to run:**
+
+```bash
+# 1. Build the Linux package
+pnpm nx run electron:build:linux
+
+# 2. Run the smoke test as root (required for dpkg -i SUID setup)
+sudo pnpm e2e:electron:smoke
+```
+
+**Nx target**: `dms-material-e2e:e2e-electron-smoke`  
+**Spec file**: `apps/dms-material-e2e/src/electron-smoke.spec.ts`
+
+> If the test is skipped with "requires root privileges", re-run with `sudo`.  
+> If the test is skipped with "No .deb artifact found", build the package first.

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -317,12 +317,12 @@ elevated privileges or a fully packaged artifact.
 
 **Story 102.3** — Validates the Linux `.deb` artifact end-to-end.
 
-| What it checks | Related story |
-|---|---|
-| `chrome-sandbox` has owner `root:root` and mode `4755` after `dpkg -i` | Story 102.1 |
-| No `The SUID sandbox helper binary was found, but is not configured correctly` in process output | Story 102.1 |
-| No `Cannot find module 'tslib'` in process output | Story 102.2 |
-| Angular home route renders without renderer console errors | Story 77.5 |
+| What it checks                                                                                   | Related story |
+| ------------------------------------------------------------------------------------------------ | ------------- |
+| `chrome-sandbox` has owner `root:root` and mode `4755` after `dpkg -i`                           | Story 102.1   |
+| No `The SUID sandbox helper binary was found, but is not configured correctly` in process output | Story 102.1   |
+| No `Cannot find module 'tslib'` in process output                                                | Story 102.2   |
+| Angular home route renders without renderer console errors                                       | Story 77.5    |
 
 **How to run:**
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "e2e:dms-material:chromium": "nx run dms-material-e2e:e2e-chromium",
     "e2e:dms-material:firefox": "nx run dms-material-e2e:e2e-firefox",
     "e2e:electron": "nx run dms-material-e2e:e2e-electron",
+    "e2e:electron:smoke": "nx run dms-material-e2e:e2e-electron-smoke",
     "db:create": "prisma generate && prisma migrate deploy",
     "postinstall": "if [ \"$CI\" = \"true\" ]; then prisma generate; fi"
   },


### PR DESCRIPTION
## Summary

Implements story 102-3: a release-gate smoke test that verifies the packaged Electron app launches cleanly without errors.

### Changes

- **apps/dms-material-e2e/src/electron-smoke.spec.ts** — new Playwright smoke test that launches the packaged Electron binary, waits for the main window to appear, and asserts no fatal console errors occur
- **apps/dms-material-e2e/playwright.config.ts** — added `electron-smoke` Playwright project wired to the Electron launch helper
- **apps/dms-material-e2e/project.json** — added `e2e-electron-smoke` Nx target so the smoke suite can be run independently of the full E2E suite
- **package.json** — added `e2e:electron:smoke` convenience script
- **docs/deployment-guide.md** — added *Release Gate Tests* section documenting when and how to run the smoke test before shipping a release

### Testing

Run the smoke test locally against a packaged build:

```bash
pnpm e2e:electron:smoke
```

Or via the Nx target:

```bash
nx e2e-electron-smoke dms-material-e2e
```

Closes #1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a packaged Electron smoke E2E that verifies install, sandbox ownership/mode, runtime stdout/stderr, renderer console errors, and home-route rendering.

* **Tests**
  * Split projects to isolate the smoke test; suite auto-skips when not run as root or when no packaged artifact is present.

* **Chores**
  * Added an Nx target and a top-level script to run the smoke smoke test.

* **Documentation**
  * Added release-gate smoke test guidance and run instructions to the deployment guide.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaveMBush/dms-workspace/pull/1251)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->