### PR TITLE
feat(story-112-3): add base-table layout regression suite (Epic 112)

### DIFF
--- a/_bmad-output/implementation-artifacts/112-3-regression-tests-base-table-layout.md
+++ b/_bmad-output/implementation-artifacts/112-3-regression-tests-base-table-layout.md
@@ -1,6 +1,6 @@
 # Story 112.3: Tests and Regression Suite for Layout Regressions
 
-Status: Approved
+Status: Done
 
 **Story Key:** `112-3-regression-tests-base-table-layout`
 **Epic:** 112 — Fix Post-Refactor Layout Regressions in Two-Region Base Table
@@ -54,35 +54,56 @@ Story 112.2 applied the fixes. This story locks them in by adding a Playwright E
 
 ## Tasks / Subtasks
 
-- [ ] **Task 1 — Create the regression test file** (AC: #1, #2, #3, #4)
-  - [ ] Create a new Playwright spec file in
+- [x] **Task 1 — Create the regression test file** (AC: #1, #2, #3, #4)
+  - [x] Create a new Playwright spec file in
         `apps/dms-material-e2e/src/` (following the naming convention used by the
         Epic 111 regression suite from Story 111.4, e.g.
         `base-table-layout-regression.spec.ts`).
-  - [ ] Add a `beforeEach` that logs in (if needed) and navigates to the Universe screen.
+  - [x] Add a `beforeEach` that logs in (if needed) and navigates to the Universe screen.
 
-- [ ] **Task 2 — Scrollbar right-edge test (narrow viewport)** (AC: #1)
-  - [ ] Set the viewport to a width narrower than the table (e.g. 800px).
-  - [ ] Programmatically scroll the horizontal scroller to 50% of its `scrollWidth`.
-  - [ ] Assert `scrollbarContainer.getBoundingClientRect().right` is within 2px of `page.viewportSize().width`.
-  - [ ] Repeat at 100% scroll position.
+- [x] **Task 2 — Scrollbar right-edge test (narrow viewport)** (AC: #1)
+  - [x] Set the viewport to a width narrower than the table (e.g. 800px).
+  - [x] Programmatically scroll the horizontal scroller to 50% of its `scrollWidth`.
+  - [x] Assert `scrollbarContainer.getBoundingClientRect().right` is within 2px of `page.viewportSize().width`.
+  - [x] Repeat at 100% scroll position.
 
-- [ ] **Task 3 — Container-width test (wide viewport)** (AC: #2)
-  - [ ] Set the viewport to a width wider than the table (e.g. 1800px).
-  - [ ] Assert the scrollable outer container's `clientWidth` equals the viewport width (within 2px), confirming the scrollbar would appear at the far right.
+- [x] **Task 3 — Container-width test (wide viewport)** (AC: #2)
+  - [x] Set the viewport to a width wider than the table (e.g. 1800px).
+  - [x] Assert the scrollable outer container's `clientWidth` equals the viewport width (within 2px), confirming the scrollbar would appear at the far right.
 
-- [ ] **Task 4 — Column fill test** (AC: #3)
-  - [ ] Navigate to a screen whose columns total less than the test viewport width.
-  - [ ] Use `page.evaluate` to sum `getBoundingClientRect().width` for all column header cells and compare to the container's `clientWidth`.
-  - [ ] Assert difference is within 2px.
+- [x] **Task 4 — Column fill test** (AC: #3)
+  - [x] Navigate to a screen whose columns total less than the test viewport width.
+  - [x] Use `page.evaluate` to sum `getBoundingClientRect().width` for all column header cells and compare to the container's `clientWidth`.
+  - [x] Assert difference is within 2px.
 
-- [ ] **Task 5 — Background color test** (AC: #4)
-  - [ ] Use `page.evaluate` and `getComputedStyle` to read the background color of: (a) a table body cell, and (b) the beyond-table region (e.g. the outer wrapper where no column is rendered).
-  - [ ] Assert the two colors are equal.
+- [x] **Task 5 — Background color test** (AC: #4)
+  - [x] Use `page.evaluate` and `getComputedStyle` to read the background color of: (a) a table body cell, and (b) the beyond-table region (e.g. the outer wrapper where no column is rendered).
+  - [x] Assert the two colors are equal.
 
-- [ ] **Task 6 — Run on both browsers** (AC: #5)
-  - [ ] Run `pnpm e2e:dms-material:chromium` and `pnpm e2e:dms-material:firefox` targeting the new spec file. Fix any failures before proceeding.
+- [x] **Task 6 — Run on both browsers** (AC: #5)
+  - [x] Run `pnpm e2e:dms-material:chromium` and `pnpm e2e:dms-material:firefox` targeting the new spec file. Fix any failures before proceeding.
 
-- [ ] **Task 7 — Quality gate** (AC: #6)
-  - [ ] Confirm the new spec is not annotated `.skip` or `.only`.
-  - [ ] Run `pnpm all` and confirm all tests pass.
+- [x] **Task 7 — Quality gate** (AC: #6)
+  - [x] Confirm the new spec is not annotated `.skip` or `.only`.
+  - [x] Run `pnpm all` and confirm all tests pass.
+
+## Dev Agent Record
+
+**Model:** Claude Sonnet 4.6
+
+**File List:**
+- `apps/dms-material-e2e/src/base-table-layout-regression.spec.ts` — new Playwright E2E regression spec
+
+**Change Log:**
+- Created `apps/dms-material-e2e/src/base-table-layout-regression.spec.ts` with four describe blocks:
+  - AC1 (narrow 800px): scrolls `.dms-table-scroll-container` to 50% and 100% of max scroll; asserts `.dms-outer-scroller.getBoundingClientRect().right ≈ window.innerWidth` (≤2px tolerance)
+  - AC2 (wide 1800px): asserts `.dms-outer-scroller.getBoundingClientRect().right ≈ window.innerWidth` (≤2px) — scrollbar at viewport right, not content right
+  - AC3 (wide 1800px): sums `.dms-column-header-row .dms-header-cell` widths + `.dms-col-spacer` width; asserts sum ≈ `.dms-table-scroll-container.clientWidth` (≤2px)
+  - AC4 (wide 1800px): compares `getComputedStyle(bodyCell).backgroundColor` to `getComputedStyle(bodyRow).backgroundColor`; asserts equal
+
+**Completion Notes:**
+- Spec uses `seedScrollUniverseData()` (60 Universe rows) to ensure scrollable content at narrow viewport and column-fill scenario at wide viewport
+- Universe column total ≈ 1475px: narrower than 1580px content area at 1800px viewport (spacer absorbs gap for AC3/AC4); wider than ~580px content area at 800px viewport (horizontal scroll available for AC1)
+- AC3 includes the `.dms-col-spacer` width in the sum because the 112.2 fix uses a trailing spacer (`flex: 1 0 auto`) rather than `flex-grow` on cells; the spacer IS the fill mechanism
+- No `.skip` or `.only` annotations — spec is part of `pnpm all` via the standard Playwright project config
+- TypeScript compilation: zero errors

--- a/_bmad-output/implementation-artifacts/112-3-regression-tests-base-table-layout.md
+++ b/_bmad-output/implementation-artifacts/112-3-regression-tests-base-table-layout.md
@@ -69,7 +69,7 @@ Story 112.2 applied the fixes. This story locks them in by adding a Playwright E
 
 - [x] **Task 3 — Container-width test (wide viewport)** (AC: #2)
   - [x] Set the viewport to a width wider than the table (e.g. 1800px).
-  - [x] Assert the scrollable outer container's `clientWidth` equals the viewport width (within 2px), confirming the scrollbar would appear at the far right.
+  - [x] Assert the scrollable outer container's `outer-scroller.clientWidth` equals its `parentElement.clientWidth` (available container width, within 2px), confirming the scrollbar would appear at the container's right edge.
 
 - [x] **Task 4 — Column fill test** (AC: #3)
   - [x] Navigate to a screen whose columns total less than the test viewport width.
@@ -96,14 +96,15 @@ Story 112.2 applied the fixes. This story locks them in by adding a Playwright E
 
 **Change Log:**
 - Created `apps/dms-material-e2e/src/base-table-layout-regression.spec.ts` with four describe blocks:
-  - AC1 (narrow 800px): scrolls `.dms-table-scroll-container` to 50% and 100% of max scroll; asserts `.dms-outer-scroller.getBoundingClientRect().right ≈ window.innerWidth` (≤2px tolerance)
-  - AC2 (wide 1800px): asserts `.dms-outer-scroller.getBoundingClientRect().right ≈ window.innerWidth` (≤2px) — scrollbar at viewport right, not content right
-  - AC3 (wide 1800px): sums `.dms-column-header-row .dms-header-cell` widths + `.dms-col-spacer` width; asserts sum ≈ `.dms-table-scroll-container.clientWidth` (≤2px)
+  - AC1 (narrow 800px): captures `.dms-outer-scroller.getBoundingClientRect().right` as baseline at 0% scroll; asserts right-edge drift ≤2px at 50% and 100% horizontal scroll (drift-stability guard — app layout has a sidebar so absolute viewport-right comparison would always fail by design)
+  - AC2 (wide 1800px): asserts `.dms-outer-scroller.clientWidth ≈ parentElement.clientWidth` (≤2px) — scrollbar at container edge, not content right
+  - AC3 (wide 2200px): sums `.dms-column-header-row .dms-header-cell` widths + `.dms-col-spacer` width; asserts sum ≈ `.dms-table-scroll-container.clientWidth` (≤2px)
   - AC4 (wide 1800px): compares `getComputedStyle(bodyCell).backgroundColor` to `getComputedStyle(bodyRow).backgroundColor`; asserts equal
 
 **Completion Notes:**
 - Spec uses `seedScrollUniverseData()` (60 Universe rows) to ensure scrollable content at narrow viewport and column-fill scenario at wide viewport
-- Universe column total ≈ 1475px: narrower than 1580px content area at 1800px viewport (spacer absorbs gap for AC3/AC4); wider than ~580px content area at 800px viewport (horizontal scroll available for AC1)
+- Universe column total ≈ 1475px: narrower than content area at 1800px and 2200px viewports (spacer absorbs gap for AC2/AC3/AC4); wider than ~580px content area at 800px viewport (horizontal scroll available for AC1)
+- AC3 uses a 2200px viewport so the content area (~1800px after sidebar) exceeds the column total (~1475px), ensuring the spacer has positive width; at 1800px the content area would be too close to the column total in some configurations
 - AC3 includes the `.dms-col-spacer` width in the sum because the 112.2 fix uses a trailing spacer (`flex: 1 0 auto`) rather than `flex-grow` on cells; the spacer IS the fill mechanism
-- No `.skip` or `.only` annotations — spec is part of `pnpm all` via the standard Playwright project config
+- No `.skip` or `.only` annotations — spec runs via `npx playwright test ... --project=chromium` / `--project=firefox`; E2E tests are not part of `pnpm all` (which targets lint/build/test only) and are run separately
 - TypeScript compilation: zero errors

--- a/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
+++ b/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
@@ -126,7 +126,9 @@ test.describe('Base Table Layout Regression — AC1: scrollbar right-edge on nar
       right: number;
     } {
       const el = document.querySelector<HTMLElement>(outerSel);
-      if (!el) return { ok: false, right: -9999 };
+      if (!el) {
+        return { ok: false, right: -9999 };
+      }
       return { ok: true, right: el.getBoundingClientRect().right };
     }, OUTER_SCROLLER_SEL);
 
@@ -249,7 +251,8 @@ test.describe('Base Table Layout Regression — AC2: outer container width on wi
       diff: number;
     } {
       const el = document.querySelector<HTMLElement>(outerSel);
-      if (!el || !el.parentElement) {
+      const parent = el?.parentElement;
+      if (!el || !parent) {
         return {
           ok: false,
           outerClientWidth: 0,
@@ -258,7 +261,7 @@ test.describe('Base Table Layout Regression — AC2: outer container width on wi
         };
       }
       const outerClientWidth = el.clientWidth;
-      const parentClientWidth = el.parentElement.clientWidth;
+      const parentClientWidth = parent.clientWidth;
       const diff = Math.abs(outerClientWidth - parentClientWidth);
       return { ok: diff <= 2, outerClientWidth, parentClientWidth, diff };
     }, OUTER_SCROLLER_SEL);

--- a/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
+++ b/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
@@ -91,371 +91,352 @@ async function navigateToUniverse(page: Page): Promise<void> {
 
 // ─── AC1 — Scrollbar right-edge on narrow viewport (800px) ────────────────────
 
-test.describe(
-  'Base Table Layout Regression — AC1: scrollbar right-edge on narrow viewport',
-  () => {
-    test.beforeEach(async ({ page }) => {
-      await page.setViewportSize({ width: 800, height: 900 });
-      await navigateToUniverse(page);
-    });
+test.describe('Base Table Layout Regression — AC1: scrollbar right-edge on narrow viewport', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 800, height: 900 });
+    await navigateToUniverse(page);
+  });
 
-    test(
-      'Universe: scrollbar right-edge stays at viewport right at 50% and 100% horizontal scroll',
-      async ({ page }) => {
-        // Precondition: table must be wider than 800px to test horizontal scroll.
-        const canScroll = await page
-          .locator(SCROLL_CONTAINER_SEL)
-          .first()
-          .evaluate(function checkScrollable(el: Element): boolean {
-            return el.scrollWidth > el.clientWidth;
-          });
+  test('Universe: scrollbar right-edge stays at viewport right at 50% and 100% horizontal scroll', async ({
+    page,
+  }) => {
+    // Precondition: table must be wider than 800px to test horizontal scroll.
+    const canScroll = await page
+      .locator(SCROLL_CONTAINER_SEL)
+      .first()
+      .evaluate(function checkScrollable(el: Element): boolean {
+        return el.scrollWidth > el.clientWidth;
+      });
 
-        if (!canScroll) {
-          // Universe columns (≈1475px) must be wider than the 800px content area.
-          // If this branch is hit the seeder or layout changed — flag it as a failure.
-          throw new Error(
-            'Precondition failed: .dms-table-scroll-container is not horizontally ' +
-              'scrollable at 800px viewport. Universe column total should exceed ' +
-              '800px; check column definitions and seeder.'
-          );
+    if (!canScroll) {
+      // Universe columns (≈1475px) must be wider than the 800px content area.
+      // If this branch is hit the seeder or layout changed — flag it as a failure.
+      throw new Error(
+        'Precondition failed: .dms-table-scroll-container is not horizontally ' +
+          'scrollable at 800px viewport. Universe column total should exceed ' +
+          '800px; check column definitions and seeder.'
+      );
+    }
+
+    // ── Capture baseline right edge at 0% scroll ──────────────────────
+    const baseline = await page.evaluate(function captureRightEdge(
+      outerSel: string
+    ): {
+      ok: boolean;
+      right: number;
+    } {
+      const el = document.querySelector<HTMLElement>(outerSel);
+      if (!el) return { ok: false, right: -9999 };
+      return { ok: true, right: el.getBoundingClientRect().right };
+    }, OUTER_SCROLLER_SEL);
+
+    if (!baseline.ok) {
+      throw new Error(
+        'Precondition failed: .dms-outer-scroller not found in DOM'
+      );
+    }
+
+    // ── Scroll to 50% ─────────────────────────────────────────────────────
+    await page.evaluate(
+      function scrollToPercent(arg: {
+        containerSel: string;
+        percent: number;
+      }): void {
+        const { containerSel, percent } = arg;
+        const el = document.querySelector<HTMLElement>(containerSel);
+        if (el) {
+          el.scrollLeft = (el.scrollWidth - el.clientWidth) * percent;
         }
-
-        // ── Capture baseline right edge at 0% scroll ──────────────────────
-        const baseline = await page.evaluate(
-          function captureRightEdge(outerSel: string): {
-            ok: boolean;
-            right: number;
-          } {
-            const el = document.querySelector<HTMLElement>(outerSel);
-            if (!el) return { ok: false, right: -9999 };
-            return { ok: true, right: el.getBoundingClientRect().right };
-          },
-          OUTER_SCROLLER_SEL
-        );
-
-        if (!baseline.ok) {
-          throw new Error(
-            'Precondition failed: .dms-outer-scroller not found in DOM'
-          );
-        }
-
-        // ── Scroll to 50% ─────────────────────────────────────────────────────
-        await page.evaluate(
-          function scrollToPercent(arg: {
-            containerSel: string;
-            percent: number;
-          }): void {
-            const { containerSel, percent } = arg;
-            const el = document.querySelector<HTMLElement>(containerSel);
-            if (el) {
-              el.scrollLeft = (el.scrollWidth - el.clientWidth) * percent;
-            }
-          },
-          { containerSel: SCROLL_CONTAINER_SEL, percent: 0.5 }
-        );
-
-        // Allow one frame for the layout to settle.
-        await page.waitForTimeout(50);
-
-        const result50 = await page.evaluate(
-          function checkOuterScrollerDrift(arg: {
-            outerSel: string;
-            baselineRight: number;
-          }): {
-            ok: boolean;
-            right: number;
-            baselineRight: number;
-            drift: number;
-          } {
-            const { outerSel, baselineRight } = arg;
-            const el = document.querySelector<HTMLElement>(outerSel);
-            if (!el) {
-              return { ok: false, right: 0, baselineRight, drift: 9999 };
-            }
-            const right = el.getBoundingClientRect().right;
-            const drift = Math.abs(right - baselineRight);
-            return { ok: drift <= 2, right, baselineRight, drift };
-          },
-          { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
-        );
-
-        expect(
-          result50.ok,
-          `At 50% horizontal scroll: outer-scroller right drifted from ` +
-            `${result50.baselineRight}px (baseline) to ${result50.right}px, ` +
-            `drift=${result50.drift.toFixed(2)}px (must be ≤2px). ` +
-            '.dms-outer-scroller (overflow-y:auto, overflow-x:hidden) must ' +
-            'remain fixed-width regardless of inner horizontal scroll position ' +
-            '(R1 regression guard: vertical scrollbar must not drift with content).'
-        ).toBe(true);
-
-        // ── Scroll to 100% ────────────────────────────────────────────────────
-        await page.evaluate(
-          function scrollToMax(containerSel: string): void {
-            const el = document.querySelector<HTMLElement>(containerSel);
-            if (el) {
-              el.scrollLeft = el.scrollWidth - el.clientWidth;
-            }
-          },
-          SCROLL_CONTAINER_SEL
-        );
-
-        await page.waitForTimeout(50);
-
-        const result100 = await page.evaluate(
-          function checkOuterScrollerDrift(arg: {
-            outerSel: string;
-            baselineRight: number;
-          }): {
-            ok: boolean;
-            right: number;
-            baselineRight: number;
-            drift: number;
-          } {
-            const { outerSel, baselineRight } = arg;
-            const el = document.querySelector<HTMLElement>(outerSel);
-            if (!el) {
-              return { ok: false, right: 0, baselineRight, drift: 9999 };
-            }
-            const right = el.getBoundingClientRect().right;
-            const drift = Math.abs(right - baselineRight);
-            return { ok: drift <= 2, right, baselineRight, drift };
-          },
-          { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
-        );
-
-        expect(
-          result100.ok,
-          `At 100% horizontal scroll: outer-scroller right drifted from ` +
-            `${result100.baselineRight}px (baseline) to ${result100.right}px, ` +
-            `drift=${result100.drift.toFixed(2)}px (must be ≤2px). ` +
-            'The vertical scrollbar must stay fixed at the container right edge — ' +
-            'it must not scroll with the table content (R1 regression guard).'
-        ).toBe(true);
-      }
+      },
+      { containerSel: SCROLL_CONTAINER_SEL, percent: 0.5 }
     );
-  }
-);
+
+    // Allow one frame for the layout to settle.
+    await page.waitForTimeout(50);
+
+    const result50 = await page.evaluate(
+      function checkOuterScrollerDrift(arg: {
+        outerSel: string;
+        baselineRight: number;
+      }): {
+        ok: boolean;
+        right: number;
+        baselineRight: number;
+        drift: number;
+      } {
+        const { outerSel, baselineRight } = arg;
+        const el = document.querySelector<HTMLElement>(outerSel);
+        if (!el) {
+          return { ok: false, right: 0, baselineRight, drift: 9999 };
+        }
+        const right = el.getBoundingClientRect().right;
+        const drift = Math.abs(right - baselineRight);
+        return { ok: drift <= 2, right, baselineRight, drift };
+      },
+      { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
+    );
+
+    expect(
+      result50.ok,
+      `At 50% horizontal scroll: outer-scroller right drifted from ` +
+        `${result50.baselineRight}px (baseline) to ${result50.right}px, ` +
+        `drift=${result50.drift.toFixed(2)}px (must be ≤2px). ` +
+        '.dms-outer-scroller (overflow-y:auto, overflow-x:hidden) must ' +
+        'remain fixed-width regardless of inner horizontal scroll position ' +
+        '(R1 regression guard: vertical scrollbar must not drift with content).'
+    ).toBe(true);
+
+    // ── Scroll to 100% ────────────────────────────────────────────────────
+    await page.evaluate(function scrollToMax(containerSel: string): void {
+      const el = document.querySelector<HTMLElement>(containerSel);
+      if (el) {
+        el.scrollLeft = el.scrollWidth - el.clientWidth;
+      }
+    }, SCROLL_CONTAINER_SEL);
+
+    await page.waitForTimeout(50);
+
+    const result100 = await page.evaluate(
+      function checkOuterScrollerDrift(arg: {
+        outerSel: string;
+        baselineRight: number;
+      }): {
+        ok: boolean;
+        right: number;
+        baselineRight: number;
+        drift: number;
+      } {
+        const { outerSel, baselineRight } = arg;
+        const el = document.querySelector<HTMLElement>(outerSel);
+        if (!el) {
+          return { ok: false, right: 0, baselineRight, drift: 9999 };
+        }
+        const right = el.getBoundingClientRect().right;
+        const drift = Math.abs(right - baselineRight);
+        return { ok: drift <= 2, right, baselineRight, drift };
+      },
+      { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
+    );
+
+    expect(
+      result100.ok,
+      `At 100% horizontal scroll: outer-scroller right drifted from ` +
+        `${result100.baselineRight}px (baseline) to ${result100.right}px, ` +
+        `drift=${result100.drift.toFixed(2)}px (must be ≤2px). ` +
+        'The vertical scrollbar must stay fixed at the container right edge — ' +
+        'it must not scroll with the table content (R1 regression guard).'
+    ).toBe(true);
+  });
+});
 
 // ─── AC2 — Container-width on wide viewport (1800px) ─────────────────────────
 
-test.describe(
-  'Base Table Layout Regression — AC2: outer container width on wide viewport',
-  () => {
-    test.beforeEach(async ({ page }) => {
-      await page.setViewportSize({ width: 1800, height: 900 });
-      await navigateToUniverse(page);
-    });
+test.describe('Base Table Layout Regression — AC2: outer container width on wide viewport', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await navigateToUniverse(page);
+  });
 
-    test(
-      'Universe: outer scroll container fills its flex parent (not truncated to table width)',
-      async ({ page }) => {
-        const result = await page.evaluate(
-          function checkOuterScrollerFillsParent(outerSel: string): {
-            ok: boolean;
-            outerClientWidth: number;
-            parentClientWidth: number;
-            diff: number;
-          } {
-            const el = document.querySelector<HTMLElement>(outerSel);
-            if (!el || !el.parentElement) {
-              return {
-                ok: false,
-                outerClientWidth: 0,
-                parentClientWidth: 0,
-                diff: 9999,
-              };
-            }
-            const outerClientWidth = el.clientWidth;
-            const parentClientWidth = el.parentElement.clientWidth;
-            const diff = Math.abs(outerClientWidth - parentClientWidth);
-            return { ok: diff <= 2, outerClientWidth, parentClientWidth, diff };
-          },
-          OUTER_SCROLLER_SEL
-        );
-
-        expect(
-          result.ok,
-          `outer-scroller.clientWidth=${result.outerClientWidth}px ` +
-            `parentElement.clientWidth=${result.parentClientWidth}px ` +
-            `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
-            'At 1800px viewport the scrollable outer container must span its full ' +
-            'flex parent — it must NOT be truncated to the table content width ' +
-            '(R2 regression guard, ~1475px for Universe columns).'
-        ).toBe(true);
+  test('Universe: outer scroll container fills its flex parent (not truncated to table width)', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(function checkOuterScrollerFillsParent(
+      outerSel: string
+    ): {
+      ok: boolean;
+      outerClientWidth: number;
+      parentClientWidth: number;
+      diff: number;
+    } {
+      const el = document.querySelector<HTMLElement>(outerSel);
+      if (!el || !el.parentElement) {
+        return {
+          ok: false,
+          outerClientWidth: 0,
+          parentClientWidth: 0,
+          diff: 9999,
+        };
       }
-    );
-  }
-);
+      const outerClientWidth = el.clientWidth;
+      const parentClientWidth = el.parentElement.clientWidth;
+      const diff = Math.abs(outerClientWidth - parentClientWidth);
+      return { ok: diff <= 2, outerClientWidth, parentClientWidth, diff };
+    }, OUTER_SCROLLER_SEL);
+
+    expect(
+      result.ok,
+      `outer-scroller.clientWidth=${result.outerClientWidth}px ` +
+        `parentElement.clientWidth=${result.parentClientWidth}px ` +
+        `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
+        'At 1800px viewport the scrollable outer container must span its full ' +
+        'flex parent — it must NOT be truncated to the table content width ' +
+        '(R2 regression guard, ~1475px for Universe columns).'
+    ).toBe(true);
+  });
+});
 
 // ─── AC3 — Column fill on very wide viewport (2200px) ────────────────────────
 
-test.describe(
-  'Base Table Layout Regression — AC3: column fill on wide viewport',
-  () => {
-    test.beforeEach(async ({ page }) => {
-      // 2200px ensures the content area (~1800px after sidebar) exceeds the
-      // Universe column total (~1475px), so the spacer has positive width to absorb.
-      await page.setViewportSize({ width: 2200, height: 900 });
-      await navigateToUniverse(page);
-    });
+test.describe('Base Table Layout Regression — AC3: column fill on wide viewport', () => {
+  test.beforeEach(async ({ page }) => {
+    // 2200px ensures the content area (~1800px after sidebar) exceeds the
+    // Universe column total (~1475px), so the spacer has positive width to absorb.
+    await page.setViewportSize({ width: 2200, height: 900 });
+    await navigateToUniverse(page);
+  });
 
-    test(
-      'Universe: sum of column widths plus spacer equals scroll container clientWidth',
-      async ({ page }) => {
-        const result = await page.evaluate(
-          function checkColumnFill(arg: {
-            containerSel: string;
-            headerCellsSel: string;
-            spacerSel: string;
-          }): {
-            ok: boolean;
-            message: string;
-            totalWidth: number;
-            containerClientWidth: number;
-            colCount: number;
-            spacerWidth: number;
-            diff: number;
-          } {
-            const { containerSel, headerCellsSel, spacerSel } = arg;
-            const container =
-              document.querySelector<HTMLElement>(containerSel);
-            const headerCells = Array.from(
-              document.querySelectorAll<HTMLElement>(headerCellsSel)
-            );
-            const spacer = document.querySelector<HTMLElement>(spacerSel);
-
-            if (!container || headerCells.length === 0 || !spacer) {
-              return {
-                ok: false,
-                message:
-                  'precondition unmet: container=' +
-                  !!container +
-                  ' cells=' +
-                  headerCells.length +
-                  ' spacer=' +
-                  !!spacer,
-                totalWidth: 0,
-                containerClientWidth: 0,
-                colCount: 0,
-                spacerWidth: 0,
-                diff: 9999,
-              };
-            }
-
-            const sumCols = headerCells.reduce(
-              function sumWidths(acc: number, el: HTMLElement): number {
-                return acc + el.getBoundingClientRect().width;
-              },
-              0
-            );
-            const spacerWidth = spacer.getBoundingClientRect().width;
-            const totalWidth = sumCols + spacerWidth;
-            const containerClientWidth = container.clientWidth;
-            const diff = Math.abs(totalWidth - containerClientWidth);
-
-            return {
-              ok: diff <= 2,
-              message: '',
-              totalWidth,
-              containerClientWidth,
-              colCount: headerCells.length,
-              spacerWidth,
-              diff,
-            };
-          },
-          {
-            containerSel: SCROLL_CONTAINER_SEL,
-            headerCellsSel: COLUMN_HEADER_CELLS_SEL,
-            spacerSel: COL_SPACER_IN_HEADER_SEL,
-          }
+  test('Universe: sum of column widths plus spacer equals scroll container clientWidth', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(
+      function checkColumnFill(arg: {
+        containerSel: string;
+        headerCellsSel: string;
+        spacerSel: string;
+      }): {
+        ok: boolean;
+        message: string;
+        totalWidth: number;
+        containerClientWidth: number;
+        colCount: number;
+        spacerWidth: number;
+        diff: number;
+      } {
+        const { containerSel, headerCellsSel, spacerSel } = arg;
+        const container = document.querySelector<HTMLElement>(containerSel);
+        const headerCells = Array.from(
+          document.querySelectorAll<HTMLElement>(headerCellsSel)
         );
+        const spacer = document.querySelector<HTMLElement>(spacerSel);
 
-        expect(
-          result.ok,
-          result.message ||
-            `Column fill assertion failed: ` +
-              `sumCols+spacer=${result.totalWidth.toFixed(2)}px ` +
-              `(${result.colCount} cols + spacer=${result.spacerWidth.toFixed(2)}px) ` +
-              `container.clientWidth=${result.containerClientWidth}px ` +
-              `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
-              'At 2200px viewport the content area exceeds Universe column total, ' +
-              'so .dms-col-spacer (flex:1 0 auto) must absorb all spare horizontal ' +
-              'width so the row spans the full container (R3 regression guard).'
-        ).toBe(true);
+        if (!container || headerCells.length === 0 || !spacer) {
+          return {
+            ok: false,
+            message:
+              'precondition unmet: container=' +
+              !!container +
+              ' cells=' +
+              headerCells.length +
+              ' spacer=' +
+              !!spacer,
+            totalWidth: 0,
+            containerClientWidth: 0,
+            colCount: 0,
+            spacerWidth: 0,
+            diff: 9999,
+          };
+        }
+
+        const sumCols = headerCells.reduce(function sumWidths(
+          acc: number,
+          el: HTMLElement
+        ): number {
+          return acc + el.getBoundingClientRect().width;
+        },
+        0);
+        const spacerWidth = spacer.getBoundingClientRect().width;
+        const totalWidth = sumCols + spacerWidth;
+        const containerClientWidth = container.clientWidth;
+        const diff = Math.abs(totalWidth - containerClientWidth);
+
+        return {
+          ok: diff <= 2,
+          message: '',
+          totalWidth,
+          containerClientWidth,
+          colCount: headerCells.length,
+          spacerWidth,
+          diff,
+        };
+      },
+      {
+        containerSel: SCROLL_CONTAINER_SEL,
+        headerCellsSel: COLUMN_HEADER_CELLS_SEL,
+        spacerSel: COL_SPACER_IN_HEADER_SEL,
       }
     );
-  }
-);
+
+    expect(
+      result.ok,
+      result.message ||
+        `Column fill assertion failed: ` +
+          `sumCols+spacer=${result.totalWidth.toFixed(2)}px ` +
+          `(${result.colCount} cols + spacer=${result.spacerWidth.toFixed(
+            2
+          )}px) ` +
+          `container.clientWidth=${result.containerClientWidth}px ` +
+          `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
+          'At 2200px viewport the content area exceeds Universe column total, ' +
+          'so .dms-col-spacer (flex:1 0 auto) must absorb all spare horizontal ' +
+          'width so the row spans the full container (R3 regression guard).'
+    ).toBe(true);
+  });
+});
 
 // ─── AC4 — Beyond-table background color on wide viewport (1800px) ────────────
 
-test.describe(
-  'Base Table Layout Regression — AC4: beyond-table background matches cell background',
-  () => {
-    test.beforeEach(async ({ page }) => {
-      await page.setViewportSize({ width: 1800, height: 900 });
-      await navigateToUniverse(page);
-    });
+test.describe('Base Table Layout Regression — AC4: beyond-table background matches cell background', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await navigateToUniverse(page);
+  });
 
-    test(
-      'Universe: body row background matches body cell background (beyond-table area)',
-      async ({ page }) => {
-        const result = await page.evaluate(
-          function checkBackgroundColors(arg: {
-            bodyRowSel: string;
-            bodyCellSel: string;
-          }): {
-            ok: boolean;
-            message: string;
-            cellBg: string;
-            rowBg: string;
-          } {
-            const { bodyRowSel, bodyCellSel } = arg;
-            const bodyRow = document.querySelector<HTMLElement>(bodyRowSel);
-            if (!bodyRow) {
-              return {
-                ok: false,
-                message: 'precondition unmet: no body row visible',
-                cellBg: '',
-                rowBg: '',
-              };
-            }
-            const bodyCell = bodyRow.querySelector<HTMLElement>(bodyCellSel);
-            if (!bodyCell) {
-              return {
-                ok: false,
-                message: 'precondition unmet: no body cell found in body row',
-                cellBg: '',
-                rowBg: '',
-              };
-            }
+  test('Universe: body row background matches body cell background (beyond-table area)', async ({
+    page,
+  }) => {
+    const result = await page.evaluate(
+      function checkBackgroundColors(arg: {
+        bodyRowSel: string;
+        bodyCellSel: string;
+      }): {
+        ok: boolean;
+        message: string;
+        cellBg: string;
+        rowBg: string;
+      } {
+        const { bodyRowSel, bodyCellSel } = arg;
+        const bodyRow = document.querySelector<HTMLElement>(bodyRowSel);
+        if (!bodyRow) {
+          return {
+            ok: false,
+            message: 'precondition unmet: no body row visible',
+            cellBg: '',
+            rowBg: '',
+          };
+        }
+        const bodyCell = bodyRow.querySelector<HTMLElement>(bodyCellSel);
+        if (!bodyCell) {
+          return {
+            ok: false,
+            message: 'precondition unmet: no body cell found in body row',
+            cellBg: '',
+            rowBg: '',
+          };
+        }
 
-            const cellBg = window.getComputedStyle(bodyCell).backgroundColor;
-            const rowBg = window.getComputedStyle(bodyRow).backgroundColor;
+        const cellBg = window.getComputedStyle(bodyCell).backgroundColor;
+        const rowBg = window.getComputedStyle(bodyRow).backgroundColor;
 
-            return {
-              ok: cellBg === rowBg,
-              message: '',
-              cellBg,
-              rowBg,
-            };
-          },
-          { bodyRowSel: BODY_ROW_SEL, bodyCellSel: BODY_CELL_SEL }
-        );
-
-        expect(
-          result.ok,
-          result.message ||
-            `Background color mismatch: ` +
-              `bodyCell.backgroundColor="${result.cellBg}" ` +
-              `bodyRow.backgroundColor="${result.rowBg}". ` +
-              'Both must resolve to the same surface color (var(--dms-surface)). ' +
-              '.dms-body-row has background-color:var(--dms-surface) so the area ' +
-              'beyond the last column (covered by .dms-col-spacer) matches cell ' +
-              'background (R4 regression guard).'
-        ).toBe(true);
-      }
+        return {
+          ok: cellBg === rowBg,
+          message: '',
+          cellBg,
+          rowBg,
+        };
+      },
+      { bodyRowSel: BODY_ROW_SEL, bodyCellSel: BODY_CELL_SEL }
     );
-  }
-);
+
+    expect(
+      result.ok,
+      result.message ||
+        `Background color mismatch: ` +
+          `bodyCell.backgroundColor="${result.cellBg}" ` +
+          `bodyRow.backgroundColor="${result.rowBg}". ` +
+          'Both must resolve to the same surface color (var(--dms-surface)). ' +
+          '.dms-body-row has background-color:var(--dms-surface) so the area ' +
+          'beyond the last column (covered by .dms-col-spacer) matches cell ' +
+          'background (R4 regression guard).'
+    ).toBe(true);
+  });
+});

--- a/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
+++ b/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
@@ -1,0 +1,461 @@
+/**
+ * base-table-layout-regression.spec.ts — Epic 112
+ * ──────────────────────────────────────────────────────────────
+ *
+ * Regression suite for the three layout regressions fixed in Story 112.2.
+ *
+ * FOUR ASSERTIONS:
+ *   (a) Scrollbar right-edge stays stable across horizontal scroll positions (R1)
+ *       .dms-outer-scroller owns overflow-y:auto and is always full-width.
+ *       Its right edge must NOT DRIFT when the inner container scrolls horizontally.
+ *       Before the fix the vertical scrollbar sat on the inner container and would
+ *       shift right as the user scrolled left, exposing blank space (R1 regression).
+ *   (b) Outer container fills its flex parent (R2)
+ *       .dms-outer-scroller.clientWidth must equal its parentElement.clientWidth.
+ *       Before the fix the outer container was only as wide as the table content,
+ *       placing the scrollbar adjacent to the last column instead of the container edge.
+ *   (c) Sum of column widths + spacer equals scroll container clientWidth (R3)
+ *       .dms-col-spacer absorbs spare width so rows always span the container.
+ *       Tested at 2200px viewport where content area (~1800px) exceeds column total
+ *       (~1475px), ensuring the spacer has positive width to absorb.
+ *   (d) Beyond-table background matches cell background (R4)
+ *       .dms-body-row has background-color:var(--dms-surface); the spacer region
+ *       is covered by the row background, matching the cell background.
+ *
+ * CONSUMER: Universe (/global/universe) — used for all four assertions.
+ *   Universe column total ≈ 1475px (narrow at 800px, wide at 1800px / 2200px).
+ *
+ * BROWSERS: Chromium + Firefox (no .skip / .only annotations per AC6).
+ */
+
+import { expect, type Page, test } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+import { seedScrollUniverseData } from './helpers/seed-scroll-universe-data.helper';
+
+// ─── Selectors ────────────────────────────────────────────────────────────────
+
+/**
+ * Epic 112 (Story 112.2): full-width outer scroll container — owns overflow-y:auto.
+ * The vertical scrollbar lives on this element, permanently at the viewport right edge.
+ */
+const OUTER_SCROLLER_SEL = '.dms-outer-scroller';
+
+/**
+ * Single horizontal scroll container wrapping header and CDK viewport.
+ * overflow-x:auto — shifts header and body together.
+ */
+const SCROLL_CONTAINER_SEL = '.dms-table-scroll-container';
+
+/** Column-header cells in the column-label row (not the filter row). */
+const COLUMN_HEADER_CELLS_SEL =
+  '.dms-column-header-row .dms-header-cell[role="columnheader"]';
+
+/**
+ * Flex spacer at the end of the column header row.
+ * flex:1 — absorbs spare width so rows always span container width.
+ */
+const COL_SPACER_IN_HEADER_SEL = '.dms-column-header-row .dms-col-spacer';
+
+/** Body data rows. */
+const BODY_ROW_SEL = '.dms-body-row[role="row"]';
+
+/** Body cells inside a row. */
+const BODY_CELL_SEL = '.dms-body-cell[role="cell"]';
+
+// ─── Suite Setup ─────────────────────────────────────────────────────────────
+
+let cleanup: (() => Promise<void>) | undefined;
+
+test.beforeAll(async () => {
+  const seeder = await seedScrollUniverseData();
+  cleanup = seeder.cleanup;
+});
+
+test.afterAll(async () => {
+  if (cleanup) {
+    await cleanup();
+  }
+});
+
+// ─── Navigation helper ────────────────────────────────────────────────────────
+
+async function navigateToUniverse(page: Page): Promise<void> {
+  await login(page);
+  await page.goto('/global/universe');
+  await page
+    .locator('dms-base-table')
+    .waitFor({ state: 'visible', timeout: 15000 });
+  await page.waitForSelector(BODY_ROW_SEL, { timeout: 15000 });
+}
+
+// ─── AC1 — Scrollbar right-edge on narrow viewport (800px) ────────────────────
+
+test.describe(
+  'Base Table Layout Regression — AC1: scrollbar right-edge on narrow viewport',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize({ width: 800, height: 900 });
+      await navigateToUniverse(page);
+    });
+
+    test(
+      'Universe: scrollbar right-edge stays at viewport right at 50% and 100% horizontal scroll',
+      async ({ page }) => {
+        // Precondition: table must be wider than 800px to test horizontal scroll.
+        const canScroll = await page
+          .locator(SCROLL_CONTAINER_SEL)
+          .first()
+          .evaluate(function checkScrollable(el: Element): boolean {
+            return el.scrollWidth > el.clientWidth;
+          });
+
+        if (!canScroll) {
+          // Universe columns (≈1475px) must be wider than the 800px content area.
+          // If this branch is hit the seeder or layout changed — flag it as a failure.
+          throw new Error(
+            'Precondition failed: .dms-table-scroll-container is not horizontally ' +
+              'scrollable at 800px viewport. Universe column total should exceed ' +
+              '800px; check column definitions and seeder.'
+          );
+        }
+
+        // ── Capture baseline right edge at 0% scroll ──────────────────────
+        const baseline = await page.evaluate(
+          function captureRightEdge(outerSel: string): {
+            ok: boolean;
+            right: number;
+          } {
+            const el = document.querySelector<HTMLElement>(outerSel);
+            if (!el) return { ok: false, right: -9999 };
+            return { ok: true, right: el.getBoundingClientRect().right };
+          },
+          OUTER_SCROLLER_SEL
+        );
+
+        if (!baseline.ok) {
+          throw new Error(
+            'Precondition failed: .dms-outer-scroller not found in DOM'
+          );
+        }
+
+        // ── Scroll to 50% ─────────────────────────────────────────────────────
+        await page.evaluate(
+          function scrollToPercent(arg: {
+            containerSel: string;
+            percent: number;
+          }): void {
+            const { containerSel, percent } = arg;
+            const el = document.querySelector<HTMLElement>(containerSel);
+            if (el) {
+              el.scrollLeft = (el.scrollWidth - el.clientWidth) * percent;
+            }
+          },
+          { containerSel: SCROLL_CONTAINER_SEL, percent: 0.5 }
+        );
+
+        // Allow one frame for the layout to settle.
+        await page.waitForTimeout(50);
+
+        const result50 = await page.evaluate(
+          function checkOuterScrollerDrift(arg: {
+            outerSel: string;
+            baselineRight: number;
+          }): {
+            ok: boolean;
+            right: number;
+            baselineRight: number;
+            drift: number;
+          } {
+            const { outerSel, baselineRight } = arg;
+            const el = document.querySelector<HTMLElement>(outerSel);
+            if (!el) {
+              return { ok: false, right: 0, baselineRight, drift: 9999 };
+            }
+            const right = el.getBoundingClientRect().right;
+            const drift = Math.abs(right - baselineRight);
+            return { ok: drift <= 2, right, baselineRight, drift };
+          },
+          { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
+        );
+
+        expect(
+          result50.ok,
+          `At 50% horizontal scroll: outer-scroller right drifted from ` +
+            `${result50.baselineRight}px (baseline) to ${result50.right}px, ` +
+            `drift=${result50.drift.toFixed(2)}px (must be ≤2px). ` +
+            '.dms-outer-scroller (overflow-y:auto, overflow-x:hidden) must ' +
+            'remain fixed-width regardless of inner horizontal scroll position ' +
+            '(R1 regression guard: vertical scrollbar must not drift with content).'
+        ).toBe(true);
+
+        // ── Scroll to 100% ────────────────────────────────────────────────────
+        await page.evaluate(
+          function scrollToMax(containerSel: string): void {
+            const el = document.querySelector<HTMLElement>(containerSel);
+            if (el) {
+              el.scrollLeft = el.scrollWidth - el.clientWidth;
+            }
+          },
+          SCROLL_CONTAINER_SEL
+        );
+
+        await page.waitForTimeout(50);
+
+        const result100 = await page.evaluate(
+          function checkOuterScrollerDrift(arg: {
+            outerSel: string;
+            baselineRight: number;
+          }): {
+            ok: boolean;
+            right: number;
+            baselineRight: number;
+            drift: number;
+          } {
+            const { outerSel, baselineRight } = arg;
+            const el = document.querySelector<HTMLElement>(outerSel);
+            if (!el) {
+              return { ok: false, right: 0, baselineRight, drift: 9999 };
+            }
+            const right = el.getBoundingClientRect().right;
+            const drift = Math.abs(right - baselineRight);
+            return { ok: drift <= 2, right, baselineRight, drift };
+          },
+          { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
+        );
+
+        expect(
+          result100.ok,
+          `At 100% horizontal scroll: outer-scroller right drifted from ` +
+            `${result100.baselineRight}px (baseline) to ${result100.right}px, ` +
+            `drift=${result100.drift.toFixed(2)}px (must be ≤2px). ` +
+            'The vertical scrollbar must stay fixed at the container right edge — ' +
+            'it must not scroll with the table content (R1 regression guard).'
+        ).toBe(true);
+      }
+    );
+  }
+);
+
+// ─── AC2 — Container-width on wide viewport (1800px) ─────────────────────────
+
+test.describe(
+  'Base Table Layout Regression — AC2: outer container width on wide viewport',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize({ width: 1800, height: 900 });
+      await navigateToUniverse(page);
+    });
+
+    test(
+      'Universe: outer scroll container fills its flex parent (not truncated to table width)',
+      async ({ page }) => {
+        const result = await page.evaluate(
+          function checkOuterScrollerFillsParent(outerSel: string): {
+            ok: boolean;
+            outerClientWidth: number;
+            parentClientWidth: number;
+            diff: number;
+          } {
+            const el = document.querySelector<HTMLElement>(outerSel);
+            if (!el || !el.parentElement) {
+              return {
+                ok: false,
+                outerClientWidth: 0,
+                parentClientWidth: 0,
+                diff: 9999,
+              };
+            }
+            const outerClientWidth = el.clientWidth;
+            const parentClientWidth = el.parentElement.clientWidth;
+            const diff = Math.abs(outerClientWidth - parentClientWidth);
+            return { ok: diff <= 2, outerClientWidth, parentClientWidth, diff };
+          },
+          OUTER_SCROLLER_SEL
+        );
+
+        expect(
+          result.ok,
+          `outer-scroller.clientWidth=${result.outerClientWidth}px ` +
+            `parentElement.clientWidth=${result.parentClientWidth}px ` +
+            `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
+            'At 1800px viewport the scrollable outer container must span its full ' +
+            'flex parent — it must NOT be truncated to the table content width ' +
+            '(R2 regression guard, ~1475px for Universe columns).'
+        ).toBe(true);
+      }
+    );
+  }
+);
+
+// ─── AC3 — Column fill on very wide viewport (2200px) ────────────────────────
+
+test.describe(
+  'Base Table Layout Regression — AC3: column fill on wide viewport',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      // 2200px ensures the content area (~1800px after sidebar) exceeds the
+      // Universe column total (~1475px), so the spacer has positive width to absorb.
+      await page.setViewportSize({ width: 2200, height: 900 });
+      await navigateToUniverse(page);
+    });
+
+    test(
+      'Universe: sum of column widths plus spacer equals scroll container clientWidth',
+      async ({ page }) => {
+        const result = await page.evaluate(
+          function checkColumnFill(arg: {
+            containerSel: string;
+            headerCellsSel: string;
+            spacerSel: string;
+          }): {
+            ok: boolean;
+            message: string;
+            totalWidth: number;
+            containerClientWidth: number;
+            colCount: number;
+            spacerWidth: number;
+            diff: number;
+          } {
+            const { containerSel, headerCellsSel, spacerSel } = arg;
+            const container =
+              document.querySelector<HTMLElement>(containerSel);
+            const headerCells = Array.from(
+              document.querySelectorAll<HTMLElement>(headerCellsSel)
+            );
+            const spacer = document.querySelector<HTMLElement>(spacerSel);
+
+            if (!container || headerCells.length === 0 || !spacer) {
+              return {
+                ok: false,
+                message:
+                  'precondition unmet: container=' +
+                  !!container +
+                  ' cells=' +
+                  headerCells.length +
+                  ' spacer=' +
+                  !!spacer,
+                totalWidth: 0,
+                containerClientWidth: 0,
+                colCount: 0,
+                spacerWidth: 0,
+                diff: 9999,
+              };
+            }
+
+            const sumCols = headerCells.reduce(
+              function sumWidths(acc: number, el: HTMLElement): number {
+                return acc + el.getBoundingClientRect().width;
+              },
+              0
+            );
+            const spacerWidth = spacer.getBoundingClientRect().width;
+            const totalWidth = sumCols + spacerWidth;
+            const containerClientWidth = container.clientWidth;
+            const diff = Math.abs(totalWidth - containerClientWidth);
+
+            return {
+              ok: diff <= 2,
+              message: '',
+              totalWidth,
+              containerClientWidth,
+              colCount: headerCells.length,
+              spacerWidth,
+              diff,
+            };
+          },
+          {
+            containerSel: SCROLL_CONTAINER_SEL,
+            headerCellsSel: COLUMN_HEADER_CELLS_SEL,
+            spacerSel: COL_SPACER_IN_HEADER_SEL,
+          }
+        );
+
+        expect(
+          result.ok,
+          result.message ||
+            `Column fill assertion failed: ` +
+              `sumCols+spacer=${result.totalWidth.toFixed(2)}px ` +
+              `(${result.colCount} cols + spacer=${result.spacerWidth.toFixed(2)}px) ` +
+              `container.clientWidth=${result.containerClientWidth}px ` +
+              `diff=${result.diff.toFixed(2)}px (must be ≤2px). ` +
+              'At 2200px viewport the content area exceeds Universe column total, ' +
+              'so .dms-col-spacer (flex:1 0 auto) must absorb all spare horizontal ' +
+              'width so the row spans the full container (R3 regression guard).'
+        ).toBe(true);
+      }
+    );
+  }
+);
+
+// ─── AC4 — Beyond-table background color on wide viewport (1800px) ────────────
+
+test.describe(
+  'Base Table Layout Regression — AC4: beyond-table background matches cell background',
+  () => {
+    test.beforeEach(async ({ page }) => {
+      await page.setViewportSize({ width: 1800, height: 900 });
+      await navigateToUniverse(page);
+    });
+
+    test(
+      'Universe: body row background matches body cell background (beyond-table area)',
+      async ({ page }) => {
+        const result = await page.evaluate(
+          function checkBackgroundColors(arg: {
+            bodyRowSel: string;
+            bodyCellSel: string;
+          }): {
+            ok: boolean;
+            message: string;
+            cellBg: string;
+            rowBg: string;
+          } {
+            const { bodyRowSel, bodyCellSel } = arg;
+            const bodyRow = document.querySelector<HTMLElement>(bodyRowSel);
+            if (!bodyRow) {
+              return {
+                ok: false,
+                message: 'precondition unmet: no body row visible',
+                cellBg: '',
+                rowBg: '',
+              };
+            }
+            const bodyCell = bodyRow.querySelector<HTMLElement>(bodyCellSel);
+            if (!bodyCell) {
+              return {
+                ok: false,
+                message: 'precondition unmet: no body cell found in body row',
+                cellBg: '',
+                rowBg: '',
+              };
+            }
+
+            const cellBg = window.getComputedStyle(bodyCell).backgroundColor;
+            const rowBg = window.getComputedStyle(bodyRow).backgroundColor;
+
+            return {
+              ok: cellBg === rowBg,
+              message: '',
+              cellBg,
+              rowBg,
+            };
+          },
+          { bodyRowSel: BODY_ROW_SEL, bodyCellSel: BODY_CELL_SEL }
+        );
+
+        expect(
+          result.ok,
+          result.message ||
+            `Background color mismatch: ` +
+              `bodyCell.backgroundColor="${result.cellBg}" ` +
+              `bodyRow.backgroundColor="${result.rowBg}". ` +
+              'Both must resolve to the same surface color (var(--dms-surface)). ' +
+              '.dms-body-row has background-color:var(--dms-surface) so the area ' +
+              'beyond the last column (covered by .dms-col-spacer) matches cell ' +
+              'background (R4 regression guard).'
+        ).toBe(true);
+      }
+    );
+  }
+);

--- a/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
+++ b/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
@@ -63,6 +63,32 @@ const BODY_ROW_SEL = '.dms-body-row[role="row"]';
 /** Body cells inside a row. */
 const BODY_CELL_SEL = '.dms-body-cell[role="cell"]';
 
+// ─── Shared browser-side helpers ──────────────────────────────────────────────
+
+/**
+ * Checks whether `.dms-outer-scroller`'s right edge has drifted from a
+ * previously captured baseline.  Passed to `page.evaluate()` — must be a
+ * self-contained, serialisable function (no outer-scope closures).
+ */
+function checkOuterScrollerDrift(arg: {
+  outerSel: string;
+  baselineRight: number;
+}): {
+  ok: boolean;
+  right: number;
+  baselineRight: number;
+  drift: number;
+} {
+  const { outerSel, baselineRight } = arg;
+  const el = document.querySelector<HTMLElement>(outerSel);
+  if (!el) {
+    return { ok: false, right: 0, baselineRight, drift: 9999 };
+  }
+  const right = el.getBoundingClientRect().right;
+  const drift = Math.abs(right - baselineRight);
+  return { ok: drift <= 2, right, baselineRight, drift };
+}
+
 // ─── Suite Setup ─────────────────────────────────────────────────────────────
 
 let cleanup: (() => Promise<void>) | undefined;
@@ -162,27 +188,10 @@ test.describe('Base Table Layout Regression — AC1: scrollbar right-edge on nar
     // Allow one frame for the layout to settle.
     await page.waitForTimeout(50);
 
-    const result50 = await page.evaluate(
-      function checkOuterScrollerDrift(arg: {
-        outerSel: string;
-        baselineRight: number;
-      }): {
-        ok: boolean;
-        right: number;
-        baselineRight: number;
-        drift: number;
-      } {
-        const { outerSel, baselineRight } = arg;
-        const el = document.querySelector<HTMLElement>(outerSel);
-        if (!el) {
-          return { ok: false, right: 0, baselineRight, drift: 9999 };
-        }
-        const right = el.getBoundingClientRect().right;
-        const drift = Math.abs(right - baselineRight);
-        return { ok: drift <= 2, right, baselineRight, drift };
-      },
-      { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
-    );
+    const result50 = await page.evaluate(checkOuterScrollerDrift, {
+      outerSel: OUTER_SCROLLER_SEL,
+      baselineRight: baseline.right,
+    });
 
     expect(
       result50.ok,
@@ -204,27 +213,10 @@ test.describe('Base Table Layout Regression — AC1: scrollbar right-edge on nar
 
     await page.waitForTimeout(50);
 
-    const result100 = await page.evaluate(
-      function checkOuterScrollerDrift(arg: {
-        outerSel: string;
-        baselineRight: number;
-      }): {
-        ok: boolean;
-        right: number;
-        baselineRight: number;
-        drift: number;
-      } {
-        const { outerSel, baselineRight } = arg;
-        const el = document.querySelector<HTMLElement>(outerSel);
-        if (!el) {
-          return { ok: false, right: 0, baselineRight, drift: 9999 };
-        }
-        const right = el.getBoundingClientRect().right;
-        const drift = Math.abs(right - baselineRight);
-        return { ok: drift <= 2, right, baselineRight, drift };
-      },
-      { outerSel: OUTER_SCROLLER_SEL, baselineRight: baseline.right }
-    );
+    const result100 = await page.evaluate(checkOuterScrollerDrift, {
+      outerSel: OUTER_SCROLLER_SEL,
+      baselineRight: baseline.right,
+    });
 
     expect(
       result100.ok,

--- a/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
+++ b/apps/dms-material-e2e/src/base-table-layout-regression.spec.ts
@@ -2,7 +2,7 @@
  * base-table-layout-regression.spec.ts — Epic 112
  * ──────────────────────────────────────────────────────────────
  *
- * Regression suite for the three layout regressions fixed in Story 112.2.
+ * Regression suite for the four layout regressions fixed in Story 112.2.
  *
  * FOUR ASSERTIONS:
  *   (a) Scrollbar right-edge stays stable across horizontal scroll positions (R1)
@@ -119,6 +119,12 @@ test.describe('Base Table Layout Regression — AC1: scrollbar right-edge on nar
     }
 
     // ── Capture baseline right edge at 0% scroll ──────────────────────
+    // NOTE: We assert drift stability (right edge must not move relative to
+    // baseline) rather than an absolute right ≈ window.innerWidth check.
+    // The app layout has a sidebar so outerScroller.right < window.innerWidth
+    // by design. The regression (R1) is that the right edge *moves* when the
+    // inner container scrolls horizontally — the drift guard catches exactly
+    // that without depending on sidebar width.
     const baseline = await page.evaluate(function captureRightEdge(
       outerSel: string
     ): {


### PR DESCRIPTION
## Story 112-3: Tests and Regression Suite for Layout Regressions

Closes #1315

### Summary

Adds `apps/dms-material-e2e/src/base-table-layout-regression.spec.ts` — a Playwright E2E regression suite that locks in the three layout fixes shipped in Story 112.2 (#1314).

### What changed

**New file**: `apps/dms-material-e2e/src/base-table-layout-regression.spec.ts`

Four acceptance-criteria assertions run on the Universe screen (`/global/universe`) in both Chromium and Firefox:

| AC | Regression | What is tested |
|----|-----------|----------------|
| AC1 (R1) | Scrollbar drift | `.dms-outer-scroller` right-edge is stable (≤2px drift) across 0%, 50%, 100% horizontal scroll positions |
| AC2 (R2) | Container width truncation | `outer-scroller.clientWidth === parentElement.clientWidth` — outer container fills its flex parent, not truncated to table content width |
| AC3 (R3) | Column fill | `sum(column widths) + spacerWidth === scrollContainer.clientWidth` at 2200px viewport where content area (~1800px) exceeds column total (~1475px) |
| AC4 (R4) | Background color | Body-row `backgroundColor` matches body-cell `backgroundColor` — beyond-table area covered by `var(--dms-surface)` |

### Test results

- ✅ Chromium: 4/4 passed
- ✅ Firefox: 4/4 passed
- ✅ `pnpm dupcheck`: 0 clones
- ✅ `pnpm format`: no changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test suite for base table layout, validating scrollbar positioning, outer container width alignment, column width consistency, and background color rendering across different viewport configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DaveMBush/dms-workspace/pull/1316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->