### PR TITLE
feat(story-111-3): verify all consuming screens after base-table refactor

### DIFF
--- a/apps/dms-material-e2e/src/scrolling-regression-105.spec.ts
+++ b/apps/dms-material-e2e/src/scrolling-regression-105.spec.ts
@@ -399,7 +399,8 @@ test.describe('Sold Positions — filter-change (symbol) sticky-header regressio
     // Context-change: symbol filter input (placeholder="Search Symbol")
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: 'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
+        columnSelector:
+          'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
         filterValue: 'E2E-SD',
       });
     });

--- a/apps/dms-material-e2e/src/scrolling-regression-105.spec.ts
+++ b/apps/dms-material-e2e/src/scrolling-regression-105.spec.ts
@@ -220,7 +220,7 @@ test.describe('Universe — filter-change (symbol) sticky-header regression', ()
 
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: `${VIEWPORT_SELECTOR} thead input[placeholder]`,
+        columnSelector: 'dms-base-table .dms-filter-row input[placeholder]',
         filterValue: symbolPrefix,
       });
     });
@@ -399,7 +399,7 @@ test.describe('Sold Positions — filter-change (symbol) sticky-header regressio
     // Context-change: symbol filter input (placeholder="Search Symbol")
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: `${VIEWPORT_SELECTOR} thead input[placeholder="Search Symbol"]`,
+        columnSelector: 'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
         filterValue: 'E2E-SD',
       });
     });

--- a/apps/dms-material-e2e/src/scrolling-regression-106-investigation.spec.ts
+++ b/apps/dms-material-e2e/src/scrolling-regression-106-investigation.spec.ts
@@ -355,7 +355,7 @@ test.describe.skip(
       await resetScrollToTop(page);
       console.log('\n=== UNIVERSE: Apply + clear column filter ===');
       await applyAndClearColumnFilter(page, {
-        columnSelector: `${VIEWPORT_SELECTOR} thead input[placeholder]`,
+        columnSelector: 'dms-base-table .dms-filter-row input[placeholder]',
         filterValue: 'USCRL0',
       });
       await page.waitForTimeout(1000);
@@ -492,7 +492,7 @@ test.describe.skip(
       // Use inline approach: applyAndClearColumnFilter waits for .dms-body-row but
       // sold positions filter may not trigger row visibility change reliably in all envs.
       const soldFilterInput = page
-        .locator(`${VIEWPORT_SELECTOR} thead input[placeholder]`)
+        .locator('dms-base-table .dms-filter-row input[placeholder]')
         .first();
       await soldFilterInput.click();
       await soldFilterInput.fill('USCRL');

--- a/apps/dms-material-e2e/src/scrolling-regression-106.spec.ts
+++ b/apps/dms-material-e2e/src/scrolling-regression-106.spec.ts
@@ -381,7 +381,8 @@ test.describe('Sold Positions — filter-change (symbol) sticky-header regressio
     // Round-9 (Story 106.1) confirmed drift=0, overlap=0 on Chromium and Firefox.
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: 'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
+        columnSelector:
+          'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
         filterValue: 'TESTEQ',
       });
     });

--- a/apps/dms-material-e2e/src/scrolling-regression-106.spec.ts
+++ b/apps/dms-material-e2e/src/scrolling-regression-106.spec.ts
@@ -239,7 +239,7 @@ test.describe('Universe — filter-change (symbol) sticky-header regression (Rou
 
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: `${VIEWPORT_SELECTOR} thead input[placeholder]`,
+        columnSelector: 'dms-base-table .dms-filter-row input[placeholder]',
         filterValue: symbolPrefix,
       });
     });
@@ -381,7 +381,7 @@ test.describe('Sold Positions — filter-change (symbol) sticky-header regressio
     // Round-9 (Story 106.1) confirmed drift=0, overlap=0 on Chromium and Firefox.
     await runTwoPassInvariantCheck(page, async function doContextChange() {
       await applyAndClearColumnFilter(page, {
-        columnSelector: `${VIEWPORT_SELECTOR} thead input[placeholder="Search Symbol"]`,
+        columnSelector: 'dms-base-table .dms-filter-row input[placeholder="Search Symbol"]',
         filterValue: 'TESTEQ',
       });
     });


### PR DESCRIPTION
## Story 111-3: Verify Every Consuming Screen After Base-Table Refactor

### Summary

Verified all 5 consuming screens (Universe, Screener, Open Positions, Sold Positions, Dividend Deposits) on both Chromium and Firefox after the Story 111.2 two-region layout refactor.

### Changes

Fixed 6 broken Playwright selectors in prior-epic regression specs that referenced `thead input` inside the CDK virtual-scroll viewport. Story 111.2 removed `<thead>` from the viewport; the selectors were updated to target the new location `dms-base-table .dms-filter-row input[placeholder]` without weakening any assertion.

**Files changed:**
- `apps/dms-material-e2e/src/scrolling-regression-105.spec.ts` (L223, L402)
- `apps/dms-material-e2e/src/scrolling-regression-106.spec.ts` (L242, L384)
- `apps/dms-material-e2e/src/scrolling-regression-106-investigation.spec.ts` (L358, L495)

### Regression Suite Results

| Suite | Browser | Result |
|-------|---------|--------|
| scrolling-regression-101 | chromium | 7/7 PASS |
| scrolling-regression-101 | firefox | 7/7 PASS |
| scrolling-regression-105 | chromium | 8/8 PASS |
| scrolling-regression-105 | firefox | 8/8 PASS |
| scrolling-regression-106 | chromium | 7/7 PASS (10 investigation tests skipped) |
| scrolling-regression-106 | firefox | 7/7 PASS (10 investigation tests skipped) |

### Quality Gate

- `pnpm all` ✅ passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test selectors in regression test suite to improve filter input detection accuracy across sticky-header scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaveMBush/dms-workspace/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->