### PR TITLE
Story 116.3: Add Regression Tests for Stable Summary Loading

### DIFF
--- a/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
+++ b/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
@@ -32,7 +32,12 @@ test.describe('Summary Load Stability Regression', () => {
 
       page.on('request', (req) => {
         const url = req.url();
-        if (url.includes('/api/summary') && !url.includes('/graph') && !url.includes('/months') && !url.includes('/years')) {
+        if (
+          url.includes('/api/summary') &&
+          !url.includes('/graph') &&
+          !url.includes('/months') &&
+          !url.includes('/years')
+        ) {
           requestCounts.summary++;
         } else if (url.includes('/api/summary/graph')) {
           requestCounts.graph++;
@@ -50,7 +55,9 @@ test.describe('Summary Load Stability Regression', () => {
       await page.waitForLoadState('networkidle');
 
       // Wait for summary card to be visible
-      const summaryCard = page.locator('[data-testid="account-summary-container"]');
+      const summaryCard = page.locator(
+        '[data-testid="account-summary-container"]'
+      );
       await expect(summaryCard).toBeVisible({ timeout: 15000 });
 
       // Record counts after initial load
@@ -109,8 +116,18 @@ test.describe('Summary Load Stability Regression', () => {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify([
-              { month: '2025-01', deposits: 10000, dividends: 100, capitalGains: 200 },
-              { month: '2025-02', deposits: 20000, dividends: 150, capitalGains: 300 },
+              {
+                month: '2025-01',
+                deposits: 10000,
+                dividends: 100,
+                capitalGains: 200,
+              },
+              {
+                month: '2025-02',
+                deposits: 20000,
+                dividends: 150,
+                capitalGains: 300,
+              },
             ]),
           });
         }
@@ -135,7 +152,12 @@ test.describe('Summary Load Stability Regression', () => {
 
       page.on('request', (req) => {
         const url = req.url();
-        if (url.includes('/api/summary') && !url.includes('/graph') && !url.includes('/months') && !url.includes('/years')) {
+        if (
+          url.includes('/api/summary') &&
+          !url.includes('/graph') &&
+          !url.includes('/months') &&
+          !url.includes('/years')
+        ) {
           summaryRequests++;
         } else if (url.includes('/api/summary/graph')) {
           graphRequests++;
@@ -194,8 +216,18 @@ test.describe('Summary Load Stability Regression', () => {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify([
-              { month: '2025-01', deposits: 10000, dividends: 100, capitalGains: 200 },
-              { month: '2025-02', deposits: 20000, dividends: 150, capitalGains: 300 },
+              {
+                month: '2025-01',
+                deposits: 10000,
+                dividends: 100,
+                capitalGains: 200,
+              },
+              {
+                month: '2025-02',
+                deposits: 20000,
+                dividends: 150,
+                capitalGains: 300,
+              },
             ]),
           });
         }
@@ -270,7 +302,9 @@ test.describe('Summary Load Stability Regression', () => {
       await page.waitForLoadState('networkidle');
 
       // Wait for summary card to be visible
-      const summaryCard = page.locator('[data-testid="account-summary-container"]');
+      const summaryCard = page.locator(
+        '[data-testid="account-summary-container"]'
+      );
       await expect(summaryCard).toBeVisible({ timeout: 15000 });
 
       // Wait for stats grid to be visible
@@ -342,7 +376,9 @@ test.describe('Summary Load Stability Regression', () => {
         await page.waitForLoadState('networkidle');
 
         // Assert: Screen remains stable after month change
-        const summaryCard = page.locator('[data-testid="account-summary-container"]');
+        const summaryCard = page.locator(
+          '[data-testid="account-summary-container"]'
+        );
         const statsGrid = page.locator('[data-testid="stats-grid"]');
 
         await expect(summaryCard).toBeVisible();
@@ -365,7 +401,10 @@ test.describe('Summary Load Stability Regression', () => {
       let requestCount = 0;
 
       page.on('request', (req) => {
-        if (req.url().includes('/api/summary') && !req.url().includes('/graph')) {
+        if (
+          req.url().includes('/api/summary') &&
+          !req.url().includes('/graph')
+        ) {
           requestCount++;
         }
       });
@@ -375,7 +414,9 @@ test.describe('Summary Load Stability Regression', () => {
       await page.waitForLoadState('networkidle');
 
       // Wait for summary card to be visible
-      const summaryCard = page.locator('[data-testid="global-summary-container"]');
+      const summaryCard = page.locator(
+        '[data-testid="global-summary-container"]'
+      );
       await expect(summaryCard).toBeVisible({ timeout: 15000 });
 
       // Record count after initial load

--- a/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
+++ b/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
@@ -148,15 +148,14 @@ test.describe('Summary Load Stability Regression', () => {
       const options = page.locator('mat-option');
       const count = await options.count();
 
-      if (count > 1) {
-        await options.nth(1).click();
-        await page.waitForLoadState('networkidle');
-        await page.waitForTimeout(1000);
+      expect(count).toBeGreaterThan(1);
+      await options.nth(1).click();
+      await page.waitForLoadState('networkidle');
+      await page.waitForTimeout(1000);
 
-        // Assert: Exactly one summary and one graph request
-        expect(summaryRequests).toBe(1);
-        expect(graphRequests).toBe(1);
-      }
+      // Assert: Exactly one summary and one graph request
+      expect(summaryRequests).toBe(1);
+      expect(graphRequests).toBe(1);
     });
 
     test('AC2: should issue only one months and one graph request per year change', async ({

--- a/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
+++ b/apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts
@@ -1,0 +1,392 @@
+import { test, expect } from 'playwright/test';
+
+import { login } from './helpers/login.helper';
+
+const ACCOUNT_UUID = '1677e04f-ef9b-4372-adb3-b740443088dc';
+
+/**
+ * E2E Regression: Summary Load Stability
+ *
+ * Validates that summary screens load once and settle, with no continuous
+ * reload loop, and that legitimate month/year changes trigger only bounded
+ * follow-up requests.
+ *
+ * Covers AC1, AC2, AC3, AC4 from Story 116.3.
+ */
+test.describe('Summary Load Stability Regression', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test.describe('Account Summary', () => {
+    test('AC1: should settle after initial load with no idle summary requests', async ({
+      page,
+    }) => {
+      // Track summary-related requests
+      const requestCounts: Record<string, number> = {
+        summary: 0,
+        graph: 0,
+        months: 0,
+        years: 0,
+      };
+
+      page.on('request', (req) => {
+        const url = req.url();
+        if (url.includes('/api/summary') && !url.includes('/graph') && !url.includes('/months') && !url.includes('/years')) {
+          requestCounts.summary++;
+        } else if (url.includes('/api/summary/graph')) {
+          requestCounts.graph++;
+        } else if (url.includes('/api/summary/months')) {
+          requestCounts.months++;
+        } else if (url.includes('/api/summary/years')) {
+          requestCounts.years++;
+        }
+      });
+
+      // Navigate to account summary
+      await page.goto(`/account/${ACCOUNT_UUID}`);
+
+      // Wait for initial load to complete
+      await page.waitForLoadState('networkidle');
+
+      // Wait for summary card to be visible
+      const summaryCard = page.locator('[data-testid="account-summary-container"]');
+      await expect(summaryCard).toBeVisible({ timeout: 15000 });
+
+      // Record counts after initial load
+      const initialCounts = { ...requestCounts };
+
+      // Wait for observation window (5 seconds) to detect any idle requests
+      await page.waitForTimeout(5000);
+
+      // Assert: No additional summary requests during idle period
+      expect(requestCounts.summary).toBe(initialCounts.summary);
+      expect(requestCounts.graph).toBe(initialCounts.graph);
+      expect(requestCounts.months).toBe(initialCounts.months);
+      expect(requestCounts.years).toBe(initialCounts.years);
+    });
+
+    test('AC2: should issue only one summary and one graph request per month change', async ({
+      page,
+    }) => {
+      // Mock API to provide consistent month options
+      await page.route(
+        '**/api/summary/months*',
+        async function fulfillMonths(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { month: '2025-03', label: 'March 2025' },
+              { month: '2025-02', label: 'February 2025' },
+            ]),
+          });
+        }
+      );
+
+      await page.route(
+        /\/api\/summary\?/,
+        async function fulfillSummary(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              deposits: 50000,
+              dividends: 1200,
+              capitalGains: 3000,
+              equities: 25000,
+              income: 15000,
+              tax_free_income: 10000,
+            }),
+          });
+        }
+      );
+
+      await page.route(
+        '**/api/summary/graph*',
+        async function fulfillGraph(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { month: '2025-01', deposits: 10000, dividends: 100, capitalGains: 200 },
+              { month: '2025-02', deposits: 20000, dividends: 150, capitalGains: 300 },
+            ]),
+          });
+        }
+      );
+
+      // Navigate to account summary
+      await page.goto(`/account/${ACCOUNT_UUID}`);
+      await page.waitForLoadState('networkidle');
+
+      // Wait for selectors to be enabled
+      const monthSelector = page.locator('[data-testid="month-selector"]');
+      await expect(monthSelector).not.toHaveAttribute('aria-disabled', 'true', {
+        timeout: 15000,
+      });
+
+      // Wait for initial requests to complete
+      await page.waitForTimeout(1000);
+
+      // Track requests for month change
+      let summaryRequests = 0;
+      let graphRequests = 0;
+
+      page.on('request', (req) => {
+        const url = req.url();
+        if (url.includes('/api/summary') && !url.includes('/graph') && !url.includes('/months') && !url.includes('/years')) {
+          summaryRequests++;
+        } else if (url.includes('/api/summary/graph')) {
+          graphRequests++;
+        }
+      });
+
+      // Change month
+      await monthSelector.click();
+      await page.waitForSelector('mat-option', { state: 'visible' });
+      const options = page.locator('mat-option');
+      const count = await options.count();
+
+      if (count > 1) {
+        await options.nth(1).click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Assert: Exactly one summary and one graph request
+        expect(summaryRequests).toBe(1);
+        expect(graphRequests).toBe(1);
+      }
+    });
+
+    test('AC2: should issue only one months and one graph request per year change', async ({
+      page,
+    }) => {
+      // Mock API to provide consistent year options
+      await page.route(
+        '**/api/summary/years',
+        async function fulfillYears(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([2025, 2024, 2023]),
+          });
+        }
+      );
+
+      await page.route(
+        '**/api/summary/months*',
+        async function fulfillMonths(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { month: '2025-03', label: 'March 2025' },
+              { month: '2025-02', label: 'February 2025' },
+            ]),
+          });
+        }
+      );
+
+      await page.route(
+        '**/api/summary/graph*',
+        async function fulfillGraph(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { month: '2025-01', deposits: 10000, dividends: 100, capitalGains: 200 },
+              { month: '2025-02', deposits: 20000, dividends: 150, capitalGains: 300 },
+            ]),
+          });
+        }
+      );
+
+      await page.route(
+        /\/api\/summary\?/,
+        async function fulfillSummary(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              deposits: 50000,
+              dividends: 1200,
+              capitalGains: 3000,
+              equities: 25000,
+              income: 15000,
+              tax_free_income: 10000,
+            }),
+          });
+        }
+      );
+
+      // Navigate to account summary
+      await page.goto(`/account/${ACCOUNT_UUID}`);
+      await page.waitForLoadState('networkidle');
+
+      // Wait for selectors to be enabled
+      const yearSelector = page.locator('[data-testid="year-selector"]');
+      await expect(yearSelector).not.toHaveAttribute('aria-disabled', 'true', {
+        timeout: 15000,
+      });
+
+      // Wait for initial requests to complete
+      await page.waitForTimeout(1000);
+
+      // Track requests for year change
+      let monthsRequests = 0;
+      let graphRequests = 0;
+
+      page.on('request', (req) => {
+        const url = req.url();
+        if (url.includes('/api/summary/months')) {
+          monthsRequests++;
+        } else if (url.includes('/api/summary/graph')) {
+          graphRequests++;
+        }
+      });
+
+      // Change year
+      await yearSelector.click();
+      await page.waitForSelector('mat-option', { state: 'visible' });
+      const options = page.locator('mat-option');
+      const count = await options.count();
+
+      if (count > 1) {
+        await options.nth(1).click();
+        await page.waitForLoadState('networkidle');
+        await page.waitForTimeout(1000);
+
+        // Assert: Exactly one months and one graph request
+        expect(monthsRequests).toBe(1);
+        expect(graphRequests).toBe(1);
+      }
+    });
+
+    test('AC3: should remain visually stable after initial load', async ({
+      page,
+    }) => {
+      // Navigate to account summary
+      await page.goto(`/account/${ACCOUNT_UUID}`);
+      await page.waitForLoadState('networkidle');
+
+      // Wait for summary card to be visible
+      const summaryCard = page.locator('[data-testid="account-summary-container"]');
+      await expect(summaryCard).toBeVisible({ timeout: 15000 });
+
+      // Wait for stats grid to be visible
+      const statsGrid = page.locator('[data-testid="stats-grid"]');
+      await expect(statsGrid).toBeVisible();
+
+      // Assert: Screen remains stable (no continuous repaint/reload)
+      // by verifying elements are still visible after observation period
+      await page.waitForTimeout(5000);
+
+      await expect(summaryCard).toBeVisible();
+      await expect(statsGrid).toBeVisible();
+    });
+
+    test('AC3: should remain visually stable after month change', async ({
+      page,
+    }) => {
+      // Mock API for month options
+      await page.route(
+        '**/api/summary/months*',
+        async function fulfillMonths(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify([
+              { month: '2025-03', label: 'March 2025' },
+              { month: '2025-02', label: 'February 2025' },
+            ]),
+          });
+        }
+      );
+
+      await page.route(
+        /\/api\/summary\?/,
+        async function fulfillSummary(route) {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              deposits: 50000,
+              dividends: 1200,
+              capitalGains: 3000,
+              equities: 25000,
+              income: 15000,
+              tax_free_income: 10000,
+            }),
+          });
+        }
+      );
+
+      // Navigate to account summary
+      await page.goto(`/account/${ACCOUNT_UUID}`);
+      await page.waitForLoadState('networkidle');
+
+      // Wait for selectors to be enabled
+      const monthSelector = page.locator('[data-testid="month-selector"]');
+      await expect(monthSelector).not.toHaveAttribute('aria-disabled', 'true', {
+        timeout: 15000,
+      });
+
+      // Change month
+      await monthSelector.click();
+      await page.waitForSelector('mat-option', { state: 'visible' });
+      const options = page.locator('mat-option');
+      const count = await options.count();
+
+      if (count > 1) {
+        await options.nth(1).click();
+        await page.waitForLoadState('networkidle');
+
+        // Assert: Screen remains stable after month change
+        const summaryCard = page.locator('[data-testid="account-summary-container"]');
+        const statsGrid = page.locator('[data-testid="stats-grid"]');
+
+        await expect(summaryCard).toBeVisible();
+        await expect(statsGrid).toBeVisible();
+
+        // Wait for observation period
+        await page.waitForTimeout(3000);
+
+        await expect(summaryCard).toBeVisible();
+        await expect(statsGrid).toBeVisible();
+      }
+    });
+  });
+
+  test.describe('Global Summary Preservation', () => {
+    test('AC3: should load once and remain stable (preservation)', async ({
+      page,
+    }) => {
+      // Track requests
+      let requestCount = 0;
+
+      page.on('request', (req) => {
+        if (req.url().includes('/api/summary') && !req.url().includes('/graph')) {
+          requestCount++;
+        }
+      });
+
+      // Navigate to global summary
+      await page.goto('/global/summary');
+      await page.waitForLoadState('networkidle');
+
+      // Wait for summary card to be visible
+      const summaryCard = page.locator('[data-testid="global-summary-container"]');
+      await expect(summaryCard).toBeVisible({ timeout: 15000 });
+
+      // Record count after initial load
+      const initialCount = requestCount;
+
+      // Wait for observation window
+      await page.waitForTimeout(3000);
+
+      // Assert: No additional requests during idle period
+      expect(requestCount).toBe(initialCount);
+    });
+  });
+});

--- a/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
+++ b/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
@@ -1445,7 +1445,7 @@ describe('SummaryViewComponent - Service Integration', () => {
   });
 
   describe('Regression: Summary Load Stability', () => {
-    it('AC1: should settle after one bounded bootstrap sequence with no idle requests', () => {
+    it('AC1: should settle after one bounded bootstrap sequence with no idle requests', async () => {
       // Arrange & Act: Open account summary
       initAccount('123');
 
@@ -1459,6 +1459,10 @@ describe('SummaryViewComponent - Service Integration', () => {
       // Flush bootstrap requests
       summaryReqs[0].flush(createMockSummary());
       graphReqs[0].flush(createMockGraphData());
+
+      // Allow queued async work (timers/microtasks) to run
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      fixture.detectChanges();
 
       // Assert: After bootstrap completes, no idle summary requests fire
       const idleSummaryReqs = httpMock.match(matchSummary('123'));

--- a/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
+++ b/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
@@ -1443,4 +1443,129 @@ describe('SummaryViewComponent - Service Integration', () => {
       expect(component.loading()).toBe(true);
     });
   });
+
+  describe('Regression: Summary Load Stability', () => {
+    it('AC1: should settle after one bounded bootstrap sequence with no idle requests', () => {
+      // Arrange & Act: Open account summary
+      initAccount('123');
+
+      // Assert: Initial bootstrap produces exactly one summary and one graph request
+      const summaryReqs = httpMock.match(matchSummary('123'));
+      const graphReqs = httpMock.match(matchGraph('123', testCurrentMonth()));
+
+      expect(summaryReqs).toHaveLength(1);
+      expect(graphReqs).toHaveLength(1);
+
+      // Flush bootstrap requests
+      summaryReqs[0].flush(createMockSummary());
+      graphReqs[0].flush(createMockGraphData());
+
+      // Assert: After bootstrap completes, no idle summary requests fire
+      const idleSummaryReqs = httpMock.match(matchSummary('123'));
+      const idleGraphReqs = httpMock.match(matchGraph('123', testCurrentMonth()));
+
+      expect(idleSummaryReqs).toHaveLength(0);
+      expect(idleGraphReqs).toHaveLength(0);
+    });
+
+    it('AC2: should issue only one summary and one graph request per month change', () => {
+      // Arrange: Initial load and flush
+      initAccount('123');
+      flushPendingRequests(httpMock);
+
+      // Track request counts before month change
+      let summaryCount = 0;
+      let graphCount = 0;
+
+      // Act: Change month
+      component.selectedMonth.setValue('2025-02');
+
+      // Assert: Exactly one summary and one graph request for the month change
+      const monthSummaryReqs = httpMock.match(matchSummary('123'));
+      const monthGraphReqs = httpMock.match(matchGraph('123', '2025-02'));
+
+      summaryCount = monthSummaryReqs.length;
+      graphCount = monthGraphReqs.length;
+
+      expect(summaryCount).toBe(1);
+      expect(graphCount).toBe(1);
+
+      // Flush
+      monthSummaryReqs[0].flush(createMockSummary());
+      monthGraphReqs[0].flush(createMockGraphData());
+    });
+
+    it('AC2: should issue only one months and one graph request per year change', () => {
+      // Arrange: Initial load and flush
+      initAccount('123');
+      flushPendingRequests(httpMock);
+
+      // Act: Change year
+      component.selectedYear.setValue(2024);
+
+      // Assert: Exactly one months and one graph request for the year change
+      const monthsReqs = httpMock.match((r: HttpRequest<unknown>) =>
+        r.url.includes('/api/summary/months') &&
+        r.params.get('year') === '2024'
+      );
+      const yearGraphReqs = httpMock.match(matchGraphByYear('123', 2024));
+
+      expect(monthsReqs).toHaveLength(1);
+      expect(yearGraphReqs).toHaveLength(1);
+
+      // Flush
+      monthsReqs[0].flush(createMockMonths());
+      yearGraphReqs[0].flush(createMockGraphData());
+    });
+
+    it('AC2: should not re-trigger bootstrap on repeated same-account emission', () => {
+      // Arrange: Initial load and flush
+      initAccount('123');
+      flushPendingRequests(httpMock);
+
+      // Act: Re-emit same account ID
+      store.setCurrentAccountId('123');
+      fixture.detectChanges();
+
+      // Assert: No new bootstrap requests
+      const pending = httpMock.match((r: HttpRequest<unknown>) =>
+        r.url.includes('/api/summary')
+      );
+      expect(pending).toHaveLength(0);
+    });
+
+    it('AC2: should not re-trigger bootstrap on same month selection', () => {
+      // Arrange: Initial load and flush
+      initAccount('123');
+      flushPendingRequests(httpMock);
+
+      const currentMonth = component.selectedMonth.value;
+
+      // Act: Select same month
+      component.selectedMonth.setValue(currentMonth);
+
+      // Assert: No new requests (distinctUntilChanged blocks)
+      const pending = httpMock.match((r: HttpRequest<unknown>) =>
+        r.url.includes('/api/summary')
+      );
+      expect(pending).toHaveLength(0);
+    });
+
+    it('AC2: should not re-trigger bootstrap on same year selection', () => {
+      // Arrange: Initial load and flush
+      initAccount('123');
+      flushPendingRequests(httpMock);
+
+      const currentYear = component.selectedYear.value;
+
+      // Act: Select same year
+      component.selectedYear.setValue(currentYear);
+
+      // Assert: No new requests (distinctUntilChanged blocks)
+      const pending = httpMock.match((r: HttpRequest<unknown>) =>
+        r.url.includes('/api/summary')
+      );
+      expect(pending).toHaveLength(0);
+    });
+  });
 });

--- a/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
+++ b/apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts
@@ -1466,7 +1466,9 @@ describe('SummaryViewComponent - Service Integration', () => {
 
       // Assert: After bootstrap completes, no idle summary requests fire
       const idleSummaryReqs = httpMock.match(matchSummary('123'));
-      const idleGraphReqs = httpMock.match(matchGraph('123', testCurrentMonth()));
+      const idleGraphReqs = httpMock.match(
+        matchGraph('123', testCurrentMonth())
+      );
 
       expect(idleSummaryReqs).toHaveLength(0);
       expect(idleGraphReqs).toHaveLength(0);
@@ -1508,9 +1510,10 @@ describe('SummaryViewComponent - Service Integration', () => {
       component.selectedYear.setValue(2024);
 
       // Assert: Exactly one months and one graph request for the year change
-      const monthsReqs = httpMock.match((r: HttpRequest<unknown>) =>
-        r.url.includes('/api/summary/months') &&
-        r.params.get('year') === '2024'
+      const monthsReqs = httpMock.match(
+        (r: HttpRequest<unknown>) =>
+          r.url.includes('/api/summary/months') &&
+          r.params.get('year') === '2024'
       );
       const yearGraphReqs = httpMock.match(matchGraphByYear('123', 2024));
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive regression tests for stable summary loading behavior to ensure future changes cannot reintroduce the reload loop.

## Changes

### Unit Tests (6 new tests)

Added to `apps/dms-material/src/app/shared/components/summary-view/summary-view-account.spec.ts`:

- **AC1**: Verifies screen settles after one bounded bootstrap sequence with no idle requests
- **AC2**: Verifies only one summary and one graph request per month change
- **AC2**: Verifies only one months and one graph request per year change
- **AC2**: Verifies no re-trigger on repeated same-account emission
- **AC2**: Verifies no re-trigger on same month selection
- **AC2**: Verifies no re-trigger on same year selection

### E2E Tests (5 new tests)

Created new `apps/dms-material-e2e/src/summary-load-stability-regression.spec.ts`:

- **AC1**: Verifies no idle summary requests after initial load
- **AC2**: Verifies exactly one summary and one graph request per month change
- **AC2**: Verifies exactly one months and one graph request per year change
- **AC3**: Verifies visual stability after initial load
- **AC3**: Verifies visual stability after month change
- **AC3**: Global summary preservation test

## Test Results

- All 83 unit tests pass
- Lint passes
- No duplicate code detected

## Related

- Depends on: Story 116.2
- Epic: 116 - Stop Continuous Reloading on Account Summary Screens

Closes #1337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added E2E regression tests for Summary pages (account and global) to ensure network activity settles after initial load, month/year changes produce a single expected follow-up request, and key summary UI remains visually stable.
  * Added unit regression tests for the Summary view to prevent idle re-fetches, ensure repeated account/month/year selections don’t duplicate requests, and confirm single-request behavior on period changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->