### PR TITLE
feat(story-109-1): investigate universe expired-no-open filter

### DIFF
--- a/_bmad-output/implementation-artifacts/109-1-investigate-universe-expired-filter.md
+++ b/_bmad-output/implementation-artifacts/109-1-investigate-universe-expired-filter.md
@@ -1,6 +1,6 @@
 # Story 109.1: Investigate Universe Endpoint and Define Expired-No-Open Filter
 
-Status: Approved
+Status: review
 
 **Story Key:** `109-1-investigate-universe-expired-filter`
 **Epic:** 109 — Filter Expired Symbols With No Open Positions from Universe Screen
@@ -48,62 +48,62 @@ This story (109.1) is the **investigation/diagnosis** story. It locates the rout
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Trace Universe page load end-to-end** (AC: #1)
-  - [ ] Locate the Angular Universe component and its data service:
+- [x] **Task 1 — Trace Universe page load end-to-end** (AC: #1)
+  - [x] Locate the Angular Universe component and its data service:
         [apps/dms-material/src/app/global/global-universe/global-universe.component.ts](../../apps/dms-material/src/app/global/global-universe/global-universe.component.ts)
         and surrounding files. Note the HTTP call (URL, method, query string).
-  - [ ] Locate the Fastify route registration:
+  - [x] Locate the Fastify route registration:
         [apps/server/src/app/routes/universe/get-all-universes/index.ts](../../apps/server/src/app/routes/universe/get-all-universes/index.ts).
         Note the route path, method, and handler function.
-  - [ ] Walk the handler and record (a) the Prisma query call(s), (b) the `include`/`select`
+  - [x] Walk the handler and record (a) the Prisma query call(s), (b) the `include`/`select`
         shape, (c) any post-query mapping (cite
         [apps/server/src/app/routes/universe/universe-helpers.ts](../../apps/server/src/app/routes/universe/universe-helpers.ts)
         functions used).
-  - [ ] Record the returned row DTO shape (cite
+  - [x] Record the returned row DTO shape (cite
         [apps/server/src/app/routes/universe/universe.interface.ts](../../apps/server/src/app/routes/universe/universe.interface.ts)).
 
-- [ ] **Task 2 — Identify the expired predicate** (AC: #2)
-  - [ ] Inspect [prisma/schema.prisma](../../prisma/schema.prisma) `model universe`
+- [x] **Task 2 — Identify the expired predicate** (AC: #2)
+  - [x] Inspect [prisma/schema.prisma](../../prisma/schema.prisma) `model universe`
         lines 25–50 and note both relevant fields: the boolean `expired` flag and the
         `ex_date DateTime?` field.
-  - [ ] Decide and document whether the predicate uses (a) the persisted `expired`
+  - [x] Decide and document whether the predicate uses (a) the persisted `expired`
         boolean column or (b) a real-time comparison `ex_date < now()`. Justify based
         on (i) which value the existing handler already mapper uses (see
         `mapUniverseToResponse` in [universe/index.ts](../../apps/server/src/app/routes/universe/index.ts)
         line ~36 and the `expired` field on `UniverseWithTrades`), (ii) whether `expired`
         is recomputed on read or written once and may go stale.
-  - [ ] If `expired` is authoritative (already kept in sync), prefer it (simpler WHERE
+  - [x] If `expired` is authoritative (already kept in sync), prefer it (simpler WHERE
         clause). If not, prefer `ex_date < server now()` — document the precise SQL/Prisma
         shape in either case.
 
-- [ ] **Task 3 — Cite the canonical open-trade predicate** (AC: #2)
-  - [ ] Locate `getOpenTrades` in
+- [x] **Task 3 — Cite the canonical open-trade predicate** (AC: #2)
+  - [x] Locate `getOpenTrades` in
         [apps/server/src/app/routes/universe/universe-helpers.ts](../../apps/server/src/app/routes/universe/universe-helpers.ts)
         (lines 7–11). Confirm the predicate is `sell_date === null`.
-  - [ ] Confirm by searching for any other open-position predicate in the codebase
+  - [x] Confirm by searching for any other open-position predicate in the codebase
         (`apps/server/src/app/routes/trades/get-open-trades`,
         `apps/server/src/app/routes/positions`, etc.). If multiple variants exist,
         cite each and choose the canonical one to reuse.
-  - [ ] Document the exact Prisma shape that expresses "this universe row has at
+  - [x] Document the exact Prisma shape that expresses "this universe row has at
         least one open trade" — e.g. `trades: { some: { sell_date: null, deletedAt: null } }`
         — paying attention to soft-delete (`deletedAt`) conventions used elsewhere.
 
-- [ ] **Task 4 — Choose the filter strategy** (AC: #3)
-  - [ ] Compare Option A (single Prisma `WHERE` clause that excludes rows where
+- [x] **Task 4 — Choose the filter strategy** (AC: #3)
+  - [x] Compare Option A (single Prisma `WHERE` clause that excludes rows where
         `expired = true AND NOT (trades has any open)`) vs. Option B (post-query
         filter on the already-fetched row list).
-  - [ ] Option A is preferred for correctness (zero N+1 risk, server never sends the
+  - [x] Option A is preferred for correctness (zero N+1 risk, server never sends the
         rows) and aligns with the existing handler which already loads `trades` via
         `include`. Option B is acceptable if the existing handler maps over trades to
         derive `position` and the boolean is already on the row.
-  - [ ] Write the chosen approach with one paragraph of justification and the exact
+  - [x] Write the chosen approach with one paragraph of justification and the exact
         Prisma fragment (`where: { NOT: { AND: [{ expired: true }, { trades: { none: { sell_date: null } } }] } }`
         or equivalent) that Story 109.2 will use.
 
-- [ ] **Task 5 — Quality gate** (AC: #4)
-  - [ ] Confirm `git status` shows no production source file changes (only this story
+- [x] **Task 5 — Quality gate** (AC: #4)
+  - [x] Confirm `git status` shows no production source file changes (only this story
         file's Dev Notes were updated).
-  - [ ] Run `pnpm all` and record the result in Dev Notes.
+  - [x] Run `pnpm all` and record the result in Dev Notes.
 
 ## Dev Notes
 
@@ -188,26 +188,84 @@ to compare `ex_date < now()` (less efficient — no exact index — but correct)
 
 ## Definition of Done
 
-- [ ] Universe endpoint traced end-to-end in Dev Notes
-- [ ] Expired predicate defined and source field cited
-- [ ] Open-position predicate cited from existing code (not re-invented)
-- [ ] Filter approach (Prisma query vs post-query) chosen with rationale
-- [ ] No production code changed; `pnpm all` passes
+- [x] Universe endpoint traced end-to-end in Dev Notes
+- [x] Expired predicate defined and source field cited
+- [x] Open-position predicate cited from existing code (not re-invented)
+- [x] Filter approach (Prisma query vs post-query) chosen with rationale
+- [x] No production code changed; `pnpm all` passes
 
 ## Dev Agent Record
 
 ### Agent Model Used
 
-_To be filled by dev agent._
+Claude Sonnet 4.6
 
 ### Debug Log References
 
-_To be filled by dev agent._
+None — investigation only; no instrumentation added.
 
 ### Completion Notes List
 
-_To be filled by dev agent._
+**AC1 — Route traced end-to-end:**
+
+- **Angular client:** `GlobalUniverseComponent` (`apps/dms-material/src/app/global/global-universe/global-universe.component.ts`) uses `UniverseService` which reads `selectUniverses()` from SmartNgRX store. SmartNgRX hydrates rows via `UniverseEffectsService.loadByIds(ids)` → `POST ./api/universe` (body: string[] of IDs). The list-load path uses `GET /api/universe` when SmartNgRX needs the full index.
+- **Route handler:** `apps/server/src/app/routes/universe/get-all-universes/index.ts`, function `handleGetAllUniverses`. Registered via `registerGetAllUniverses(fastify)` in `apps/server/src/app/routes/universe/index.ts`. HTTP method: **GET**, path: **`/api/universe`** (autoload prefix `/api` + route directory `universe`).
+- **Prisma query** (get-all-universes/index.ts):
+
+  ```ts
+  const universes = await prisma.universe.findMany({
+    include: { risk_group: true, trades: true },
+    orderBy: buildPrismaOrderBy(effectiveSortBy, effectiveSortOrder),
+  });
+  ```
+
+  No `where` clause today — loads every universe row with all trades.
+- **Post-query mapping:** Local `mapUniverseToResponse(u: unknown)` (lines ~115–140 of get-all-universes/index.ts) calls:
+  - `universeHelpers.getOpenTrades(uw.trades)` — filters open trades
+  - `universeHelpers.getMostRecentSell(uw.trades)` — most recent sell
+  - `universeHelpers.calculatePosition(openTrades)` — position value
+  - `universeHelpers.calculateAvgPurchaseYieldPercent(openTrades, ...)` — yield
+  - Maps `uw.expired` directly from DB (no recomputation)
+- **Row DTO** (`apps/server/src/app/routes/universe/universe.interface.ts`): `Universe` — includes `id`, `symbol`, `distribution`, `distributions_per_year`, `last_price`, `most_recent_sell_date`, `most_recent_sell_price`, `ex_date`, `risk_group_id`, `expired: boolean`, `is_closed_end_fund: boolean`, `position: number`, `avg_purchase_yield_percent: number`, `volatilityLong`, `volatilityShort`.
+
+**AC2 — Expired and open-position predicates:**
+
+- **Schema** (`prisma/schema.prisma`): `model universe` has `expired Boolean @default(false)` and `ex_date DateTime?`. Index: `@@index([expired])`.
+- **Expired predicate — use `expired: true` (the persisted boolean).** Rationale: `expired` is actively written by multiple server paths:
+  - `sync-from-screener/index.ts` `markExpired()`: sets `data: { expired: true }` for CEF symbols not in screener
+  - `sync-from-screener/index.ts` `updateExistingUniverseRecord()`: sets `expired: false` when a symbol is re-synced
+  - `universe/index.ts` `updateUniverseData()`: writes `expired: data.expired` on manual field edit
+  - Client `handle-cell-edit.function.ts` `applyExDateExpiry()`: sets `expired` when ex_date is set to a past date
+  The field is authoritative and actively maintained. `mapUniverseToResponse` reads `uw.expired` directly — confirming it is the canonical source. Using `expired: true` also leverages `@@index([expired])` for a cheap indexed scan.
+- **Open-position predicate:** `getOpenTrades` in `apps/server/src/app/routes/universe/universe-helpers.ts` (lines 8–12): `t.sell_date === null`. This is the canonical predicate. The `get-open-trades` route (`apps/server/src/app/routes/trades/get-open-trades/index.ts`) also uses `where: { sell_date: null }` — consistent. No `deletedAt` filter is applied to trades in either the get-all-universes handler or the get-open-trades handler; follow the same pattern.
+- **"No open positions"** = zero `trades` rows with `sell_date: null` for that universe symbol across all accounts.
+- **Prisma shape for "has at least one open trade":** `trades: { some: { sell_date: null } }` (no `deletedAt` filter, consistent with existing code).
+
+**AC3 — Filter strategy: Option A (single Prisma WHERE clause).**
+
+Add to `get-all-universes/index.ts` `prisma.universe.findMany`:
+
+```ts
+where: {
+  NOT: {
+    AND: [
+      { expired: true },
+      { trades: { none: { sell_date: null } } },
+    ],
+  },
+},
+```
+
+Justification: (a) **Correctness** — expired symbols with zero open trades are excluded at DB level before any data reaches Node.js; (b) **No N+1 risk** — translates to a single SQL statement with a correlated `NOT EXISTS` subquery, not per-row queries; (c) **Consistency** — the handler already includes `trades: true`, so the query shape is unchanged; adding a `where` is the minimal surgical change. Both `universe.expired` (`@@index([expired])`) and `trades.sell_date` (`@@index([sell_date])`) are indexed, giving the DB planner efficient paths.
+
+**AC4 — Quality gate:**
+
+`pnpm all` passed — see File List for the only changed file (story doc). No production source files modified.
 
 ### File List
 
-_To be filled by dev agent._
+- `_bmad-output/implementation-artifacts/109-1-investigate-universe-expired-filter.md` (modified — Dev Notes and Dev Agent Record filled in; no production source files changed)
+
+### Change Log
+
+- 2026-05-23: Investigation complete. Traced Universe endpoint end-to-end, identified `expired` boolean as canonical predicate, confirmed `sell_date: null` as open-trade predicate, chose single Prisma WHERE clause as filter strategy for Story 109.2.

--- a/_bmad-output/implementation-artifacts/109-1-investigate-universe-expired-filter.md
+++ b/_bmad-output/implementation-artifacts/109-1-investigate-universe-expired-filter.md
@@ -260,7 +260,7 @@ Justification: (a) **Correctness** — expired symbols with zero open trades are
 
 **AC4 — Quality gate:**
 
-`pnpm all` passed — see File List for the only changed file (story doc). No production source files modified.
+`pnpm all` passed — see File List for the only changed file (story doc). No production source files modified. CI evidence: [run 26352011954, job 77571829027](https://github.com/DaveMBush/dms-workspace/actions/runs/26352011954/job/77571829027) completed 2026-05-24T04:36:38Z with conclusion **success**.
 
 ### File List
 


### PR DESCRIPTION
## Summary

Investigation story for Epic 109. Traced the Universe screen server endpoint end-to-end and defined the exact filter predicate for Story 109.2.

- Traced `GET /api/universe` from Angular client through Fastify route to Prisma query
- Identified `expired` boolean (persisted, indexed, authoritative) as the expiry predicate
- Confirmed `sell_date: null` (from `getOpenTrades` in universe-helpers.ts) as canonical open-trade predicate
- Chose single Prisma `WHERE` clause (Option A) as filter strategy: zero N+1 risk, both fields indexed

No production code changed. `pnpm all` passes as no-op gate.

Closes #1291

## Testing

No new tests in this story — Story 109.3 owns unit + E2E tests. Quality gate: `pnpm all` passes (proves nothing inadvertently modified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Completed investigation notes for the Universe expired-filter story: status set to review, all tasks and DoD checklist marked complete, investigation log and tracing details added, filter strategy and verification steps recorded, and a short change log appended. Confirmed no production-code changes and quality gate checks completed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaveMBush/dms-workspace/pull/1292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->